### PR TITLE
Allow multiple anchor classes per mark glyph in the mark feature

### DIFF
--- a/Lib/ufo2ft/featureWriters/markFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/markFeatureWriter.py
@@ -34,7 +34,7 @@ class AbstractMarkPos(object):
                 markGlyphToMarkClasses[markGlyph].add(namedAnchor.markClass.name)
         for markGlyph, markClasses in markGlyphToMarkClasses.items():
             if len(markClasses) > 1:
-                log.warning(
+                log.info(
                     "The base glyph %s and mark glyph %s are ambiguously "
                     "connected by several anchor classes: %s. "
                     "Only one will prevail; which exactly is not guaranteed.",
@@ -89,7 +89,7 @@ class MarkToLigaPos(AbstractMarkPos):
                     markGlyphToMarkClasses[markGlyph].add(namedAnchor.markClass.name)
         for markGlyph, markClasses in markGlyphToMarkClasses.items():
             if len(markClasses) > 1:
-                log.warning(
+                log.info(
                     "The base ligature %s and mark glyph %s are ambiguously "
                     "connected by several anchor classes: %s. "
                     "Only one will prevail; which exactly is not guaranteed.",

--- a/Lib/ufo2ft/featureWriters/markFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/markFeatureWriter.py
@@ -626,15 +626,13 @@ class MarkFeatureWriter(BaseFeatureWriter):
         return lkp
 
     def _makeMarkFeature(self, include):
-        baseLkps = [
-            lookup
-            for i, attachments in enumerate(self.context.groupedMarkToBaseAttachments)
-            if (
-                lookup := self._makeMarkLookup(
-                    f"mark2base{'_' + str(i) if i > 0 else ''}", attachments, include
-                )
+        baseLkps = []
+        for i, attachments in enumerate(self.context.groupedMarkToBaseAttachments):
+            lookup = self._makeMarkLookup(
+                f"mark2base{'_' + str(i) if i > 0 else ''}", attachments, include
             )
-        ]
+            if lookup:
+                baseLkps.append(lookup)
         # TODO: do the same for ligaLkps?
         ligaLkp = self._makeMarkLookup(
             "mark2liga", self.context.markToLigaAttachments, include
@@ -687,18 +685,16 @@ class MarkFeatureWriter(BaseFeatureWriter):
         else:
             raise AssertionError(tag)
 
-        baseLkps = [
-            lookup
-            for i, attachments in enumerate(self.context.groupedMarkToBaseAttachments)
-            if (
-                lookup := self._makeMarkLookup(
-                    f"{tag}_mark2base{'_' + str(i) if i > 0 else ''}",
-                    attachments,
-                    include=include,
-                    marksFilter=marksFilter,
-                )
+        baseLkps = []
+        for i, attachments in enumerate(self.context.groupedMarkToBaseAttachments):
+            lookup = self._makeMarkLookup(
+                f"{tag}_mark2base{'_' + str(i) if i > 0 else ''}",
+                attachments,
+                include=include,
+                marksFilter=marksFilter,
             )
-        ]
+            if lookup:
+                baseLkps.append(lookup)
         ligaLkp = self._makeMarkLookup(
             "%s_mark2liga" % tag,
             self.context.markToLigaAttachments,

--- a/Lib/ufo2ft/featureWriters/markFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/markFeatureWriter.py
@@ -488,10 +488,9 @@ class MarkFeatureWriter(BaseFeatureWriter):
             for markClass in markClasses
         }
         for markGlyph, markClasses in markGlyphToMarkClasses.items():
-            for markClass in markClasses:
-                for other in markClasses:
-                    if other != markClass:
-                        adjacency[markClass].add(other)
+            for markClass, other in itertools.combinations(markClasses, 2):
+                adjacency[markClass].add(other)
+                adjacency[other].add(markClass)
         colorGroups = colorGraph(adjacency)
         # Sort the groups for reproducibility
         colorGroups = sorted(colorGroups)

--- a/Lib/ufo2ft/featureWriters/markFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/markFeatureWriter.py
@@ -682,22 +682,6 @@ class MarkFeatureWriter(BaseFeatureWriter):
             lkp.statements.extend(statements)
             return lkp
 
-    def _makeMarkLookupWithSubtables(
-        self, lookupName, attachments, include, marksFilter=None
-    ):
-        statements = []
-        for i, subtable in enumerate(attachments):
-            if i > 0:
-                statements.append(ast.ast.SubtableStatement())
-            statements.extend(
-                pos.asAST()
-                for pos in self._iterAttachments(subtable, include, marksFilter)
-            )
-        if statements:
-            lkp = ast.LookupBlock(lookupName)
-            lkp.statements.extend(statements)
-            return lkp
-
     def _makeMarkFilteringSetClass(self, lookupName, attachments, markClass, include):
         markGlyphs = (glyphName for glyphName in markClass.glyphs if include(glyphName))
         baseGlyphs = (
@@ -730,19 +714,27 @@ class MarkFeatureWriter(BaseFeatureWriter):
         return lkp
 
     def _makeMarkFeature(self, include):
-        baseLkp = self._makeMarkLookupWithSubtables(
-            "mark2base", self.context.groupedMarkToBaseAttachments, include
-        )
-        ligaLkp = self._makeMarkLookupWithSubtables(
-            "mark2liga", self.context.groupedMarkToLigaAttachments, include
-        )
-        if baseLkp is None and ligaLkp is None:
+        baseLkps = []
+        for i, attachments in enumerate(self.context.groupedMarkToBaseAttachments):
+            lookup = self._makeMarkLookup(
+                f"mark2base{'_' + str(i) if i > 0 else ''}", attachments, include
+            )
+            if lookup:
+                baseLkps.append(lookup)
+        ligaLkps = []
+        for i, attachments in enumerate(self.context.groupedMarkToLigaAttachments):
+            lookup = self._makeMarkLookup(
+                f"mark2liga{'_' + str(i) if i > 0 else ''}", attachments, include
+            )
+            if lookup:
+                ligaLkps.append(lookup)
+        if not baseLkps and not ligaLkps:
             return
 
         feature = ast.FeatureBlock("mark")
-        if baseLkp is not None:
+        for baseLkp in baseLkps:
             feature.statements.append(baseLkp)
-        if ligaLkp is not None:
+        for ligaLkp in ligaLkps:
             feature.statements.append(ligaLkp)
         return feature
 
@@ -784,18 +776,26 @@ class MarkFeatureWriter(BaseFeatureWriter):
         else:
             raise AssertionError(tag)
 
-        baseLkp = self._makeMarkLookupWithSubtables(
-            f"{tag}_mark2base",
-            self.context.groupedMarkToBaseAttachments,
-            include=include,
-            marksFilter=marksFilter,
-        )
-        ligaLkp = self._makeMarkLookupWithSubtables(
-            f"{tag}_mark2liga",
-            self.context.groupedMarkToLigaAttachments,
-            include=include,
-            marksFilter=marksFilter,
-        )
+        baseLkps = []
+        for i, attachments in enumerate(self.context.groupedMarkToBaseAttachments):
+            lookup = self._makeMarkLookup(
+                f"{tag}_mark2base{'_' + str(i) if i > 0 else ''}",
+                attachments,
+                include=include,
+                marksFilter=marksFilter,
+            )
+            if lookup:
+                baseLkps.append(lookup)
+        ligaLkps = []
+        for i, attachments in enumerate(self.context.groupedMarkToLigaAttachments):
+            lookup = self._makeMarkLookup(
+                f"{tag}_mark2liga{'_' + str(i) if i > 0 else ''}",
+                attachments,
+                include=include,
+                marksFilter=marksFilter,
+            )
+            if lookup:
+                ligaLkps.append(lookup)
         mkmkLookups = []
         for anchorName, attachments in sorted(
             self.context.markToMarkAttachments.items()
@@ -810,13 +810,13 @@ class MarkFeatureWriter(BaseFeatureWriter):
             if lkp is not None:
                 mkmkLookups.append(lkp)
 
-        if not any([baseLkp, ligaLkp, mkmkLookups]):
+        if not any([baseLkps, ligaLkps, mkmkLookups]):
             return
 
         feature = ast.FeatureBlock(tag)
-        if baseLkp is not None:
+        for baseLkp in baseLkps:
             feature.statements.append(baseLkp)
-        if ligaLkp is not None:
+        for ligaLkp in ligaLkps:
             feature.statements.append(ligaLkp)
         feature.statements.extend(mkmkLookups)
         return feature

--- a/tests/data/MultipleAnchorClasses.ufo/fontinfo.plist
+++ b/tests/data/MultipleAnchorClasses.ufo/fontinfo.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>note</key>
+	  <string>https://github.com/googlefonts/ufo2ft/issues/303</string>
+    <key>ascender</key>
+    <integer>750</integer>
+    <key>capHeight</key>
+    <integer>750</integer>
+    <key>descender</key>
+    <integer>-250</integer>
+    <key>familyName</key>
+    <string>MultipleAnchorClasses</string>
+    <key>guidelines</key>
+    <array/>
+    <key>postscriptBlueValues</key>
+    <array/>
+    <key>postscriptFamilyBlues</key>
+    <array/>
+    <key>postscriptFamilyOtherBlues</key>
+    <array/>
+    <key>postscriptOtherBlues</key>
+    <array/>
+    <key>postscriptStemSnapH</key>
+    <array/>
+    <key>postscriptStemSnapV</key>
+    <array/>
+    <key>styleName</key>
+    <string>Regular</string>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+    <key>xHeight</key>
+    <integer>500</integer>
+  </dict>
+</plist>
+

--- a/tests/data/MultipleAnchorClasses.ufo/glyphs/_notdef.glif
+++ b/tests/data/MultipleAnchorClasses.ufo/glyphs/_notdef.glif
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name=".notdef" format="2">
+  <advance width="250"/>
+</glyph>

--- a/tests/data/MultipleAnchorClasses.ufo/glyphs/a.glif
+++ b/tests/data/MultipleAnchorClasses.ufo/glyphs/a.glif
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="a" format="2">
+  <advance width="561"/>
+  <unicode hex="0061"/>
+  <anchor x="515" y="581" name="topA"/>
+  <outline>
+    <contour>
+      <point x="163" y="498" type="line"/>
+      <point x="229" y="516"/>
+      <point x="293" y="524"/>
+      <point x="348" y="524" type="curve" smooth="yes"/>
+      <point x="399" y="524"/>
+      <point x="437" y="517"/>
+      <point x="462" y="477" type="curve" smooth="yes"/>
+      <point x="496" y="425"/>
+      <point x="520" y="288"/>
+      <point x="520" y="223" type="curve" smooth="yes"/>
+      <point x="520" y="206"/>
+      <point x="518" y="189"/>
+      <point x="516" y="172" type="curve" smooth="yes"/>
+      <point x="514" y="155"/>
+      <point x="510" y="138"/>
+      <point x="507" y="121" type="curve" smooth="yes"/>
+      <point x="501" y="88"/>
+      <point x="496" y="55"/>
+      <point x="498" y="23" type="curve"/>
+      <point x="478" y="21" type="line"/>
+      <point x="474" y="49"/>
+      <point x="468" y="78"/>
+      <point x="460" y="105" type="curve"/>
+      <point x="405" y="56"/>
+      <point x="333" y="21"/>
+      <point x="259" y="21" type="curve" smooth="yes"/>
+      <point x="165" y="21"/>
+      <point x="141" y="73"/>
+      <point x="130" y="153" type="curve" smooth="yes"/>
+      <point x="124" y="198"/>
+      <point x="124" y="202"/>
+      <point x="124" y="202" type="curve"/>
+      <point x="124" y="251"/>
+      <point x="156" y="270"/>
+      <point x="208" y="277" type="curve" smooth="yes"/>
+      <point x="243" y="282"/>
+      <point x="296" y="283"/>
+      <point x="337" y="283" type="curve" smooth="yes"/>
+      <point x="396" y="283"/>
+      <point x="446" y="281"/>
+      <point x="495" y="276" type="curve"/>
+      <point x="493" y="256" type="line"/>
+      <point x="444" y="261"/>
+      <point x="396" y="263"/>
+      <point x="337" y="263" type="curve" smooth="yes"/>
+      <point x="296" y="263"/>
+      <point x="245" y="262"/>
+      <point x="210" y="257" type="curve" smooth="yes"/>
+      <point x="162" y="250"/>
+      <point x="144" y="235"/>
+      <point x="144" y="202" type="curve"/>
+      <point x="144" y="202"/>
+      <point x="144" y="198"/>
+      <point x="150" y="155" type="curve" smooth="yes"/>
+      <point x="152" y="142"/>
+      <point x="154" y="128"/>
+      <point x="157" y="114" type="curve"/>
+      <point x="161" y="101"/>
+      <point x="165" y="89"/>
+      <point x="173" y="78" type="curve"/>
+      <point x="186" y="57"/>
+      <point x="211" y="41"/>
+      <point x="259" y="41" type="curve" smooth="yes"/>
+      <point x="310" y="41"/>
+      <point x="379" y="65"/>
+      <point x="420" y="97" type="curve" smooth="yes"/>
+      <point x="435" y="108"/>
+      <point x="446" y="120"/>
+      <point x="459" y="130" type="curve" smooth="yes"/>
+      <point x="470" y="139" type="line"/>
+      <point x="474" y="125" type="line"/>
+      <point x="478" y="116"/>
+      <point x="480" y="107"/>
+      <point x="483" y="97" type="curve"/>
+      <point x="484" y="107"/>
+      <point x="486" y="116"/>
+      <point x="488" y="125" type="curve" smooth="yes"/>
+      <point x="491" y="142"/>
+      <point x="494" y="158"/>
+      <point x="496" y="175" type="curve" smooth="yes"/>
+      <point x="498" y="191"/>
+      <point x="500" y="207"/>
+      <point x="500" y="223" type="curve" smooth="yes"/>
+      <point x="500" y="286"/>
+      <point x="476" y="419"/>
+      <point x="446" y="467" type="curve" smooth="yes"/>
+      <point x="427" y="497"/>
+      <point x="397" y="504"/>
+      <point x="348" y="504" type="curve" smooth="yes"/>
+      <point x="295" y="504"/>
+      <point x="233" y="496"/>
+      <point x="169" y="478" type="curve"/>
+    </contour>
+  </outline>
+</glyph>

--- a/tests/data/MultipleAnchorClasses.ufo/glyphs/acutecomb.glif
+++ b/tests/data/MultipleAnchorClasses.ufo/glyphs/acutecomb.glif
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="acutecomb" format="2">
+  <advance width="333"/>
+  <unicode hex="0301"/>
+  <anchor x="-175" y="589" name="_topA"/>
+  <anchor x="-175" y="572" name="_topE"/>
+  <outline>
+    <contour>
+      <point x="28" y="763" type="curve" smooth="yes"/>
+      <point x="-7" y="766"/>
+      <point x="-50" y="775"/>
+      <point x="-69" y="762" type="curve" smooth="yes"/>
+      <point x="-115" y="731"/>
+      <point x="-136" y="648"/>
+      <point x="-162" y="605" type="curve"/>
+      <point x="-141" y="605"/>
+      <point x="-118" y="597"/>
+      <point x="-93" y="603" type="curve" smooth="yes"/>
+      <point x="-57" y="611"/>
+      <point x="-20" y="655"/>
+      <point x="13" y="692" type="curve" smooth="yes"/>
+      <point x="30" y="710"/>
+      <point x="42" y="738"/>
+      <point x="45" y="752" type="curve" smooth="yes"/>
+      <point x="46" y="756"/>
+      <point x="44" y="761"/>
+    </contour>
+  </outline>
+</glyph>

--- a/tests/data/MultipleAnchorClasses.ufo/glyphs/contents.plist
+++ b/tests/data/MultipleAnchorClasses.ufo/glyphs/contents.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>.notdef</key>
+  <string>_notdef.glif</string>
+  <key>a</key>
+  <string>a.glif</string>
+  <key>acutecomb</key>
+  <string>acutecomb.glif</string>
+  <key>e</key>
+  <string>e.glif</string>
+</dict>
+</plist>

--- a/tests/data/MultipleAnchorClasses.ufo/glyphs/e.glif
+++ b/tests/data/MultipleAnchorClasses.ufo/glyphs/e.glif
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="e" format="2">
+  <advance width="564"/>
+  <unicode hex="0065"/>
+  <anchor x="-21" y="396" name="topE"/>
+  <outline>
+    <contour>
+      <point x="481" y="286" type="curve"/>
+      <point x="482" y="287"/>
+      <point x="482" y="289"/>
+      <point x="482" y="290" type="curve"/>
+      <point x="482" y="296" type="line" smooth="yes"/>
+      <point x="482" y="326"/>
+      <point x="473" y="354"/>
+      <point x="462" y="377" type="curve" smooth="yes"/>
+      <point x="450" y="401"/>
+      <point x="437" y="420"/>
+      <point x="429" y="433" type="curve" smooth="yes"/>
+      <point x="397" y="487"/>
+      <point x="351" y="497"/>
+      <point x="304" y="497" type="curve" smooth="yes"/>
+      <point x="167" y="497"/>
+      <point x="154" y="347"/>
+      <point x="154" y="242" type="curve" smooth="yes"/>
+      <point x="154" y="117"/>
+      <point x="175" y="39"/>
+      <point x="332" y="39" type="curve" smooth="yes"/>
+      <point x="369" y="39"/>
+      <point x="398" y="43"/>
+      <point x="422" y="48" type="curve" smooth="yes"/>
+      <point x="447" y="54"/>
+      <point x="468" y="59"/>
+      <point x="490" y="62" type="curve"/>
+      <point x="492" y="42" type="line"/>
+      <point x="471" y="40"/>
+      <point x="450" y="34"/>
+      <point x="426" y="29" type="curve" smooth="yes"/>
+      <point x="400" y="24"/>
+      <point x="371" y="19"/>
+      <point x="332" y="19" type="curve" smooth="yes"/>
+      <point x="159" y="19"/>
+      <point x="134" y="113"/>
+      <point x="134" y="242" type="curve" smooth="yes"/>
+      <point x="134" y="360"/>
+      <point x="154" y="517"/>
+      <point x="304" y="517" type="curve" smooth="yes"/>
+      <point x="355" y="517"/>
+      <point x="409" y="505"/>
+      <point x="447" y="443" type="curve"/>
+      <point x="454" y="430"/>
+      <point x="468" y="410"/>
+      <point x="480" y="386" type="curve" smooth="yes"/>
+      <point x="492" y="361"/>
+      <point x="502" y="331"/>
+      <point x="502" y="296" type="curve" smooth="yes"/>
+      <point x="502" y="287" type="line"/>
+      <point x="501" y="284"/>
+      <point x="501" y="282"/>
+      <point x="500" y="280" type="curve"/>
+      <point x="500" y="275"/>
+      <point x="494" y="270"/>
+      <point x="490" y="268" type="curve"/>
+      <point x="489" y="268"/>
+      <point x="487" y="267"/>
+      <point x="485" y="267" type="curve"/>
+      <point x="478" y="265"/>
+      <point x="409" y="264"/>
+      <point x="401" y="264" type="curve" smooth="yes"/>
+      <point x="328" y="264"/>
+      <point x="244" y="273"/>
+      <point x="160" y="273" type="curve" smooth="yes"/>
+      <point x="141" y="273" type="line"/>
+      <point x="141" y="293" type="line"/>
+      <point x="160" y="293" type="line" smooth="yes"/>
+      <point x="244" y="293"/>
+      <point x="328" y="284"/>
+      <point x="401" y="284" type="curve" smooth="yes"/>
+      <point x="435" y="284"/>
+      <point x="458" y="286"/>
+      <point x="473" y="286" type="curve" smooth="yes"/>
+      <point x="477" y="286"/>
+      <point x="479" y="286"/>
+    </contour>
+  </outline>
+</glyph>

--- a/tests/data/MultipleAnchorClasses.ufo/glyphs/layerinfo.plist
+++ b/tests/data/MultipleAnchorClasses.ufo/glyphs/layerinfo.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/tests/data/MultipleAnchorClasses.ufo/layercontents.plist
+++ b/tests/data/MultipleAnchorClasses.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+  <array>
+    <string>public.default</string>
+    <string>glyphs</string>
+  </array>
+</array>
+</plist>

--- a/tests/data/MultipleAnchorClasses.ufo/lib.plist
+++ b/tests/data/MultipleAnchorClasses.ufo/lib.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>public.glyphOrder</key>
+  <array>
+    <string>.notdef</string>
+    <string>a</string>
+    <string>e</string>
+    <string>acutecomb</string>
+  </array>
+</dict>
+</plist>

--- a/tests/data/MultipleAnchorClasses.ufo/metainfo.plist
+++ b/tests/data/MultipleAnchorClasses.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>creator</key>
+  <string>com.fontlab.ufoLib</string>
+  <key>formatVersion</key>
+  <integer>3</integer>
+</dict>
+</plist>

--- a/tests/data/MultipleAnchorClassesConflict.ufo/fontinfo.plist
+++ b/tests/data/MultipleAnchorClassesConflict.ufo/fontinfo.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>note</key>
+	  <string>https://github.com/googlefonts/ufo2ft/issues/303</string>
+    <key>ascender</key>
+    <integer>750</integer>
+    <key>capHeight</key>
+    <integer>750</integer>
+    <key>descender</key>
+    <integer>-250</integer>
+    <key>familyName</key>
+    <string>MultipleAnchorClassesConflict</string>
+    <key>guidelines</key>
+    <array/>
+    <key>postscriptBlueValues</key>
+    <array/>
+    <key>postscriptFamilyBlues</key>
+    <array/>
+    <key>postscriptFamilyOtherBlues</key>
+    <array/>
+    <key>postscriptOtherBlues</key>
+    <array/>
+    <key>postscriptStemSnapH</key>
+    <array/>
+    <key>postscriptStemSnapV</key>
+    <array/>
+    <key>styleName</key>
+    <string>Regular</string>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+    <key>xHeight</key>
+    <integer>500</integer>
+  </dict>
+</plist>
+

--- a/tests/data/MultipleAnchorClassesConflict.ufo/glyphs/_notdef.glif
+++ b/tests/data/MultipleAnchorClassesConflict.ufo/glyphs/_notdef.glif
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name=".notdef" format="2">
+  <advance width="250"/>
+</glyph>

--- a/tests/data/MultipleAnchorClassesConflict.ufo/glyphs/acutecomb.glif
+++ b/tests/data/MultipleAnchorClassesConflict.ufo/glyphs/acutecomb.glif
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="acutecomb" format="2">
+  <advance width="333"/>
+  <unicode hex="0301"/>
+  <anchor x="-175" y="589" name="_topA"/>
+  <anchor x="-175" y="572" name="_topE"/>
+  <outline>
+    <contour>
+      <point x="28" y="763" type="curve"/>
+      <point x="-7" y="766"/>
+      <point x="-50" y="775"/>
+      <point x="-69" y="762" type="curve" smooth="yes"/>
+      <point x="-115" y="731"/>
+      <point x="-136" y="648"/>
+      <point x="-162" y="605" type="curve"/>
+      <point x="-141" y="605"/>
+      <point x="-118" y="597"/>
+      <point x="-93" y="603" type="curve" smooth="yes"/>
+      <point x="-57" y="611"/>
+      <point x="-20" y="655"/>
+      <point x="13" y="692" type="curve"/>
+      <point x="30" y="710"/>
+      <point x="42" y="738"/>
+      <point x="45" y="752" type="curve"/>
+      <point x="46" y="756"/>
+      <point x="44" y="761"/>
+    </contour>
+  </outline>
+</glyph>

--- a/tests/data/MultipleAnchorClassesConflict.ufo/glyphs/ae.glif
+++ b/tests/data/MultipleAnchorClassesConflict.ufo/glyphs/ae.glif
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="ae" format="2">
+  <advance width="973"/>
+  <unicode hex="00E6"/>
+  <anchor x="268" y="578" name="topA"/>
+  <anchor x="657" y="562" name="topE"/>
+  <outline>
+    <contour>
+      <point x="163" y="498" type="line"/>
+      <point x="229" y="516"/>
+      <point x="293" y="524"/>
+      <point x="348" y="524" type="curve" smooth="yes"/>
+      <point x="399" y="524"/>
+      <point x="437" y="517"/>
+      <point x="462" y="477" type="curve" smooth="yes"/>
+      <point x="496" y="425"/>
+      <point x="520" y="288"/>
+      <point x="520" y="223" type="curve" smooth="yes"/>
+      <point x="520" y="206"/>
+      <point x="518" y="189"/>
+      <point x="516" y="172" type="curve" smooth="yes"/>
+      <point x="514" y="155"/>
+      <point x="510" y="138"/>
+      <point x="507" y="121" type="curve" smooth="yes"/>
+      <point x="501" y="88"/>
+      <point x="496" y="55"/>
+      <point x="498" y="23" type="curve"/>
+      <point x="478" y="21" type="line"/>
+      <point x="474" y="49"/>
+      <point x="468" y="78"/>
+      <point x="460" y="105" type="curve"/>
+      <point x="405" y="56"/>
+      <point x="333" y="21"/>
+      <point x="259" y="21" type="curve" smooth="yes"/>
+      <point x="165" y="21"/>
+      <point x="141" y="73"/>
+      <point x="130" y="153" type="curve" smooth="yes"/>
+      <point x="124" y="198"/>
+      <point x="124" y="202"/>
+      <point x="124" y="202" type="curve"/>
+      <point x="124" y="251"/>
+      <point x="156" y="270"/>
+      <point x="208" y="277" type="curve" smooth="yes"/>
+      <point x="243" y="282"/>
+      <point x="296" y="283"/>
+      <point x="337" y="283" type="curve" smooth="yes"/>
+      <point x="396" y="283"/>
+      <point x="446" y="281"/>
+      <point x="495" y="276" type="curve"/>
+      <point x="493" y="256" type="line"/>
+      <point x="444" y="261"/>
+      <point x="396" y="263"/>
+      <point x="337" y="263" type="curve" smooth="yes"/>
+      <point x="296" y="263"/>
+      <point x="245" y="262"/>
+      <point x="210" y="257" type="curve" smooth="yes"/>
+      <point x="162" y="250"/>
+      <point x="144" y="235"/>
+      <point x="144" y="202" type="curve"/>
+      <point x="144" y="202"/>
+      <point x="144" y="198"/>
+      <point x="150" y="155" type="curve" smooth="yes"/>
+      <point x="152" y="142"/>
+      <point x="154" y="128"/>
+      <point x="157" y="114" type="curve"/>
+      <point x="161" y="101"/>
+      <point x="165" y="89"/>
+      <point x="173" y="78" type="curve"/>
+      <point x="186" y="57"/>
+      <point x="211" y="41"/>
+      <point x="259" y="41" type="curve" smooth="yes"/>
+      <point x="310" y="41"/>
+      <point x="379" y="65"/>
+      <point x="420" y="97" type="curve"/>
+      <point x="435" y="108"/>
+      <point x="446" y="120"/>
+      <point x="459" y="130" type="curve"/>
+      <point x="470" y="139" type="line"/>
+      <point x="474" y="125" type="line"/>
+      <point x="478" y="116"/>
+      <point x="480" y="107"/>
+      <point x="483" y="97" type="curve"/>
+      <point x="484" y="107"/>
+      <point x="486" y="116"/>
+      <point x="488" y="125" type="curve"/>
+      <point x="491" y="142"/>
+      <point x="494" y="158"/>
+      <point x="496" y="175" type="curve" smooth="yes"/>
+      <point x="498" y="191"/>
+      <point x="500" y="207"/>
+      <point x="500" y="223" type="curve" smooth="yes"/>
+      <point x="500" y="286"/>
+      <point x="476" y="419"/>
+      <point x="446" y="467" type="curve" smooth="yes"/>
+      <point x="427" y="497"/>
+      <point x="397" y="504"/>
+      <point x="348" y="504" type="curve" smooth="yes"/>
+      <point x="295" y="504"/>
+      <point x="233" y="496"/>
+      <point x="169" y="478" type="curve"/>
+    </contour>
+    <contour>
+      <point x="834" y="281.465" type="curve"/>
+      <point x="835" y="282.465"/>
+      <point x="835" y="284.465"/>
+      <point x="835" y="285.465" type="curve"/>
+      <point x="835" y="291.465" type="line" smooth="yes"/>
+      <point x="835" y="321.465"/>
+      <point x="826" y="349.465"/>
+      <point x="815" y="372.465" type="curve" smooth="yes"/>
+      <point x="803" y="396.465"/>
+      <point x="790" y="415.465"/>
+      <point x="782" y="428.465" type="curve" smooth="yes"/>
+      <point x="750" y="482.465"/>
+      <point x="704" y="492.465"/>
+      <point x="657" y="492.465" type="curve" smooth="yes"/>
+      <point x="520" y="492.465"/>
+      <point x="507" y="342.465"/>
+      <point x="507" y="237.465" type="curve" smooth="yes"/>
+      <point x="507" y="112.465"/>
+      <point x="528" y="34.4649"/>
+      <point x="685" y="34.4649" type="curve" smooth="yes"/>
+      <point x="722" y="34.4649"/>
+      <point x="751" y="38.4649"/>
+      <point x="775" y="43.4649" type="curve"/>
+      <point x="800" y="49.4649"/>
+      <point x="821" y="54.4649"/>
+      <point x="843" y="57.4649" type="curve"/>
+      <point x="845" y="37.4649" type="line"/>
+      <point x="824" y="35.4649"/>
+      <point x="803" y="29.4649"/>
+      <point x="779" y="24.4649" type="curve" smooth="yes"/>
+      <point x="753" y="19.4649"/>
+      <point x="724" y="14.4649"/>
+      <point x="685" y="14.4649" type="curve" smooth="yes"/>
+      <point x="512" y="14.4649"/>
+      <point x="487" y="108.465"/>
+      <point x="487" y="237.465" type="curve" smooth="yes"/>
+      <point x="487" y="355.465"/>
+      <point x="507" y="512.465"/>
+      <point x="657" y="512.465" type="curve" smooth="yes"/>
+      <point x="708" y="512.465"/>
+      <point x="762" y="500.465"/>
+      <point x="800" y="438.465" type="curve"/>
+      <point x="807" y="425.465"/>
+      <point x="821" y="405.465"/>
+      <point x="833" y="381.465" type="curve" smooth="yes"/>
+      <point x="845" y="356.465"/>
+      <point x="855" y="326.465"/>
+      <point x="855" y="291.465" type="curve" smooth="yes"/>
+      <point x="855" y="282.465" type="line"/>
+      <point x="854" y="279.465"/>
+      <point x="854" y="277.465"/>
+      <point x="853" y="275.465" type="curve"/>
+      <point x="853" y="270.465"/>
+      <point x="847" y="265.465"/>
+      <point x="843" y="263.465" type="curve"/>
+      <point x="842" y="263.465"/>
+      <point x="840" y="262.465"/>
+      <point x="838" y="262.465" type="curve"/>
+      <point x="831" y="260.465"/>
+      <point x="762" y="259.465"/>
+      <point x="754" y="259.465" type="curve" smooth="yes"/>
+      <point x="681" y="259.465"/>
+      <point x="597" y="268.465"/>
+      <point x="513" y="268.465" type="curve" smooth="yes"/>
+      <point x="494" y="268.465" type="line"/>
+      <point x="494" y="288.465" type="line"/>
+      <point x="513" y="288.465" type="line" smooth="yes"/>
+      <point x="597" y="288.465"/>
+      <point x="681" y="279.465"/>
+      <point x="754" y="279.465" type="curve" smooth="yes"/>
+      <point x="788" y="279.465"/>
+      <point x="811" y="281.465"/>
+      <point x="826" y="281.465" type="curve" smooth="yes"/>
+      <point x="830" y="281.465"/>
+      <point x="832" y="281.465"/>
+    </contour>
+  </outline>
+</glyph>

--- a/tests/data/MultipleAnchorClassesConflict.ufo/glyphs/contents.plist
+++ b/tests/data/MultipleAnchorClassesConflict.ufo/glyphs/contents.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>.notdef</key>
+  <string>_notdef.glif</string>
+  <key>acutecomb</key>
+  <string>acutecomb.glif</string>
+  <key>ae</key>
+  <string>ae.glif</string>
+</dict>
+</plist>

--- a/tests/data/MultipleAnchorClassesConflict.ufo/glyphs/layerinfo.plist
+++ b/tests/data/MultipleAnchorClassesConflict.ufo/glyphs/layerinfo.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/tests/data/MultipleAnchorClassesConflict.ufo/layercontents.plist
+++ b/tests/data/MultipleAnchorClassesConflict.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+  <array>
+    <string>public.default</string>
+    <string>glyphs</string>
+  </array>
+</array>
+</plist>

--- a/tests/data/MultipleAnchorClassesConflict.ufo/lib.plist
+++ b/tests/data/MultipleAnchorClassesConflict.ufo/lib.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>public.glyphOrder</key>
+  <array>
+    <string>.notdef</string>
+    <string>acutecomb</string>
+    <string>ae</string>
+  </array>
+</dict>
+</plist>

--- a/tests/data/MultipleAnchorClassesConflict.ufo/metainfo.plist
+++ b/tests/data/MultipleAnchorClassesConflict.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>creator</key>
+  <string>com.fontlab.ufoLib</string>
+  <key>formatVersion</key>
+  <integer>3</integer>
+</dict>
+</plist>

--- a/tests/featureWriters/markFeatureWriter_test.py
+++ b/tests/featureWriters/markFeatureWriter_test.py
@@ -717,6 +717,7 @@ class MarkFeatureWriterTest(FeatureWriterTest):
 
         generated = self.writeFeatures(ufo)
 
+        # MC_top should be last thanks to the anchorSortKey
         assert str(generated) == dedent(
             """\
             markClass acutecomb <anchor 100 200> @MC_top;
@@ -724,17 +725,17 @@ class MarkFeatureWriterTest(FeatureWriterTest):
 
             feature mark {
                 lookup mark2liga {
-                    pos ligature f_i <anchor 100 500> mark @MC_top
-                        ligComponent <anchor 600 500> mark @MC_top;
-                    pos ligature f_l <anchor 102 502> mark @MC_top
-                        ligComponent <anchor NULL>;
-                } mark2liga;
-
-                lookup mark2liga_1 {
                     pos ligature f_f <anchor 101 501> mark @MC_topOther
                         ligComponent <anchor 601 501> mark @MC_topOther;
                     pos ligature f_l <anchor NULL>
                         ligComponent <anchor 602 502> mark @MC_topOther;
+                } mark2liga;
+
+                lookup mark2liga_1 {
+                    pos ligature f_i <anchor 100 500> mark @MC_top
+                        ligComponent <anchor 600 500> mark @MC_top;
+                    pos ligature f_l <anchor 102 502> mark @MC_top
+                        ligComponent <anchor NULL>;
                 } mark2liga_1;
 
             } mark;
@@ -766,6 +767,7 @@ class MarkFeatureWriterTest(FeatureWriterTest):
             "Only one will prevail; which exactly is not guaranteed." in caplog.text
         )
 
+        # MC_top should be last thanks to the anchorSortKey
         assert str(generated) == dedent(
             """\
             markClass acutecomb <anchor 100 200> @MC_top;
@@ -773,11 +775,11 @@ class MarkFeatureWriterTest(FeatureWriterTest):
 
             feature mark {
                 lookup mark2base {
-                    pos base a <anchor 100 500> mark @MC_top;
+                    pos base a <anchor 150 550> mark @MC_topOther;
                 } mark2base;
 
                 lookup mark2base_1 {
-                    pos base a <anchor 150 550> mark @MC_topOther;
+                    pos base a <anchor 100 500> mark @MC_top;
                 } mark2base_1;
 
             } mark;

--- a/tests/featureWriters/markFeatureWriter_test.py
+++ b/tests/featureWriters/markFeatureWriter_test.py
@@ -650,12 +650,10 @@ class MarkFeatureWriterTest(FeatureWriterTest):
             feature mark {
                 lookup mark2base {
                     pos base D <anchor 320 360> mark @MC_center;
-                } mark2base;
-
-                lookup mark2base_1 {
+                    subtable;
                     pos base D <anchor 300 700> mark @MC_top;
                     pos base a <anchor 100 200> mark @MC_top;
-                } mark2base_1;
+                } mark2base;
 
                 lookup mark2liga {
                     pos ligature f_i <anchor 100 500> mark @MC_top
@@ -690,11 +688,9 @@ class MarkFeatureWriterTest(FeatureWriterTest):
             feature mark {
                 lookup mark2base {
                     pos base a <anchor 515 581> mark @MC_topA;
-                } mark2base;
-
-                lookup mark2base_1 {
+                    subtable;
                     pos base e <anchor -21 396> mark @MC_topE;
-                } mark2base_1;
+                } mark2base;
 
             } mark;
             """
@@ -728,14 +724,12 @@ class MarkFeatureWriterTest(FeatureWriterTest):
                         ligComponent <anchor 600 500> mark @MC_top;
                     pos ligature f_l <anchor 102 502> mark @MC_top
                         ligComponent <anchor NULL>;
-                } mark2liga;
-
-                lookup mark2liga_1 {
+                    subtable;
                     pos ligature f_f <anchor 101 501> mark @MC_topOther
                         ligComponent <anchor 601 501> mark @MC_topOther;
                     pos ligature f_l <anchor NULL>
                         ligComponent <anchor 602 502> mark @MC_topOther;
-                } mark2liga_1;
+                } mark2liga;
 
             } mark;
             """
@@ -774,11 +768,9 @@ class MarkFeatureWriterTest(FeatureWriterTest):
             feature mark {
                 lookup mark2base {
                     pos base a <anchor 100 500> mark @MC_top;
-                } mark2base;
-
-                lookup mark2base_1 {
+                    subtable;
                     pos base a <anchor 150 550> mark @MC_topOther;
-                } mark2base_1;
+                } mark2base;
 
             } mark;
             """

--- a/tests/featureWriters/markFeatureWriter_test.py
+++ b/tests/featureWriters/markFeatureWriter_test.py
@@ -751,6 +751,8 @@ class MarkFeatureWriterTest(FeatureWriterTest):
         of mark positioning. See this comment for more information:
         https://github.com/googlefonts/ufo2ft/pull/416#issuecomment-721693266
         """
+        caplog.set_level(logging.INFO)
+
         ufo = FontClass()
         liga = ufo.newGlyph("a")
         liga.appendAnchor({"name": "top", "x": 100, "y": 500})

--- a/tests/featureWriters/markFeatureWriter_test.py
+++ b/tests/featureWriters/markFeatureWriter_test.py
@@ -765,8 +765,8 @@ class MarkFeatureWriterTest(FeatureWriterTest):
 
         assert (
             "The base glyph a and mark glyph acutecomb are ambiguously "
-            "connected by several anchor classes: MC_top, MC_topOther. "
-            "Only one will prevail; which exactly is not guaranteed." in caplog.text
+            "connected by several anchor classes: MC_topOther, MC_top. "
+            "The last one will prevail." in caplog.text
         )
 
         # MC_top should be last thanks to the anchorSortKey

--- a/tests/featureWriters/markFeatureWriter_test.py
+++ b/tests/featureWriters/markFeatureWriter_test.py
@@ -650,10 +650,12 @@ class MarkFeatureWriterTest(FeatureWriterTest):
             feature mark {
                 lookup mark2base {
                     pos base D <anchor 320 360> mark @MC_center;
-                    subtable;
+                } mark2base;
+
+                lookup mark2base_1 {
                     pos base D <anchor 300 700> mark @MC_top;
                     pos base a <anchor 100 200> mark @MC_top;
-                } mark2base;
+                } mark2base_1;
 
                 lookup mark2liga {
                     pos ligature f_i <anchor 100 500> mark @MC_top
@@ -688,9 +690,11 @@ class MarkFeatureWriterTest(FeatureWriterTest):
             feature mark {
                 lookup mark2base {
                     pos base a <anchor 515 581> mark @MC_topA;
-                    subtable;
-                    pos base e <anchor -21 396> mark @MC_topE;
                 } mark2base;
+
+                lookup mark2base_1 {
+                    pos base e <anchor -21 396> mark @MC_topE;
+                } mark2base_1;
 
             } mark;
             """
@@ -724,12 +728,14 @@ class MarkFeatureWriterTest(FeatureWriterTest):
                         ligComponent <anchor 600 500> mark @MC_top;
                     pos ligature f_l <anchor 102 502> mark @MC_top
                         ligComponent <anchor NULL>;
-                    subtable;
+                } mark2liga;
+
+                lookup mark2liga_1 {
                     pos ligature f_f <anchor 101 501> mark @MC_topOther
                         ligComponent <anchor 601 501> mark @MC_topOther;
                     pos ligature f_l <anchor NULL>
                         ligComponent <anchor 602 502> mark @MC_topOther;
-                } mark2liga;
+                } mark2liga_1;
 
             } mark;
             """
@@ -768,9 +774,11 @@ class MarkFeatureWriterTest(FeatureWriterTest):
             feature mark {
                 lookup mark2base {
                     pos base a <anchor 100 500> mark @MC_top;
-                    subtable;
-                    pos base a <anchor 150 550> mark @MC_topOther;
                 } mark2base;
+
+                lookup mark2base_1 {
+                    pos base a <anchor 150 550> mark @MC_topOther;
+                } mark2base_1;
 
             } mark;
             """

--- a/tests/featureWriters/markFeatureWriter_test.py
+++ b/tests/featureWriters/markFeatureWriter_test.py
@@ -676,7 +676,7 @@ class MarkFeatureWriterTest(FeatureWriterTest):
             """
         )
 
-    def test_multiple_anchor_classes(self, FontClass):
+    def test_multiple_anchor_classes_base(self, FontClass):
         dirname = os.path.dirname(os.path.dirname(__file__))
         fontPath = os.path.join(dirname, "data", "MultipleAnchorClasses.ufo")
         testufo = FontClass(fontPath)
@@ -695,6 +695,47 @@ class MarkFeatureWriterTest(FeatureWriterTest):
                 lookup mark2base_1 {
                     pos base e <anchor -21 396> mark @MC_topE;
                 } mark2base_1;
+
+            } mark;
+            """
+        )
+
+    def test_multiple_anchor_classes_liga(self, FontClass):
+        ufo = FontClass()
+        liga = ufo.newGlyph("f_i")
+        liga.appendAnchor({"name": "top_1", "x": 100, "y": 500})
+        liga.appendAnchor({"name": "top_2", "x": 600, "y": 500})
+        ligaOther = ufo.newGlyph("f_f")
+        ligaOther.appendAnchor({"name": "topOther_1", "x": 101, "y": 501})
+        ligaOther.appendAnchor({"name": "topOther_2", "x": 601, "y": 501})
+        ligaMix = ufo.newGlyph("f_l")
+        ligaMix.appendAnchor({"name": "top_1", "x": 102, "y": 502})
+        ligaMix.appendAnchor({"name": "topOther_2", "x": 602, "y": 502})
+        acutecomb = ufo.newGlyph("acutecomb")
+        acutecomb.appendAnchor({"name": "_top", "x": 100, "y": 200})
+        acutecomb.appendAnchor({"name": "_topOther", "x": 150, "y": 250})
+
+        generated = self.writeFeatures(ufo)
+
+        assert str(generated) == dedent(
+            """\
+            markClass acutecomb <anchor 100 200> @MC_top;
+            markClass acutecomb <anchor 150 250> @MC_topOther;
+
+            feature mark {
+                lookup mark2liga {
+                    pos ligature f_i <anchor 100 500> mark @MC_top
+                        ligComponent <anchor 600 500> mark @MC_top;
+                    pos ligature f_l <anchor 102 502> mark @MC_top
+                        ligComponent <anchor NULL>;
+                } mark2liga;
+
+                lookup mark2liga_1 {
+                    pos ligature f_f <anchor 101 501> mark @MC_topOther
+                        ligComponent <anchor 601 501> mark @MC_topOther;
+                    pos ligature f_l <anchor NULL>
+                        ligComponent <anchor 602 502> mark @MC_topOther;
+                } mark2liga_1;
 
             } mark;
             """


### PR DESCRIPTION
Hello, this PR aims to fix https://github.com/googlefonts/ufo2ft/issues/303

While the tests should be green, I'm not sure that I'm not introducing regressions for people who rely on very precise implementation of the Glyphs.app "tricks" with ordering _bottom and _top before others. With the new version of the code, all mark anchors are output, and if there are conflicts the last one will win, not necessarily the one Glyphs.app was picking. For example, if /a and /acutecomb can be attached through both a top/_top and an accent/_accent mark pairs, before it would only output top/_top, now it will output both in different lookups, and probably the last lookup will win (or who knows what will happen actually).

Also, @anthrotype you said you had a patch at some point using the classifier, but I haven't been able to see how to apply the classifier to the problem. I'm using a graph coloring instead. Does that sound OK? How would that be solved instead using the classifier?

Thanks in advance for some reviews!