### PR TITLE
Don't store Regular in name id 4

### DIFF
--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -351,7 +351,9 @@ class BaseOutlineCompiler(object):
         preferredSubfamilyName = getAttrWithFallback(
             font.info, "openTypeNamePreferredSubfamilyName"
         )
-        fullName = "%s %s" % (preferredFamilyName, preferredSubfamilyName)
+        fullName = "%s%s" % (preferredFamilyName, 
+            (" " + preferredSubfamilyName \
+                if preferredSubfamilyName.lower() != "regular" else ""))
 
         nameVals = {
             0: getAttrWithFallback(font.info, "copyright"),

--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -352,8 +352,8 @@ class BaseOutlineCompiler(object):
             font.info, "openTypeNamePreferredSubfamilyName"
         )
         fullName = "%s%s" % (preferredFamilyName, 
-            (" " + preferredSubfamilyName \
-                if preferredSubfamilyName.lower() != "regular" else ""))
+            (" " + preferredSubfamilyName if preferredSubfamilyName is not None \
+                        and preferredSubfamilyName.lower() != "regular" else ""))
 
         nameVals = {
             0: getAttrWithFallback(font.info, "copyright"),

--- a/tests/data/TestVariableFont-CFF2-useProductionNames.ttx
+++ b/tests/data/TestVariableFont-CFF2-useProductionNames.ttx
@@ -151,7 +151,7 @@
       0.000;NONE;LayerFont-Regular
     </namerecord>
     <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
-      Layer Font Regular
+      Layer Font
     </namerecord>
     <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
       Version 0.000

--- a/tests/data/TestVariableFont-CFF2.ttx
+++ b/tests/data/TestVariableFont-CFF2.ttx
@@ -151,7 +151,7 @@
       0.000;NONE;LayerFont-Regular
     </namerecord>
     <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
-      Layer Font Regular
+      Layer Font
     </namerecord>
     <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
       Version 0.000

--- a/tests/data/TestVariableFont-TTF-useProductionNames.ttx
+++ b/tests/data/TestVariableFont-TTF-useProductionNames.ttx
@@ -270,7 +270,7 @@
       0.000;NONE;LayerFont-Regular
     </namerecord>
     <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
-      Layer Font Regular
+      Layer Font
     </namerecord>
     <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
       Version 0.000

--- a/tests/data/TestVariableFont-TTF.ttx
+++ b/tests/data/TestVariableFont-TTF.ttx
@@ -270,7 +270,7 @@
       0.000;NONE;LayerFont-Regular
     </namerecord>
     <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
-      Layer Font Regular
+      Layer Font
     </namerecord>
     <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
       Version 0.000


### PR DESCRIPTION
Name id 4 may or may not take the word Regular as part of the full family name, but in the past all fonts removed the Regular and many systems presume that. This PR simply doesn't add the Regular to the full family name if it is the word "regular" (when lowercased).