### PR TITLE
fontInfoData: demote warnings underline position/thickness not being set

### DIFF
--- a/Lib/ufo2ft/fontInfoData.py
+++ b/Lib/ufo2ft/fontInfoData.py
@@ -328,13 +328,13 @@ def postscriptSlantAngleFallback(info):
 
 def postscriptUnderlineThicknessFallback(info):
     """Return UPM * 0.05 (50 for 1000 UPM) and warn."""
-    logger.warning("Underline thickness not set in UFO, defaulting to UPM * 0.05")
+    logger.debug("Underline thickness not set in UFO, defaulting to UPM * 0.05")
     return getAttrWithFallback(info, "unitsPerEm") * 0.05
 
 
 def postscriptUnderlinePositionFallback(info):
     """Return UPM * -0.075 (-75 for 1000 UPM) and warn."""
-    logger.warning("Underline position not set in UFO, defaulting to UPM * -0.075")
+    logger.debug("Underline position not set in UFO, defaulting to UPM * -0.075")
     return getAttrWithFallback(info, "unitsPerEm") * -0.075
 
 


### PR DESCRIPTION
... to DEBUG messages

They are too noisy, sometimes they repeat themselves (e.g. strikeout thickness is derived from underline thickness, etc.)

Not worth the a WARNING level.