### PR TITLE
Flatten components: handle contour+component glyphs in nested components

### DIFF
--- a/Lib/ufo2ft/filters/flattenComponents.py
+++ b/Lib/ufo2ft/filters/flattenComponents.py
@@ -36,7 +36,8 @@ def _flattenComponent(glyphSet, component):
     """Returns a list of tuples (baseGlyph, transform) of nested component."""
 
     glyph = glyphSet[component.baseGlyph]
-    if not glyph.components:
+    # Any contour will cause components to be decomposed
+    if not glyph.components or len(glyph) > 0:
         transformation = Transform(*component.transformation)
         return [(component.baseGlyph, transformation)]
 

--- a/tests/filters/flattenComponents_test.py
+++ b/tests/filters/flattenComponents_test.py
@@ -44,6 +44,38 @@ from ufo2ft.filters.flattenComponents import FlattenComponentsFilter, logger
                         ),
                     ],
                 },
+                {
+                    "name": "contourAndComponentGlyph",
+                    "width": 600,
+                    "outline": [
+                        ("moveTo", ((400, 0),)),
+                        ("lineTo", ((400, 100),)),
+                        ("lineTo", ((500, 100),)),
+                        ("lineTo", ((500, 0),)),
+                        ("closePath", ()),
+                        ("addComponent", ("contourGlyph", (1, 0, 0, 1, 0, 0))),
+                    ],
+                },
+                {
+                    "name": "nestedContourAndComponentGlyph",
+                    "width": 600,
+                    "outline": [
+                        (
+                            "addComponent",
+                            ("contourAndComponentGlyph", (1, 0, 0, 1, 50, 0)),
+                        ),
+                    ],
+                },
+                {
+                    "name": "nestedNestedContourAndComponentGlyph",
+                    "width": 600,
+                    "outline": [
+                        (
+                            "addComponent",
+                            ("nestedContourAndComponentGlyph", (1, 0, 0, 1, 45, 0)),
+                        ),
+                    ],
+                },
             ]
         }
     ]
@@ -81,12 +113,27 @@ class FlattenComponentsFilterTest:
             for c in font["nestedComponentGlyph"].components
         ] == [("contourGlyph", (1, 0, 0, 1, 0, 0))]
 
+    def test_nested_contour_and_component_glyph(self, font):
+        philter = FlattenComponentsFilter(
+            include={
+                "nestedContourAndComponentGlyph",
+                "nestedNestedContourAndComponentGlyph",
+            }
+        )
+        modified = philter(font)
+        assert modified == {"nestedNestedContourAndComponentGlyph"}
+        assert [
+            (c.baseGlyph, c.transformation)
+            for c in font["nestedNestedContourAndComponentGlyph"].components
+        ] == [("contourAndComponentGlyph", (1, 0, 0, 1, 95, 0))]
+
     def test_whole_font(self, font):
         philter = FlattenComponentsFilter()
         modified = philter(font)
         assert modified == {
             "nestedComponentGlyph",
             "componentAndNestedComponentsGlyph",
+            "nestedNestedContourAndComponentGlyph",
         }
         assert [
             (c.baseGlyph, c.transformation)
@@ -100,9 +147,19 @@ class FlattenComponentsFilterTest:
             ("contourGlyph", (1, 0, 0, 1, 350, 0)),
             ("contourGlyph", (1, 0, 0, 1, 700, 0)),
         ]
+        assert [
+            (c.baseGlyph, c.transformation)
+            for c in font["nestedContourAndComponentGlyph"].components
+        ] == [
+            ("contourAndComponentGlyph", (1, 0, 0, 1, 50, 0)),
+        ]
+        assert [
+            (c.baseGlyph, c.transformation)
+            for c in font["nestedNestedContourAndComponentGlyph"].components
+        ] == [("contourAndComponentGlyph", (1, 0, 0, 1, 95, 0))]
 
     def test_logger(self, font):
         with CapturingLogHandler(logger, level="INFO") as captor:
             philter = FlattenComponentsFilter()
             _ = philter(font)
-        captor.assertRegex("Flattened composite glyphs: 2")
+        captor.assertRegex("Flattened composite glyphs: 3")


### PR DESCRIPTION
At the moment FlattenComponentsFilter breaks glyphs that mix contours and components when used as nested component in other glyphs.
Only the components as copied when flattening and the contours are not carried over.
However since the target is TTF which doesn't handle mixing contours and components, FlattenComponentsFilter should just leave the nested component glyphs that use mixed glyphs