### PR TITLE
Attempt to fix #432 regression introduced with 2.18.0 

### DIFF
--- a/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
@@ -157,6 +157,7 @@ class BaseFeatureWriter(object):
             font,
             skipExportGlyphs=set(font.lib.get("public.skipExportGlyphs", [])),
         )
+        glyphOrder = [g for g in glyphOrder if g in glyphSet.keys()]
         return OrderedDict((gn, glyphSet[gn]) for gn in glyphOrder)
 
     def compileGSUB(self):


### PR DESCRIPTION
Maybe as simple as that, filter the glyphOrder against the exporting glyphs retrieved from `glyphSet`