### PR TITLE
Rename charset names in CFF2 table as well

### DIFF
--- a/Lib/ufo2ft/postProcessor.py
+++ b/Lib/ufo2ft/postProcessor.py
@@ -185,8 +185,7 @@ class PostProcessor(object):
             cff.CharStrings.charStrings = {
                 rename_map.get(n, n): v for n, v in char_strings.items()
             }
-            if cff_tag == "CFF ":
-                cff.charset = [rename_map.get(n, n) for n in cff.charset]
+            cff.charset = [rename_map.get(n, n) for n in cff.charset]
 
     def _build_production_names(self):
         seen = {}


### PR DESCRIPTION
The condition was introduced in 563108cb, but it is not clear from the commit message why it was needed. However, I can’t build variable-cff2 fonts with fontmake without this change as saving the font will fail trying to access CharStrings with the old names.