### PR TITLE
postProcessor: clear existing “post” extraNames

### DIFF
--- a/Lib/ufo2ft/postProcessor.py
+++ b/Lib/ufo2ft/postProcessor.py
@@ -78,6 +78,7 @@ class PostProcessor(object):
         # to TTX directly before compiling first, the post table will not
         # contain the extraNames.
         if "post" in otf and otf["post"].formatType == 2.0:
+            otf["post"].extraNames = []
             otf["post"].compile(self.otf)
 
         if "CFF " in otf:

--- a/tests/data/TestVariableFont-CFF2-useProductionNames.ttx
+++ b/tests/data/TestVariableFont-CFF2-useProductionNames.ttx
@@ -185,8 +185,6 @@
     </psNames>
     <extraNames>
       <!-- following are the name that are not taken from the standard Mac glyph order -->
-      <psName name="dotabovecomb"/>
-      <psName name="edotabove"/>
       <psName name="uni0061"/>
       <psName name="uni0065"/>
       <psName name="uni0073"/>

--- a/tests/data/TestVariableFont-TTF-useProductionNames.ttx
+++ b/tests/data/TestVariableFont-TTF-useProductionNames.ttx
@@ -304,8 +304,6 @@
     </psNames>
     <extraNames>
       <!-- following are the name that are not taken from the standard Mac glyph order -->
-      <psName name="dotabovecomb"/>
-      <psName name="edotabove"/>
       <psName name="uni0061"/>
       <psName name="uni0065"/>
       <psName name="uni0073"/>


### PR DESCRIPTION
When renaming glyphs, extraNames attribute of “post” table needs to be cleared as it will contain old names which will otherwise be kept in the table even if unused.

See https://github.com/googlefonts/noto-fonts/issues/1543