### PR TITLE
WIP: Add "scaleUPM" filter

### DIFF
--- a/Lib/ufo2ft/filters/scaleUPM.py
+++ b/Lib/ufo2ft/filters/scaleUPM.py
@@ -1,0 +1,146 @@
+from ufo2ft.filters import BaseFilter
+
+
+class ScaleUPMFilter(BaseFilter):
+
+    """ This filter scales the font to a new upm value. Set the target upm in
+    an UFO like this:
+    <key>com.github.googlei18n.ufo2ft.filters</key>
+    <array>
+        <dict>
+            <key>name</key>
+            <string>scaleUPM</string>
+            <key>kwargs</key>
+            <dict>
+                <key>unitsPerEm</key>
+                <string>2048</string>
+            </dict>
+        </dict>
+    </array>
+    """
+
+    _kwargs = {
+        "unitsPerEm": 1000,
+    }
+
+    def _scaleGlyph(self, glyph):
+        """
+        Scale a glyph
+        """
+        for contour in glyph:
+            for point in contour.points:
+                point.x *= self.factor
+                point.y *= self.factor
+
+        for anchor in glyph.anchors:
+            anchor.x *= self.factor
+            anchor.y *= self.factor
+
+        glyph.width *= self.factor
+
+    def _scaleList(self, obj, name):
+        """
+        Scale a font info property that is a list, i.e. scale each value.
+        """
+        lst = getattr(obj, name)
+        if lst is None:
+            return
+
+        lst = [self.factor * v for v in lst]
+        setattr(obj, name, lst)
+
+    def _scaleProperty(self, obj, name):
+        prop = getattr(obj, name)
+        if prop is None:
+            return
+
+        setattr(obj, name, self.factor * prop)
+
+    def __call__(self, font, glyphSet=None):
+        newUnitsPerEm = int(self.options.unitsPerEm)
+        if font.info.unitsPerEm == newUnitsPerEm:
+            return False
+
+        self.factor = newUnitsPerEm / font.info.unitsPerEm
+
+        # Scale glyphs
+        super(ScaleUPMFilter, self).__call__(font, glyphSet)
+
+        # Scale kerning
+        for pair, value in font.kerning.items():
+            font.kerning[pair] = value * self.factor
+
+        # TODO: Change positioning feature code
+
+        # Scale info values
+        for prop in (
+            "descender",
+            "xHeight",
+            "capHeight",
+            "ascender",
+            "openTypeHheaAscender",
+            "openTypeHheaDescender",
+            "openTypeHheaLineGap",
+            "openTypeHheaCaretOffset",
+            "openTypeOS2TypoAscender",
+            "openTypeOS2TypoDescender",
+            "openTypeOS2TypoLineGap",
+            "openTypeOS2WinAscent",
+            "openTypeOS2WinDescent",
+            "openTypeOS2SubscriptXSize",
+            "openTypeOS2SubscriptYSize",
+            "openTypeOS2SubscriptXOffset",
+            "openTypeOS2SubscriptYOffset",
+            "openTypeOS2SuperscriptXSize",
+            "openTypeOS2SuperscriptYSize",
+            "openTypeOS2SuperscriptXOffset",
+            "openTypeOS2SuperscriptYOffset",
+            "openTypeOS2StrikeoutSize",
+            "openTypeOS2StrikeoutPosition",
+            "openTypeVheaVertTypoAscender",
+            "openTypeVheaVertTypoDescender",
+            "openTypeVheaVertTypoLineGap",
+            "openTypeVheaCaretOffset",
+            "postscriptUnderlineThickness",
+            "postscriptUnderlinePosition",
+        ):
+            self._scaleProperty(font.info, prop)
+
+        for prop in (
+            "postscriptBlueValues",
+            "postscriptOtherBlues",
+            "postscriptFamilyOtherBlues",
+            "postscriptStemSnapH",
+            "postscriptStemSnapV",
+            "postscriptBlueFuzz",
+            "postscriptBlueShift",
+            "postscriptBlueScale",
+            "postscriptDefaultWidthX",
+            "postscriptNominalWidthX",
+        ):
+            self._scaleList(font.info, prop)
+
+        # Finally set new UPM
+        font.info.unitsPerEm = newUnitsPerEm
+
+        return True
+
+    def filter(self, glyph):
+        if getattr(self.context, "skipCurrentFont", False):
+            return False
+
+        # Scale glyph
+        self._scaleGlyph(glyph)
+
+        # scale component offsets
+        for i in range(len(glyph.components)):
+            comp = glyph.components[i]
+            xS, xyS, yxS, yS, xOff, yOff = comp.transformation
+            comp.transformation = (
+                xS,
+                xyS,
+                yxS,
+                yS,
+                xOff * self.factor,
+                yOff * self.factor,
+            )

--- a/tests/data/UnitsPerEmTest.ufo/features.fea
+++ b/tests/data/UnitsPerEmTest.ufo/features.fea
@@ -1,0 +1,7 @@
+# automatic
+@Uppercase = [ A O ];
+
+feature cpsp {
+pos @Uppercase <10 0 20 0>;
+} cpsp;
+

--- a/tests/data/UnitsPerEmTest.ufo/fontinfo.plist
+++ b/tests/data/UnitsPerEmTest.ufo/fontinfo.plist
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>ascender</key>
+	<integer>800</integer>
+	<key>capHeight</key>
+	<integer>720</integer>
+	<key>descender</key>
+	<integer>-160</integer>
+	<key>openTypeHeadCreated</key>
+	<string>2020/12/01 11:22:55</string>
+	<key>openTypeHheaAscender</key>
+	<integer>800</integer>
+	<key>openTypeHheaDescender</key>
+	<integer>-160</integer>
+	<key>openTypeHheaLineGap</key>
+	<integer>240</integer>
+	<key>openTypeOS2TypoAscender</key>
+	<integer>800</integer>
+	<key>openTypeOS2TypoDescender</key>
+	<integer>-160</integer>
+	<key>openTypeOS2TypoLineGap</key>
+	<integer>240</integer>
+	<key>openTypeOS2WinAscent</key>
+	<integer>800</integer>
+	<key>openTypeOS2WinDescent</key>
+	<integer>200</integer>
+	<key>postscriptBlueValues</key>
+	<array>
+		<real>-14.0</real>
+		<real>0.0</real>
+		<real>560.0</real>
+		<real>574.0</real>
+		<real>720.0</real>
+		<real>734.0</real>
+		<real>800.0</real>
+		<real>814.0</real>
+	</array>
+	<key>postscriptOtherBlues</key>
+	<array>
+		<real>-176.0</real>
+		<real>-160.0</real>
+	</array>
+	<key>postscriptStemSnapH</key>
+	<array>
+		<real>70.0</real>
+	</array>
+	<key>postscriptStemSnapV</key>
+	<array>
+		<real>80.0</real>
+	</array>
+	<key>styleName</key>
+	<string>Regular</string>
+	<key>unitsPerEm</key>
+	<integer>1000</integer>
+	<key>versionMajor</key>
+	<integer>2</integer>
+	<key>versionMinor</key>
+	<integer>0</integer>
+	<key>xHeight</key>
+	<integer>560</integer>
+</dict>
+</plist>

--- a/tests/data/UnitsPerEmTest.ufo/glyphs.public.background/A_.glif
+++ b/tests/data/UnitsPerEmTest.ufo/glyphs.public.background/A_.glif
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="A" format="2">
+	<advance width="560"/>
+	<outline>
+		<contour>
+			<point x="80" y="0" type="line"/>
+			<point x="160" y="0" type="line"/>
+			<point x="160" y="240" type="line"/>
+			<point x="400" y="240" type="line"/>
+			<point x="400" y="0" type="line"/>
+			<point x="480" y="0" type="line"/>
+			<point x="480" y="640" type="line"/>
+			<point x="400" y="640" type="line"/>
+			<point x="400" y="320" type="line"/>
+			<point x="160" y="320" type="line"/>
+			<point x="160" y="640" type="line"/>
+			<point x="80" y="640" type="line"/>
+		</contour>
+		<contour>
+			<point x="160" y="640" type="line"/>
+			<point x="400" y="640" type="line"/>
+			<point x="400" y="720" type="line"/>
+			<point x="160" y="720" type="line"/>
+		</contour>
+	</outline>
+</glyph>

--- a/tests/data/UnitsPerEmTest.ufo/glyphs.public.background/contents.plist
+++ b/tests/data/UnitsPerEmTest.ufo/glyphs.public.background/contents.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>A</key>
+	<string>A_.glif</string>
+</dict>
+</plist>

--- a/tests/data/UnitsPerEmTest.ufo/glyphs/A_.glif
+++ b/tests/data/UnitsPerEmTest.ufo/glyphs/A_.glif
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="A" format="2">
+	<advance width="560"/>
+	<unicode hex="0041"/>
+	<anchor x="522" y="0" name="ogonek"/>
+	<anchor x="280" y="0" name="bottom"/>
+	<anchor x="280" y="720" name="top"/>
+	<outline>
+		<contour>
+			<point x="294" y="650" type="line"/>
+			<point x="266" y="650" type="line"/>
+			<point x="433" y="0" type="line"/>
+			<point x="522" y="0" type="line"/>
+			<point x="323" y="720" type="line"/>
+			<point x="240" y="720" type="line"/>
+			<point x="37" y="0" type="line"/>
+			<point x="117" y="0" type="line"/>
+		</contour>
+		<contour>
+			<point x="160" y="276" type="line"/>
+			<point x="160" y="204" type="line"/>
+			<point x="400" y="204" type="line"/>
+			<point x="400" y="276" type="line"/>
+		</contour>
+	</outline>
+</glyph>

--- a/tests/data/UnitsPerEmTest.ufo/glyphs/O_.glif
+++ b/tests/data/UnitsPerEmTest.ufo/glyphs/O_.glif
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="O" format="2">
+	<advance width="560"/>
+	<unicode hex="004F"/>
+	<anchor x="280" y="360" name="center"/>
+	<anchor x="342" y="0" name="ogonek"/>
+	<anchor x="280" y="720" name="top"/>
+	<anchor x="540" y="720" name="topright"/>
+	<anchor x="20" y="720" name="topleft"/>
+	<anchor x="280" y="0" name="bottom"/>
+	<outline>
+		<contour>
+			<point x="280" y="-10" type="curve" smooth="yes"/>
+			<point x="415" y="-10"/>
+			<point x="506" y="113"/>
+			<point x="506" y="360" type="curve" smooth="yes"/>
+			<point x="506" y="599"/>
+			<point x="441" y="730"/>
+			<point x="280" y="730" type="curve" smooth="yes"/>
+			<point x="133" y="730"/>
+			<point x="54" y="603"/>
+			<point x="54" y="360" type="curve" smooth="yes"/>
+			<point x="54" y="104"/>
+			<point x="133" y="-10"/>
+		</contour>
+		<contour>
+			<point x="280" y="60" type="curve" smooth="yes"/>
+			<point x="191" y="60"/>
+			<point x="138" y="137"/>
+			<point x="138" y="360" type="curve" smooth="yes"/>
+			<point x="138" y="584"/>
+			<point x="182" y="660"/>
+			<point x="280" y="660" type="curve" smooth="yes"/>
+			<point x="379" y="660"/>
+			<point x="422" y="579"/>
+			<point x="422" y="360" type="curve" smooth="yes"/>
+			<point x="422" y="138"/>
+			<point x="371" y="60"/>
+		</contour>
+	</outline>
+</glyph>

--- a/tests/data/UnitsPerEmTest.ufo/glyphs/contents.plist
+++ b/tests/data/UnitsPerEmTest.ufo/glyphs/contents.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>A</key>
+	<string>A_.glif</string>
+	<key>O</key>
+	<string>O_.glif</string>
+</dict>
+</plist>

--- a/tests/data/UnitsPerEmTest.ufo/kerning.plist
+++ b/tests/data/UnitsPerEmTest.ufo/kerning.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>A</key>
+	<dict>
+		<key>O</key>
+		<integer>-25</integer>
+	</dict>
+	<key>O</key>
+	<dict>
+		<key>A</key>
+		<integer>-25</integer>
+	</dict>
+</dict>
+</plist>

--- a/tests/data/UnitsPerEmTest.ufo/layercontents.plist
+++ b/tests/data/UnitsPerEmTest.ufo/layercontents.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<array>
+		<string>public.default</string>
+		<string>glyphs</string>
+	</array>
+	<array>
+		<string>public.background</string>
+		<string>glyphs.public.background</string>
+	</array>
+</array>
+</plist>

--- a/tests/data/UnitsPerEmTest.ufo/lib.plist
+++ b/tests/data/UnitsPerEmTest.ufo/lib.plist
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.github.googlei18n.ufo2ft.filters</key>
+	<array>
+		<dict>
+			<key>name</key>
+			<string>scaleUPM</string>
+			<key>kwargs</key>
+			<dict>
+				<key>unitsPerEm</key>
+				<string>2048</string>
+			</dict>
+		</dict>
+	</array>
+	<key>com.schriftgestaltung.disablesAutomaticAlignment</key>
+	<false/>
+	<key>com.schriftgestaltung.fontMaster.customParameters</key>
+	<array>
+		<dict>
+			<key>name</key>
+			<string>Default Layer Width</string>
+			<key>value</key>
+			<string>560</string>
+		</dict>
+	</array>
+	<key>com.schriftgestaltung.fontMasterID</key>
+	<string>83692D61-586C-413E-9B5A-1AF652750951</string>
+	<key>com.schriftgestaltung.glyphOrder</key>
+	<false/>
+	<key>com.schriftgestaltung.gridSize</key>
+	<integer>80</integer>
+	<key>com.schriftgestaltung.gridSubDivision</key>
+	<integer>80</integer>
+	<key>com.schriftgestaltung.useNiceNames</key>
+	<true/>
+	<key>com.schriftgestaltung.weightValue</key>
+	<integer>100</integer>
+	<key>public.glyphOrder</key>
+	<array>
+		<string>A</string>
+		<string>O</string>
+	</array>
+</dict>
+</plist>

--- a/tests/data/UnitsPerEmTest.ufo/metainfo.plist
+++ b/tests/data/UnitsPerEmTest.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>creator</key>
+	<string>com.schriftgestaltung.GlyphsUFOExport</string>
+	<key>formatVersion</key>
+	<integer>3</integer>
+</dict>
+</plist>


### PR DESCRIPTION
This filter scales the font to a target upm value. Set the target upm in an UFO like this:
```xml
    <key>com.github.googlei18n.ufo2ft.filters</key>
    <array>
        <dict>
            <key>name</key>
            <string>scaleUPM</string>
            <key>kwargs</key>
            <dict>
                <key>unitsPerEm</key>
                <string>2048</string>
            </dict>
        </dict>
    </array>
```

Scaling values in feature code is not supported yet.