### PR TITLE
Change composite flags "ROUND_XY_TO_GRID" behaviour

### DIFF
--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -1305,7 +1305,7 @@ class OutlineTTFCompiler(BaseOutlineCompiler):
                 logger.error("%r has invalid curve format; skipped", name)
                 ttGlyph = Glyph()
             else:
-                ttGlyph = pen.glyph()
+                ttGlyph = pen.glyph(componentFlags=0x0)
             ttGlyphs[name] = ttGlyph
         return ttGlyphs
 

--- a/tests/data/TestFont-NoOverlaps-TTF-pathops.ttx
+++ b/tests/data/TestFont-NoOverlaps-TTF-pathops.ttx
@@ -307,12 +307,12 @@
     </TTGlyph>
 
     <TTGlyph name="uni0067" xMin="66" yMin="0" xMax="322" yMax="510">
-      <component glyphName="uni0061" x="0" y="0" flags="0x204"/>
+      <component glyphName="uni0061" x="0" y="0" flags="0x200"/>
     </TTGlyph>
 
     <TTGlyph name="uni0068" xMin="100" yMin="-5" xMax="310" yMax="657">
-      <component glyphName="uni0064" x="60" y="460" flags="0x4"/>
-      <component glyphName="uni0062" x="0" y="0" flags="0x204"/>
+      <component glyphName="uni0064" x="60" y="460" flags="0x0"/>
+      <component glyphName="uni0062" x="0" y="0" flags="0x200"/>
     </TTGlyph>
 
     <TTGlyph name="uni0069" xMin="-55" yMin="-80" xMax="454" yMax="510">
@@ -354,13 +354,13 @@
     </TTGlyph>
 
     <TTGlyph name="uni006B" xMin="66" yMin="0" xMax="422" yMax="510">
-      <component glyphName="uni0061" x="0" y="0" flags="0x4"/>
-      <component glyphName="uni0061" x="100" y="0" flags="0x4"/>
+      <component glyphName="uni0061" x="0" y="0" flags="0x0"/>
+      <component glyphName="uni0061" x="100" y="0" flags="0x0"/>
     </TTGlyph>
 
     <TTGlyph name="uni006C" xMin="78" yMin="0" xMax="422" yMax="510">
-      <component glyphName="uni0061" x="400" y="0" scalex="-1.0" scaley="1.0" flags="0x4"/>
-      <component glyphName="uni0061" x="100" y="0" flags="0x4"/>
+      <component glyphName="uni0061" x="400" y="0" scalex="-1.0" scaley="1.0" flags="0x0"/>
+      <component glyphName="uni0061" x="100" y="0" flags="0x0"/>
     </TTGlyph>
 
   </glyf>

--- a/tests/data/TestFont-NoOverlaps-TTF.ttx
+++ b/tests/data/TestFont-NoOverlaps-TTF.ttx
@@ -307,12 +307,12 @@
     </TTGlyph>
 
     <TTGlyph name="uni0067" xMin="66" yMin="0" xMax="322" yMax="510">
-      <component glyphName="uni0061" x="0" y="0" flags="0x204"/>
+      <component glyphName="uni0061" x="0" y="0" flags="0x200"/>
     </TTGlyph>
 
     <TTGlyph name="uni0068" xMin="100" yMin="-5" xMax="310" yMax="657">
-      <component glyphName="uni0064" x="60" y="460" flags="0x4"/>
-      <component glyphName="uni0062" x="0" y="0" flags="0x204"/>
+      <component glyphName="uni0064" x="60" y="460" flags="0x0"/>
+      <component glyphName="uni0062" x="0" y="0" flags="0x200"/>
     </TTGlyph>
 
     <TTGlyph name="uni0069" xMin="-55" yMin="-80" xMax="454" yMax="510">
@@ -354,13 +354,13 @@
     </TTGlyph>
 
     <TTGlyph name="uni006B" xMin="66" yMin="0" xMax="422" yMax="510">
-      <component glyphName="uni0061" x="0" y="0" flags="0x4"/>
-      <component glyphName="uni0061" x="100" y="0" flags="0x4"/>
+      <component glyphName="uni0061" x="0" y="0" flags="0x0"/>
+      <component glyphName="uni0061" x="100" y="0" flags="0x0"/>
     </TTGlyph>
 
     <TTGlyph name="uni006C" xMin="78" yMin="0" xMax="422" yMax="510">
-      <component glyphName="uni0061" x="400" y="0" scalex="-1.0" scaley="1.0" flags="0x4"/>
-      <component glyphName="uni0061" x="100" y="0" flags="0x4"/>
+      <component glyphName="uni0061" x="400" y="0" scalex="-1.0" scaley="1.0" flags="0x0"/>
+      <component glyphName="uni0061" x="100" y="0" flags="0x0"/>
     </TTGlyph>
 
   </glyf>

--- a/tests/data/TestFont-TTF-post3.ttx
+++ b/tests/data/TestFont-TTF-post3.ttx
@@ -301,12 +301,12 @@
     </TTGlyph>
 
     <TTGlyph name="g" xMin="66" yMin="0" xMax="322" yMax="510">
-      <component glyphName="a" x="0" y="0" flags="0x204"/>
+      <component glyphName="a" x="0" y="0" flags="0x200"/>
     </TTGlyph>
 
     <TTGlyph name="h" xMin="100" yMin="-5" xMax="310" yMax="657">
-      <component glyphName="d" x="60" y="460" flags="0x4"/>
-      <component glyphName="b" x="0" y="0" flags="0x204"/>
+      <component glyphName="d" x="60" y="460" flags="0x0"/>
+      <component glyphName="b" x="0" y="0" flags="0x200"/>
     </TTGlyph>
 
     <TTGlyph name="i" xMin="-55" yMin="-80" xMax="454" yMax="510">
@@ -350,13 +350,13 @@
     </TTGlyph>
 
     <TTGlyph name="k" xMin="66" yMin="0" xMax="422" yMax="510">
-      <component glyphName="a" x="0" y="0" flags="0x4"/>
-      <component glyphName="a" x="100" y="0" flags="0x4"/>
+      <component glyphName="a" x="0" y="0" flags="0x0"/>
+      <component glyphName="a" x="100" y="0" flags="0x0"/>
     </TTGlyph>
 
     <TTGlyph name="l" xMin="78" yMin="0" xMax="422" yMax="510">
-      <component glyphName="a" x="400" y="0" scalex="-1.0" scaley="1.0" flags="0x4"/>
-      <component glyphName="a" x="100" y="0" flags="0x4"/>
+      <component glyphName="a" x="400" y="0" scalex="-1.0" scaley="1.0" flags="0x0"/>
+      <component glyphName="a" x="100" y="0" flags="0x0"/>
     </TTGlyph>
 
     <TTGlyph name="space"/><!-- contains no outline data -->

--- a/tests/data/TestFont.ttx
+++ b/tests/data/TestFont.ttx
@@ -303,12 +303,12 @@
     </TTGlyph>
 
     <TTGlyph name="uni0067" xMin="66" yMin="0" xMax="322" yMax="510">
-      <component glyphName="uni0061" x="0" y="0" flags="0x204"/>
+      <component glyphName="uni0061" x="0" y="0" flags="0x200"/>
     </TTGlyph>
 
     <TTGlyph name="uni0068" xMin="100" yMin="-5" xMax="310" yMax="657">
-      <component glyphName="uni0064" x="60" y="460" flags="0x4"/>
-      <component glyphName="uni0062" x="0" y="0" flags="0x204"/>
+      <component glyphName="uni0064" x="60" y="460" flags="0x0"/>
+      <component glyphName="uni0062" x="0" y="0" flags="0x200"/>
     </TTGlyph>
 
     <TTGlyph name="uni0069" xMin="-55" yMin="-80" xMax="454" yMax="510">
@@ -352,13 +352,13 @@
     </TTGlyph>
 
     <TTGlyph name="uni006B" xMin="66" yMin="0" xMax="422" yMax="510">
-      <component glyphName="uni0061" x="0" y="0" flags="0x4"/>
-      <component glyphName="uni0061" x="100" y="0" flags="0x4"/>
+      <component glyphName="uni0061" x="0" y="0" flags="0x0"/>
+      <component glyphName="uni0061" x="100" y="0" flags="0x0"/>
     </TTGlyph>
 
     <TTGlyph name="uni006C" xMin="78" yMin="0" xMax="422" yMax="510">
-      <component glyphName="uni0061" x="400" y="0" scalex="-1.0" scaley="1.0" flags="0x4"/>
-      <component glyphName="uni0061" x="100" y="0" flags="0x4"/>
+      <component glyphName="uni0061" x="400" y="0" scalex="-1.0" scaley="1.0" flags="0x0"/>
+      <component glyphName="uni0061" x="100" y="0" flags="0x0"/>
     </TTGlyph>
 
   </glyf>

--- a/tests/data/TestVariableFont-TTF-useProductionNames.ttx
+++ b/tests/data/TestVariableFont-TTF-useProductionNames.ttx
@@ -240,8 +240,8 @@
     </TTGlyph>
 
     <TTGlyph name="uni0117" xMin="40" yMin="-18" xMax="576" yMax="693">
-      <component glyphName="uni0065" x="0" y="0" flags="0x204"/>
-      <component glyphName="uni0307" x="313" y="96" flags="0x4"/>
+      <component glyphName="uni0065" x="0" y="0" flags="0x200"/>
+      <component glyphName="uni0307" x="313" y="96" flags="0x0"/>
     </TTGlyph>
 
     <TTGlyph name="uni0307" xMin="-37" yMin="501" xMax="50" yMax="597">

--- a/tests/data/TestVariableFont-TTF.ttx
+++ b/tests/data/TestVariableFont-TTF.ttx
@@ -232,8 +232,8 @@
     </TTGlyph>
 
     <TTGlyph name="edotabove" xMin="40" yMin="-18" xMax="576" yMax="693">
-      <component glyphName="e" x="0" y="0" flags="0x204"/>
-      <component glyphName="dotabovecomb" x="313" y="96" flags="0x4"/>
+      <component glyphName="e" x="0" y="0" flags="0x200"/>
+      <component glyphName="dotabovecomb" x="313" y="96" flags="0x0"/>
     </TTGlyph>
 
     <TTGlyph name="s" xMin="25" yMin="-13" xMax="582" yMax="530">


### PR DESCRIPTION
I think the [ROUND_XY_TO_GRID](https://docs.microsoft.com/de-de/typography/opentype/spec/glyf#composite-glyph-description) flag should not be set by default on any component. It is the hinting tool's job to decide whether to set it.

E.g. I have a font where hinting makes no sense: [homecomputer-fonts](https://github.com/jenskutilek/homecomputer-fonts). The fonts are completely built of "pixel components", thus I don't want any components to be rounded to the grid, because it would look worse than leaving the font completely unhinted and unrounded. So I need to [unset this flag in post-production](https://github.com/jenskutilek/homecomputer-fonts/blob/master/scripts/fix_varfont.py#L24).