### PR TITLE
run ExplodeColorLayerGlyphsFilter by default

### DIFF
--- a/Lib/ufo2ft/filters/explodeColorLayerGlyphs.py
+++ b/Lib/ufo2ft/filters/explodeColorLayerGlyphs.py
@@ -17,7 +17,7 @@ class ExplodeColorLayerGlyphsFilter(BaseFilter):
         context.colorLayerGlyphNames = set()  # glyph names that we added
         font.lib[COLOR_LAYERS_KEY] = {}
         return context
-        
+
     def _getLayer(self, font, layerName):
         layer = self.context.layerGlyphSets.get(layerName)
         if layer is None:
@@ -33,13 +33,15 @@ class ExplodeColorLayerGlyphsFilter(BaseFilter):
                 # We've added this glyph already, so we're done
                 return layerGlyphName
             from ufo2ft.errors import InvalidFontData
+
             raise InvalidFontData(
                 f"a glyph named {layerGlyphName} already exists, "
                 "conflicting with a requested color layer glyph."
             )
         for component in layerGlyph.components:
             baseLayerGlyphName = self._copyGlyph(
-                layerGlyphSet, glyphSet, component.baseGlyph, layerName)
+                layerGlyphSet, glyphSet, component.baseGlyph, layerName
+            )
             component.baseGlyph = baseLayerGlyphName
         glyphSet[layerGlyphName] = layerGlyph
         self.context.colorLayerGlyphNames.add(layerGlyphName)
@@ -60,7 +62,8 @@ class ExplodeColorLayerGlyphsFilter(BaseFilter):
             layerGlyphSet = self._getLayer(font, layerName)
             if glyph.name in layerGlyphSet:
                 layerGlyphName = self._copyGlyph(
-                    layerGlyphSet, glyphSet, glyph.name, layerName)
+                    layerGlyphSet, glyphSet, glyph.name, layerName
+                )
                 layers.append((layerGlyphName, colorID))
         if layers:
             colorLayers[glyph.name] = layers

--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -893,7 +893,8 @@ class BaseOutlineCompiler(object):
         from fontTools.colorLib.builder import buildCOLR
 
         layerInfo = self.ufo.lib[COLOR_LAYERS_KEY]
-        self.otf["COLR"] = buildCOLR(layerInfo)
+        if layerInfo:
+            self.otf["COLR"] = buildCOLR(layerInfo)
 
     def setupTable_CPAL(self):
         """

--- a/tests/data/ColorTest.ufo/lib.plist
+++ b/tests/data/ColorTest.ufo/lib.plist
@@ -39,15 +39,6 @@
         </array>
       </array>
     </array>
-    <key>com.github.googlei18n.ufo2ft.filters</key>
-    <array>
-      <dict>
-        <key>name</key>
-        <string>Explode Color Layer Glyphs</string>
-        <key>pre</key>
-        <true/>
-      </dict>
-    </array>
     <key>public.glyphOrder</key>
     <array>
       <string>space</string>


### PR DESCRIPTION
... whenever `colorPalettes` and `colorLayerMapping` lib keys are present.

Before this, to activate it one had to list "Explode Color Layer Glyphs" among the custom list of `filters`.

@justvanrossum PTAL, thanks