### PR TITLE
OutlineOTFCompiler: Guard against missing nominalWidthX

### DIFF
--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -948,8 +948,8 @@ class OutlineOTFCompiler(BaseOutlineCompiler):
         if self._defaultAndNominalWidths is None:
             info = self.ufo.info
             # populate the width values
-            if not any(
-                getattr(info, attr, None) is not None
+            if all(
+                getattr(info, attr, None) is None
                 for attr in ("postscriptDefaultWidthX", "postscriptNominalWidthX")
             ):
                 # no custom values set in fontinfo.plist; compute optimal ones
@@ -958,9 +958,11 @@ class OutlineOTFCompiler(BaseOutlineCompiler):
                 widths = [otRound(glyph.width) for glyph in self.allGlyphs.values()]
                 defaultWidthX, nominalWidthX = optimizeWidths(widths)
             else:
-                defaultWidthX = otRound(info.postscriptDefaultWidthX)
+                defaultWidthX = otRound(
+                    getAttrWithFallback(info, "postscriptDefaultWidthX")
+                )
                 nominalWidthX = otRound(
-                    otRound(getAttrWithFallback(info, "postscriptNominalWidthX"))
+                    getAttrWithFallback(info, "postscriptNominalWidthX")
                 )
             self._defaultAndNominalWidths = (defaultWidthX, nominalWidthX)
         return self._defaultAndNominalWidths

--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -959,7 +959,9 @@ class OutlineOTFCompiler(BaseOutlineCompiler):
                 defaultWidthX, nominalWidthX = optimizeWidths(widths)
             else:
                 defaultWidthX = otRound(info.postscriptDefaultWidthX)
-                nominalWidthX = otRound(info.postscriptNominalWidthX)
+                nominalWidthX = otRound(
+                    otRound(getAttrWithFallback(info, "postscriptNominalWidthX"))
+                )
             self._defaultAndNominalWidths = (defaultWidthX, nominalWidthX)
         return self._defaultAndNominalWidths
 

--- a/tests/outlineCompiler_test.py
+++ b/tests/outlineCompiler_test.py
@@ -494,6 +494,31 @@ class OutlineOTFCompilerTest(object):
         # 250 - nominalWidthX
         assert charStrings.getItemAndSelector("space")[0].program == [-53, "endchar"]
 
+    def test_optimized_default_but_no_nominal_widths(self, FontClass):
+        ufo = FontClass()
+        ufo.info.familyName = "Test"
+        ufo.info.styleName = "R"
+        ufo.info.ascender = 1
+        ufo.info.descender = 1
+        ufo.info.capHeight = 1
+        ufo.info.xHeight = 1
+        ufo.info.unitsPerEm = 1000
+        ufo.info.postscriptDefaultWidthX = 500
+        for glyphName, width in (
+            (".notdef", 500),
+            ("space", 500),
+            ("a", 500),
+        ):
+            glyph = ufo.newGlyph(glyphName)
+            glyph.width = width
+
+        font = compileOTF(ufo)
+        cff = font["CFF "].cff
+        private = cff[list(cff.keys())[0]].Private
+
+        assert private.defaultWidthX == 500
+        assert private.nominalWidthX == 0
+
 
 class GlyphOrderTest(object):
     def test_compile_original_glyph_order(self, testufo):


### PR DESCRIPTION
Can be triggered if a UFO defines `info.postscriptDefaultWidthX` but not `info.postscriptNominalWidthX`.