### PR TITLE
outlineCompiler: improve VORG table generation

### DIFF
--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -854,7 +854,10 @@ class BaseOutlineCompiler(object):
         vorg.defaultVertOriginY = vorg_count.most_common(1)[0][0]
         if len(vorg_count) > 1:
             for glyphName, glyph in self.allGlyphs.items():
-                vorg.VOriginRecords[glyphName] = _getVerticalOrigin(self.otf, glyph)
+                vertOriginY = _getVerticalOrigin(self.otf, glyph)
+                if vertOriginY == vorg.defaultVertOriginY:
+                    continue
+                vorg.VOriginRecords[glyphName] = vertOriginY
         vorg.numVertOriginYMetrics = len(vorg.VOriginRecords)
 
     def setupTable_vhea(self):


### PR DESCRIPTION
Whilst working on glyphsLib, I noticed that the VORG table generation is too greedy. If a glyph's vertical origin is the same as the table's default vertical origin, we don't need to add it.

Here's a quick before and after on a test font.

**Current implementation**

```
  <VORG>
    <majorVersion value="1"/>
    <minorVersion value="0"/>
    <defaultVertOriginY value="850"/>
    <numVertOriginYMetrics value="6"/>
    <VOriginRecord>
      <glyphName value=".notdef"/>
      <vOrigin value="850"/>
    </VOriginRecord>
    <VOriginRecord>
      <glyphName value="A"/>
      <vOrigin value="850"/>
    </VOriginRecord>
    <VOriginRecord>
      <glyphName value="B"/>
      <vOrigin value="850"/>
    </VOriginRecord>
    <VOriginRecord>
      <glyphName value="A.rotat"/>
      <vOrigin value="850"/>
    </VOriginRecord>
    <VOriginRecord>
      <glyphName value="A.half.rotat"/>
      <vOrigin value="850"/>
    </VOriginRecord>
    <VOriginRecord>
      <glyphName value="B.half.rotat"/>
      <vOrigin value="550"/>
    </VOriginRecord>
  </VORG>
```


**This pr**

```
  <VORG>
    <majorVersion value="1"/>
    <minorVersion value="0"/>
    <defaultVertOriginY value="850"/>
    <numVertOriginYMetrics value="1"/>
    <VOriginRecord>
      <glyphName value="B.half.rotat"/>
      <vOrigin value="550"/>
    </VOriginRecord>
  </VORG>
```

