### PR TITLE
don't require openTypeVheaCaret(Offset|Slope) info attributes to build vhea/vmtx

### DIFF
--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -95,14 +95,11 @@ class BaseOutlineCompiler(object):
         """
         self.otf = TTFont(sfntVersion=self.sfntVersion)
 
-        # only compile vertical metrics tables if vhea metrics a defined
+        # only compile vertical metrics tables if vhea metrics are defined
         vertical_metrics = [
             "openTypeVheaVertTypoAscender",
             "openTypeVheaVertTypoDescender",
             "openTypeVheaVertTypoLineGap",
-            "openTypeVheaCaretSlopeRise",
-            "openTypeVheaCaretSlopeRun",
-            "openTypeVheaCaretOffset",
         ]
         self.vertical = all(
             getAttrWithFallback(self.ufo.info, metric) is not None


### PR DESCRIPTION
the current default fallback values in fontInfoData are good enough:
```
    openTypeVheaCaretSlopeRise=0
    openTypeVheaCaretSlopeRun=1
    openTypeVheaCaretOffset=0
```
Fixes https://github.com/googlefonts/fontmake/issues/586