### PR TITLE
outlineCompiler: set vmtx top sidebearing of empty glyphs to 0

### DIFF
--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -794,8 +794,11 @@ class BaseOutlineCompiler(object):
                 )
             verticalOrigin = _getVerticalOrigin(self.otf, glyph)
             bounds = self.glyphBoundingBoxes[glyphName]
-            top = bounds.yMax if bounds else 0
-            vmtx[glyphName] = (height, verticalOrigin - top)
+            if bounds:
+                top = verticalOrigin - bounds.yMax
+            else:
+                top = 0
+            vmtx[glyphName] = (height, top)
 
     def setupTable_VORG(self):
         """

--- a/tests/data/TestFont-CFF.ttx
+++ b/tests/data/TestFont-CFF.ttx
@@ -488,7 +488,7 @@
 
   <vmtx>
     <mtx name=".notdef" height="1000" tsb="0"/>
-    <mtx name="uni0020" height="250" tsb="750"/>
+    <mtx name="uni0020" height="250" tsb="0"/>
     <mtx name="uni0061" height="750" tsb="240"/>
     <mtx name="uni0062" height="750" tsb="245"/>
     <mtx name="uni0063" height="750" tsb="250"/>

--- a/tests/data/TestFont-NoOptimize-CFF.ttx
+++ b/tests/data/TestFont-NoOptimize-CFF.ttx
@@ -507,7 +507,7 @@
 
   <vmtx>
     <mtx name=".notdef" height="1000" tsb="0"/>
-    <mtx name="uni0020" height="250" tsb="750"/>
+    <mtx name="uni0020" height="250" tsb="0"/>
     <mtx name="uni0061" height="750" tsb="240"/>
     <mtx name="uni0062" height="750" tsb="245"/>
     <mtx name="uni0063" height="750" tsb="250"/>

--- a/tests/data/TestFont-NoOverlaps-CFF-pathops.ttx
+++ b/tests/data/TestFont-NoOverlaps-CFF-pathops.ttx
@@ -489,7 +489,7 @@
 
   <vmtx>
     <mtx name=".notdef" height="1000" tsb="0"/>
-    <mtx name="uni0020" height="250" tsb="750"/>
+    <mtx name="uni0020" height="250" tsb="0"/>
     <mtx name="uni0061" height="750" tsb="240"/>
     <mtx name="uni0062" height="750" tsb="245"/>
     <mtx name="uni0063" height="750" tsb="250"/>

--- a/tests/data/TestFont-NoOverlaps-CFF.ttx
+++ b/tests/data/TestFont-NoOverlaps-CFF.ttx
@@ -490,7 +490,7 @@
 
   <vmtx>
     <mtx name=".notdef" height="1000" tsb="0"/>
-    <mtx name="uni0020" height="250" tsb="750"/>
+    <mtx name="uni0020" height="250" tsb="0"/>
     <mtx name="uni0061" height="750" tsb="240"/>
     <mtx name="uni0062" height="750" tsb="245"/>
     <mtx name="uni0063" height="750" tsb="250"/>

--- a/tests/data/TestFont-NoOverlaps-TTF-pathops.ttx
+++ b/tests/data/TestFont-NoOverlaps-TTF-pathops.ttx
@@ -559,7 +559,7 @@
 
   <vmtx>
     <mtx name=".notdef" height="1000" tsb="0"/>
-    <mtx name="uni0020" height="250" tsb="750"/>
+    <mtx name="uni0020" height="250" tsb="0"/>
     <mtx name="uni0061" height="750" tsb="240"/>
     <mtx name="uni0062" height="750" tsb="245"/>
     <mtx name="uni0063" height="750" tsb="250"/>

--- a/tests/data/TestFont-NoOverlaps-TTF.ttx
+++ b/tests/data/TestFont-NoOverlaps-TTF.ttx
@@ -559,7 +559,7 @@
 
   <vmtx>
     <mtx name=".notdef" height="1000" tsb="0"/>
-    <mtx name="uni0020" height="250" tsb="750"/>
+    <mtx name="uni0020" height="250" tsb="0"/>
     <mtx name="uni0061" height="750" tsb="240"/>
     <mtx name="uni0062" height="750" tsb="245"/>
     <mtx name="uni0063" height="750" tsb="250"/>

--- a/tests/data/TestFont-Specialized-CFF.ttx
+++ b/tests/data/TestFont-Specialized-CFF.ttx
@@ -485,7 +485,7 @@
 
   <vmtx>
     <mtx name=".notdef" height="1000" tsb="0"/>
-    <mtx name="uni0020" height="250" tsb="750"/>
+    <mtx name="uni0020" height="250" tsb="0"/>
     <mtx name="uni0061" height="750" tsb="240"/>
     <mtx name="uni0062" height="750" tsb="245"/>
     <mtx name="uni0063" height="750" tsb="250"/>

--- a/tests/data/TestFont.ttx
+++ b/tests/data/TestFont.ttx
@@ -557,7 +557,7 @@
 
   <vmtx>
     <mtx name=".notdef" height="1000" tsb="0"/>
-    <mtx name="uni0020" height="250" tsb="750"/>
+    <mtx name="uni0020" height="250" tsb="0"/>
     <mtx name="uni0061" height="750" tsb="240"/>
     <mtx name="uni0062" height="750" tsb="245"/>
     <mtx name="uni0063" height="750" tsb="250"/>


### PR DESCRIPTION
like we do with empty glyphs left sidebearing in hmtx