### PR TITLE
Fix test errors due to fonttools changing OS/2 weight calculation

### DIFF
--- a/tests/data/TestVariableFont-CFF2-useProductionNames.ttx
+++ b/tests/data/TestVariableFont-CFF2-useProductionNames.ttx
@@ -62,7 +62,7 @@
          will be recalculated by the compiler -->
     <version value="4"/>
     <xAvgCharWidth value="580"/>
-    <usWeightClass value="400"/>
+    <usWeightClass value="350"/>
     <usWidthClass value="5"/>
     <fsType value="00000000 00000100"/>
     <ySubscriptXSize value="650"/>

--- a/tests/data/TestVariableFont-CFF2.ttx
+++ b/tests/data/TestVariableFont-CFF2.ttx
@@ -62,7 +62,7 @@
          will be recalculated by the compiler -->
     <version value="4"/>
     <xAvgCharWidth value="580"/>
-    <usWeightClass value="400"/>
+    <usWeightClass value="350"/>
     <usWidthClass value="5"/>
     <fsType value="00000000 00000100"/>
     <ySubscriptXSize value="650"/>

--- a/tests/data/TestVariableFont-TTF-useProductionNames.ttx
+++ b/tests/data/TestVariableFont-TTF-useProductionNames.ttx
@@ -76,7 +76,7 @@
          will be recalculated by the compiler -->
     <version value="4"/>
     <xAvgCharWidth value="580"/>
-    <usWeightClass value="400"/>
+    <usWeightClass value="350"/>
     <usWidthClass value="5"/>
     <fsType value="00000000 00000100"/>
     <ySubscriptXSize value="650"/>

--- a/tests/data/TestVariableFont-TTF.ttx
+++ b/tests/data/TestVariableFont-TTF.ttx
@@ -76,7 +76,7 @@
          will be recalculated by the compiler -->
     <version value="4"/>
     <xAvgCharWidth value="580"/>
-    <usWeightClass value="400"/>
+    <usWeightClass value="350"/>
     <usWidthClass value="5"/>
     <fsType value="00000000 00000100"/>
     <ySubscriptXSize value="650"/>


### PR DESCRIPTION
The following commit changes the OS/2 font weight calculation:
https://github.com/fonttools/fonttools/commit/1122a2612b8daab832f1d56ca9bff4da74d2dc5c

This commit fixes the failing tests due to above change in fonttools.