### PR TITLE
Use designspace source names

### DIFF
--- a/Lib/ufo2ft/__init__.py
+++ b/Lib/ufo2ft/__init__.py
@@ -415,14 +415,20 @@ def compileInterpolatableTTFsFromDS(
                 "designspace source '%s' is missing required 'font' attribute"
                 % getattr(source, "name", "<Unknown>")
             )
-        if source.familyName and source.font.info.familyName != source.familyName:
+        updateFamilyName = (source.familyName and
+                            source.font.info.familyName != source.familyName)
+        updateStyleName = (source.styleName and
+                           source.font.info.styleName != source.styleName)
+        if (updateStyleName or updateFamilyName):
+            source.font = source.font.__class__(source.font.path)
+        if updateStyleName:
             logger.info(
                 "Use designspace source familyName '%s' instead of '%s'",
                 source.familyName,
                 source.font.info.familyName
             )
             source.font.info.familyName = source.familyName
-        if source.styleName and source.font.info.styleName != source.styleName:
+        if updateStyleName:
             logger.info(
                 "Use designspace source styleName '%s' instead of '%s'",
                 source.styleName,

--- a/Lib/ufo2ft/__init__.py
+++ b/Lib/ufo2ft/__init__.py
@@ -415,6 +415,20 @@ def compileInterpolatableTTFsFromDS(
                 "designspace source '%s' is missing required 'font' attribute"
                 % getattr(source, "name", "<Unknown>")
             )
+        if source.familyName and source.font.info.familyName != source.familyName:
+            logger.info(
+                "Use designspace source familyName '%s' instead of '%s'",
+                source.familyName,
+                source.font.info.familyName
+            )
+            source.font.info.familyName = source.familyName
+        if source.styleName and source.font.info.styleName != source.styleName:
+            logger.info(
+                "Use designspace source styleName '%s' instead of '%s'",
+                source.styleName,
+                source.font.info.styleName
+            )
+            source.font.info.styleName = source.styleName
         ufos.append(source.font)
         # 'layerName' is None for the default layer
         layerNames.append(source.layerName)


### PR DESCRIPTION
At the moment the familyName and the styleName of the source.font as defined in the UFO are used instead of the familyName and the styleName of the source as defined in the designspace.

The names defined in the designspace should be used instead.

This can be useful when several designspaces use the same UFOs to produce different font families.