### PR TITLE
Flatten components: handle transformed (scaled) components

### DIFF
--- a/Lib/ufo2ft/filters/flattenComponents.py
+++ b/Lib/ufo2ft/filters/flattenComponents.py
@@ -44,8 +44,10 @@ def _flattenComponent(glyphSet, component):
     all_flattened_components = []
     for nested in glyph.components:
         flattened_components = _flattenComponent(glyphSet, nested)
-        for i, (_, tr) in enumerate(flattened_components):
-            tr = tr.transform(component.transformation)
-            flattened_components[i] = (flattened_components[i][0], tr)
+        for i, (name, tr) in enumerate(flattened_components):
+            flat_tr = Transform(*component.transformation)
+            flat_tr = flat_tr.translate(tr.dx, tr.dy)
+            flat_tr = flat_tr.transform((tr.xx, tr.xy, tr.yx, tr.yy, 0, 0))
+            flattened_components[i] = (name, flat_tr)
         all_flattened_components.extend(flattened_components)
     return all_flattened_components

--- a/tests/filters/flattenComponents_test.py
+++ b/tests/filters/flattenComponents_test.py
@@ -76,6 +76,36 @@ from ufo2ft.filters.flattenComponents import FlattenComponentsFilter, logger
                         ),
                     ],
                 },
+                {
+                    "name": "scaledComponentGlyph",
+                    "width": 600,
+                    "outline": [
+                        (
+                            "addComponent",
+                            ("contourGlyph", (0.5, 0, 0, 0.5, 50, 50)),
+                        ),
+                    ],
+                },
+                {
+                    "name": "nestedScaledComponentGlyph",
+                    "width": 600,
+                    "outline": [
+                        (
+                            "addComponent",
+                            ("scaledComponentGlyph", (1, 0, 0, 1, 40, 40)),
+                        ),
+                    ],
+                },
+                {
+                    "name": "scaledNestedComponentGlyph",
+                    "width": 600,
+                    "outline": [
+                        (
+                            "addComponent",
+                            ("scaledComponentGlyph", (1.2, 0, 0, 1.2, 40, 40)),
+                        ),
+                    ],
+                },
             ]
         }
     ]
@@ -127,6 +157,28 @@ class FlattenComponentsFilterTest:
             for c in font["nestedNestedContourAndComponentGlyph"].components
         ] == [("contourAndComponentGlyph", (1, 0, 0, 1, 95, 0))]
 
+    def test_scaled_component_glyph(self, font):
+        philter = FlattenComponentsFilter(
+            include={
+                "scaledComponentGlyph",
+                "nestedScaledComponentGlyph",
+                "scaledNestedComponentGlyph",
+            }
+        )
+        modified = philter(font)
+        assert modified == {
+            "nestedScaledComponentGlyph",
+            "scaledNestedComponentGlyph",
+        }
+        assert [
+            (c.baseGlyph, c.transformation)
+            for c in font["nestedScaledComponentGlyph"].components
+        ] == [("contourGlyph", (0.5, 0, 0, 0.5, 90, 90))]
+        assert [
+            (c.baseGlyph, c.transformation)
+            for c in font["scaledNestedComponentGlyph"].components
+        ] == [("contourGlyph", (0.6, 0, 0, 0.6, 100, 100))]
+
     def test_whole_font(self, font):
         philter = FlattenComponentsFilter()
         modified = philter(font)
@@ -134,6 +186,8 @@ class FlattenComponentsFilterTest:
             "nestedComponentGlyph",
             "componentAndNestedComponentsGlyph",
             "nestedNestedContourAndComponentGlyph",
+            "nestedScaledComponentGlyph",
+            "scaledNestedComponentGlyph",
         }
         assert [
             (c.baseGlyph, c.transformation)
@@ -157,9 +211,17 @@ class FlattenComponentsFilterTest:
             (c.baseGlyph, c.transformation)
             for c in font["nestedNestedContourAndComponentGlyph"].components
         ] == [("contourAndComponentGlyph", (1, 0, 0, 1, 95, 0))]
+        assert [
+            (c.baseGlyph, c.transformation)
+            for c in font["nestedScaledComponentGlyph"].components
+        ] == [("contourGlyph", (0.5, 0, 0, 0.5, 90, 90))]
+        assert [
+            (c.baseGlyph, c.transformation)
+            for c in font["scaledNestedComponentGlyph"].components
+        ] == [("contourGlyph", (0.6, 0, 0, 0.6, 100, 100))]
 
     def test_logger(self, font):
         with CapturingLogHandler(logger, level="INFO") as captor:
             philter = FlattenComponentsFilter()
             _ = philter(font)
-        captor.assertRegex("Flattened composite glyphs: 3")
+        captor.assertRegex("Flattened composite glyphs: 5")


### PR DESCRIPTION
Fixes #442 [Flattening components does not handle transformed components well](https://github.com/googlefonts/ufo2ft/issues/442).