### PR TITLE
Ignore non exporting glyphs in the generation of mark features for #411

### DIFF
--- a/Lib/ufo2ft/util.py
+++ b/Lib/ufo2ft/util.py
@@ -31,7 +31,12 @@ def makeOfficialGlyphOrder(font, glyphOrder=None):
     """
     if glyphOrder is None:
         glyphOrder = getattr(font, "glyphOrder", ())
+
     names = set(font.keys())
+    if "public.skipExportGlyphs" in font.lib.keys():
+        non_exporting = font.lib["public.skipExportGlyphs"]
+        names = [g for g in names if g not in non_exporting]
+        
     order = []
     if ".notdef" in names:
         names.remove(".notdef")

--- a/Lib/ufo2ft/util.py
+++ b/Lib/ufo2ft/util.py
@@ -33,10 +33,10 @@ def makeOfficialGlyphOrder(font, glyphOrder=None):
         glyphOrder = getattr(font, "glyphOrder", ())
 
     names = set(font.keys())
-    if "public.skipExportGlyphs" in font.lib.keys():
+    if hasattr(font, "lib") and "public.skipExportGlyphs" in font.lib.keys():
         non_exporting = font.lib["public.skipExportGlyphs"]
         names = [g for g in names if g not in non_exporting]
-        
+
     order = []
     if ".notdef" in names:
         names.remove(".notdef")


### PR DESCRIPTION
Not sure if this fix is too _nuclear_ in proportion, but it seems to me that the `public.skipExportGlyphs` should be dropped also for other operations that rely on the glyphOrder, thus I added the check in a rather top level spot. I'm happy to shift this to somewhere more specific to the MarkFeatureWriter, but I don't have enough insight into the library to really make that call.

Then again this code only gets called when there is no `compiler` in the context, and maybe should also run and filter a glyphSet given by that compiler, but again I have no real idea what that compiler is.

`baseFeatureWriter.getOrderedGlyphSet` could be a more appropriate place to perform this pruning for both cases.