### PR TITLE
Propagate anchors to marks, not just ligature of marks

### DIFF
--- a/Lib/ufo2ft/filters/propagateAnchors.py
+++ b/Lib/ufo2ft/filters/propagateAnchors.py
@@ -76,21 +76,27 @@ def _propagate_glyph_anchors(glyphSet, composite, processed):
                 base_components.append(component)
                 anchor_names |= {a.name for a in glyph.anchors}
 
-    if mark_components and not base_components and _is_ligature_mark(composite):
-        # The composite is a mark that is composed of other marks (E.g.
-        # "circumflexcomb_tildecomb"). Promote the mark that is positioned closest
-        # to the origin to a base.
-        try:
-            component = _component_closest_to_origin(mark_components, glyphSet)
-        except Exception as e:
-            raise Exception(
-                "Error while determining which component of composite "
-                "'{}' is the lowest: {}".format(composite.name, str(e))
-            )
-        mark_components.remove(component)
-        base_components.append(component)
-        glyph = glyphSet[component.baseGlyph]
-        anchor_names |= {a.name for a in glyph.anchors}
+    if mark_components and not base_components:
+        if _is_ligature_mark(composite):
+            # The composite is a mark that is composed of other marks (E.g.
+            # "circumflexcomb_tildecomb"). Promote the mark that is positioned closest
+            # to the origin to a base.
+            try:
+                component = _component_closest_to_origin(mark_components, glyphSet)
+            except Exception as e:
+                raise Exception(
+                    "Error while determining which component of composite "
+                    "'{}' is the lowest: {}".format(composite.name, str(e))
+                )
+            components = [component]
+        else:
+            components = mark_components
+
+        for component in components:
+            mark_components.remove(component)
+            base_components.append(component)
+            glyph = glyphSet[component.baseGlyph]
+            anchor_names |= {a.name for a in glyph.anchors}
 
     for anchor_name in anchor_names:
         # don't add if composite glyph already contains this anchor OR any

--- a/Lib/ufo2ft/filters/propagateAnchors.py
+++ b/Lib/ufo2ft/filters/propagateAnchors.py
@@ -74,7 +74,7 @@ def _propagate_glyph_anchors(glyphSet, composite, processed):
                 mark_components.append(component)
             else:
                 base_components.append(component)
-                anchor_names |= {a.name for a in glyph.anchors}
+                anchor_names.update(a.name for a in glyph.anchors)
 
     if mark_components and not base_components:
         if _is_ligature_mark(composite):
@@ -96,7 +96,7 @@ def _propagate_glyph_anchors(glyphSet, composite, processed):
             mark_components.remove(component)
             base_components.append(component)
             glyph = glyphSet[component.baseGlyph]
-            anchor_names |= {a.name for a in glyph.anchors}
+            anchor_names.update(a.name for a in glyph.anchors)
 
     for anchor_name in anchor_names:
         # don't add if composite glyph already contains this anchor OR any

--- a/Lib/ufo2ft/filters/propagateAnchors.py
+++ b/Lib/ufo2ft/filters/propagateAnchors.py
@@ -101,7 +101,10 @@ def _propagate_glyph_anchors(glyphSet, composite, processed):
     for anchor_name in anchor_names:
         # don't add if composite glyph already contains this anchor OR any
         # associated ligature anchors (e.g. "top_1, top_2" for "top")
-        if not any(a.name.startswith(anchor_name) for a in composite.anchors):
+        if not any(
+            a.name == anchor_name or a.name.split("_")[0] == (anchor_name)
+            for a in composite.anchors
+        ):
             _get_anchor_data(to_add, glyphSet, base_components, anchor_name)
 
     for component in mark_components:

--- a/tests/filters/propagateAnchors_test.py
+++ b/tests/filters/propagateAnchors_test.py
@@ -106,6 +106,14 @@ from ufo2ft.filters.propagateAnchors import PropagateAnchorsFilter, logger
                         ("addComponent", ("macroncomb", (1, 0, 0, 1, 175, 0))),
                     ],
                 },
+                {
+                    "name": "macroncomb.alt",
+                    "width": 0,
+                    "outline": [
+                        ("addComponent", ("macroncomb", (1, 0, 0, 1, 0, -30))),
+                    ],
+                    "anchors": [(0, 340, "_top")],
+                },
             ]
         }
     ]
@@ -187,6 +195,15 @@ class PropagateAnchorsFilterTest:
             ("top_2", 525, 300),
         ]
 
+    def test_mark_glyph(self, font):
+        name = "macroncomb.alt"
+        philter = PropagateAnchorsFilter(include={name})
+        assert philter(font) == {name}
+        assert [(a.name, a.x, a.y) for a in font[name].anchors] == [
+            ("_top", 0, 340),
+            ("top", 0, 450),
+        ]
+
     def test_whole_font(self, font):
         philter = PropagateAnchorsFilter()
         modified = philter(font)
@@ -197,6 +214,8 @@ class PropagateAnchorsFilterTest:
             "adieresismacron",
             "amacrondieresis",
             "a_a",
+            "emacron",
+            "macroncomb.alt",
         }
 
     def test_fail_during_anchor_propagation(self, font):
@@ -212,7 +231,7 @@ class PropagateAnchorsFilterTest:
         with CapturingLogHandler(logger, level="INFO") as captor:
             philter = PropagateAnchorsFilter()
             philter(font)
-        captor.assertRegex("Glyphs with propagated anchors: 6")
+        captor.assertRegex("Glyphs with propagated anchors: 8")
 
 
 def test_CantarellAnchorPropagation(FontClass, datadir):

--- a/tests/filters/propagateAnchors_test.py
+++ b/tests/filters/propagateAnchors_test.py
@@ -114,6 +114,36 @@ from ufo2ft.filters.propagateAnchors import PropagateAnchorsFilter, logger
                     ],
                     "anchors": [(0, 340, "_top")],
                 },
+                {
+                    "name": "o",
+                    "width": 350,
+                    "outline": [
+                        ("moveTo", ((20, 0),)),
+                        ("lineTo", ((330, 0),)),
+                        ("lineTo", ((330, 330),)),
+                        ("lineTo", ((20, 330),)),
+                        ("closePath", ()),
+                        ("moveTo", ((40, 20),)),
+                        ("lineTo", ((310, 0),)),
+                        ("lineTo", ((310, 310),)),
+                        ("lineTo", ((40, 310),)),
+                        ("closePath", ()),
+                    ],
+                    "anchors": [(175, 340, "top"), (175, 0, "bottom")],
+                },
+                {
+                    "name": "ohorn",
+                    "width": 350,
+                    "outline": [
+                        ("moveTo", ((310, 310),)),
+                        ("lineTo", ((345, 310),)),
+                        ("lineTo", ((345, 345),)),
+                        ("lineTo", ((345, 345),)),
+                        ("closePath", ()),
+                        ("addComponent", ("o", (1, 0, 0, 1, 0, 0))),
+                    ],
+                    "anchors": [(345, 340, "topright")],
+                },
             ]
         }
     ]
@@ -184,6 +214,16 @@ class PropagateAnchorsFilterTest:
             ("top", 175, 660),
         ]
 
+    def test_similar_anchor_name(self, font):
+        name = "ohorn"
+        philter = PropagateAnchorsFilter(include={name})
+        assert philter(font) == {name}
+        assert [(a.name, a.x, a.y) for a in font[name].anchors] == [
+            ("topright", 345, 340),
+            ("bottom", 175, 0),
+            ("top", 175, 340),
+        ]
+
     def test_ligature_glyph(self, font):
         name = "a_a"
         philter = PropagateAnchorsFilter(include={name})
@@ -216,6 +256,7 @@ class PropagateAnchorsFilterTest:
             "a_a",
             "emacron",
             "macroncomb.alt",
+            "ohorn",
         }
 
     def test_fail_during_anchor_propagation(self, font):
@@ -231,7 +272,7 @@ class PropagateAnchorsFilterTest:
         with CapturingLogHandler(logger, level="INFO") as captor:
             philter = PropagateAnchorsFilter()
             philter(font)
-        captor.assertRegex("Glyphs with propagated anchors: 8")
+        captor.assertRegex("Glyphs with propagated anchors: 9")
 
 
 def test_CantarellAnchorPropagation(FontClass, datadir):


### PR DESCRIPTION
The PropagateAnchorFilter only propagate anchors to ligature of marks (for example circumflexcomb_macroncomb).
With this change, the anchors are also propagate to other composites of marks (for example macroncomb.alt).

Glyphs.app (2 and 3) propagate anchors to composite of marks, not just ligatures of marks.