### PR TITLE
Add insertFeatureMarker to BaseFeatureWriter 

### DIFF
--- a/Lib/ufo2ft/errors.py
+++ b/Lib/ufo2ft/errors.py
@@ -10,6 +10,12 @@ class InvalidFontData(Error):
     pass
 
 
+class InvalidFeaturesData(Error):
+    """Raised when input font contains invalid features data."""
+
+    pass
+
+
 class InvalidDesignSpaceData(Error):
     """Raised when input DesignSpace document contains invalid data."""
 

--- a/Lib/ufo2ft/featureWriters/ast.py
+++ b/Lib/ufo2ft/featureWriters/ast.py
@@ -50,12 +50,16 @@ def findFeatureTags(feaFile):
 
 
 def findCommentPattern(feaFile, pattern):
+    """
+    Return the parent and the comment matching a given pattern.
+    Parent is either None or a block.
+    """
     for statement in feaFile.statements:
         if isinstance(statement, ast.Comment):
             if re.match(pattern, str(statement)):
-                yield statement
+                yield (None, statement)
         elif hasattr(statement, "statements"):
-            for s in findCommentPattern(statement, pattern):
+            for _, s in findCommentPattern(statement, pattern):
                 yield (statement, s)
 
 

--- a/Lib/ufo2ft/featureWriters/ast.py
+++ b/Lib/ufo2ft/featureWriters/ast.py
@@ -51,7 +51,9 @@ def findFeatureTags(feaFile):
 
 def findCommentPattern(feaFile, pattern):
     """
-    Return a tuple with the block (or nested blocks) and the comment matching a given pattern.
+    Yield a tuple of statements, starting with the parent block, followed by
+    nested blocks if present, ending with the comment matching a given pattern.
+    There is not parent block if the matched comment is a the root level.
     """
     for statement in feaFile.statements:
         if hasattr(statement, "statements"):

--- a/Lib/ufo2ft/featureWriters/ast.py
+++ b/Lib/ufo2ft/featureWriters/ast.py
@@ -49,6 +49,22 @@ def findFeatureTags(feaFile):
     return {f.name for f in iterFeatureBlocks(feaFile)}
 
 
+def findCommentPattern(feaFile, pattern):
+    for statement in feaFile.statements:
+        if isinstance(statement, ast.Comment):
+            if re.match(pattern, str(statement)):
+                yield statement
+        elif hasattr(statement, "statements"):
+            for s in findCommentPattern(statement, pattern):
+                yield (statement, s)
+
+
+def iterMarkClassDefinitions(feaFile):
+    for s in feaFile.statements:
+        if isinstance(s, ast.MarkClassDefinition):
+            yield s
+
+
 def iterClassDefinitions(feaFile, featureTag=None):
     if featureTag is None:
         # start from top-level class definitions

--- a/Lib/ufo2ft/featureWriters/ast.py
+++ b/Lib/ufo2ft/featureWriters/ast.py
@@ -51,16 +51,15 @@ def findFeatureTags(feaFile):
 
 def findCommentPattern(feaFile, pattern):
     """
-    Return the parent and the comment matching a given pattern.
-    Parent is either None or a block.
+    Return a tuple with the block (or nested blocks) and the comment matching a given pattern.
     """
     for statement in feaFile.statements:
-        if isinstance(statement, ast.Comment):
+        if hasattr(statement, "statements"):
+            for res in findCommentPattern(statement, pattern):
+                yield (statement, *res)
+        elif isinstance(statement, ast.Comment):
             if re.match(pattern, str(statement)):
-                yield (None, statement)
-        elif hasattr(statement, "statements"):
-            for _, s in findCommentPattern(statement, pattern):
-                yield (statement, s)
+                yield (statement,)
 
 
 def iterClassDefinitions(feaFile, featureTag=None):

--- a/Lib/ufo2ft/featureWriters/ast.py
+++ b/Lib/ufo2ft/featureWriters/ast.py
@@ -63,12 +63,6 @@ def findCommentPattern(feaFile, pattern):
                 yield (statement, s)
 
 
-def iterMarkClassDefinitions(feaFile):
-    for s in feaFile.statements:
-        if isinstance(s, ast.MarkClassDefinition):
-            yield s
-
-
 def iterClassDefinitions(feaFile, featureTag=None):
     if featureTag is None:
         # start from top-level class definitions

--- a/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
@@ -2,8 +2,8 @@ import logging
 from collections import OrderedDict
 from types import SimpleNamespace
 
-from ufo2ft.featureWriters import ast
 from ufo2ft.errors import InvalidFeaturesData
+from ufo2ft.featureWriters import ast
 
 INSERT_FEATURE_MARKER = "# Automatic Code"
 
@@ -13,13 +13,10 @@ def _collectInsertMarkers(feaFile, insertFeatureMarker):
     Returns a dictionary of tuples (block, comment) keyed by feature tag
     """
     insertComments = dict()
-    for parent, comment in ast.findCommentPattern(
-        feaFile, insertFeatureMarker
-    ):
+    for parent, comment in ast.findCommentPattern(feaFile, insertFeatureMarker):
         if parent is None:
             raise InvalidFeaturesData(
-                "Invalid insert marker \"%s\" outside of feature block"
-                % str(comment)
+                "Invalid insert marker '%s' outside of feature block" % str(comment)
             )
         elif parent.name not in insertComments.keys():
             insertComments[parent.name] = (parent, comment)
@@ -60,8 +57,14 @@ class BaseFeatureWriter:
 
     _SUPPORTED_MODES = frozenset(["skip", "append"])
 
-    def __init__(self, features=None, mode=None, insertFeatureMarker=None,
-                 insertFeatureMarkerEnd=None, **kwargs):
+    def __init__(
+        self,
+        features=None,
+        mode=None,
+        insertFeatureMarker=None,
+        insertFeatureMarkerEnd=None,
+        **kwargs
+    ):
         if features is not None:
             features = frozenset(features)
             assert features, "features cannot be empty"
@@ -148,9 +151,9 @@ class BaseFeatureWriter:
         """Subclasses must override this."""
         raise NotImplementedError
 
-    def _insert(self, feaFile, classDefs=None, markClassDefs=None, lookups=None,
-                features=None
-                ):
+    def _insert(
+        self, feaFile, classDefs=None, markClassDefs=None, lookups=None, features=None
+    ):
         """
         Insert feature, its classDefs or markClassDefs and lookups at insert
         marker comment.
@@ -206,13 +209,14 @@ class BaseFeatureWriter:
                 # block.
                 markerEndIndex = None
                 if (
-                    self.insertFeatureMarkerEnd and insertEndComments
+                    self.insertFeatureMarkerEnd
+                    and insertEndComments
                     and (feature.name in insertEndComments)
                 ):
                     # TODO: somehow this sometimes yields just endBlock
                     # for endBlock, endComment in insertEndComments[feature.name]:
                     for end in insertEndComments[feature.name]:
-                        if not isinstance(end , tuple):
+                        if not isinstance(end, tuple):
                             end = insertEndComments[feature.name]
                         endBlock, endComment = end
                         # This feature's comment and endComment are in the same
@@ -220,8 +224,8 @@ class BaseFeatureWriter:
                         if id(endBlock) == id(block):
                             markerEndIndex = block.statements.index(endComment)
                             block.statements = (
-                                block.statements[:markerIndex + 1]
-                                + block.statements[markerEndIndex - 1:]
+                                block.statements[: markerIndex + 1]
+                                + block.statements[markerEndIndex - 1 :]
                             )
                             # Leave both markers in new feature block
                             feature.statements.insert(0, comment)
@@ -233,12 +237,10 @@ class BaseFeatureWriter:
                         )
 
                 onlyCommentsBefore = all(
-                    isinstance(s, ast.ast.Comment) for s in
-                    block.statements[:markerIndex]
+                    isinstance(s, ast.Comment) for s in block.statements[:markerIndex]
                 )
                 onlyCommentsAfter = all(
-                    isinstance(s, ast.ast.Comment) for s in
-                    block.statements[markerIndex:]
+                    isinstance(s, ast.Comment) for s in block.statements[markerIndex:]
                 )
 
                 # Remove insert marker(s) from feature block.
@@ -273,9 +275,7 @@ class BaseFeatureWriter:
 
             else:
                 if insertEndComments and feature.name in insertEndComments:
-                    raise InvalidFeaturesData(
-                        "Insert marker ends but doesn't start"
-                    )
+                    raise InvalidFeaturesData("Insert marker ends but doesn't start")
                 index = len(statements)
 
             statements.insert(index, feature)

--- a/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
@@ -54,11 +54,13 @@ class BaseFeatureWriter:
     tableTag = None
     features = frozenset()
     mode = "skip"
+    insertFeatureMarker = INSERT_FEATURE_MARKER
     options = {}
 
     _SUPPORTED_MODES = frozenset(["skip", "append"])
 
-    def __init__(self, features=None, mode=None, **kwargs):
+    def __init__(self, features=None, mode=None, insertFeatureMarker=None,
+                 **kwargs):
         if features is not None:
             features = frozenset(features)
             assert features, "features cannot be empty"
@@ -71,6 +73,9 @@ class BaseFeatureWriter:
             self.mode = mode
         if self.mode not in self._SUPPORTED_MODES:
             raise ValueError(self.mode)
+
+        if insertFeatureMarker is not None:
+            self.insertFeatureMarker = insertFeatureMarker
 
         options = dict(self.__class__.options)
         for k in kwargs:
@@ -141,7 +146,7 @@ class BaseFeatureWriter:
         raise NotImplementedError
 
     def _insert(self, feaFile, classDefs=None, markClassDefs=None, lookups=None,
-                features=None, insertFeatureMarker=INSERT_FEATURE_MARKER,
+                features=None
                 ):
         """
         Insert feature, its classDefs or markClassDefs and lookups at insert
@@ -157,7 +162,7 @@ class BaseFeatureWriter:
         statements = feaFile.statements
 
         # Collect insert markers in blocks
-        insertComments = _collectInsertMarkers(feaFile, insertFeatureMarker)
+        insertComments = _collectInsertMarkers(feaFile, self.insertFeatureMarker)
 
         # Insert classDefs
         # Note: The AFDKO spec says glyph classes should be defined before any

--- a/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
@@ -140,17 +140,11 @@ class BaseFeatureWriter:
 
         # Find last class definition and insert classDefs
         if classDefs:
-            # currentClassDefs = [
-            #     cd for cd in ast.iterClassDefinitions(self.context.feaFile)
-            # ]
             statements.extend(classDefs)
 
         # Insert markClassDefs
         if markClassDefs:
             markClassDefs.append(ast.Comment(""))
-            # currentMarkClassDefs = [
-            #     cd for cd in ast.iterMarkClassDefinitions(feaFile)
-            # ]
             statements.extend(markClassDefs)
 
         # Add the lookup blocks

--- a/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 from ufo2ft.errors import InvalidFeaturesData
 from ufo2ft.featureWriters import ast
 
-INSERT_FEATURE_MARKER = "# Automatic Code"
+INSERT_FEATURE_MARKER = r"\s*# Automatic Code"
 
 
 def _collectInsertMarkers(feaFile, insertFeatureMarker):

--- a/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
@@ -4,6 +4,8 @@ from types import SimpleNamespace
 
 from ufo2ft.featureWriters import ast
 
+FEATURE_INSERT_MARKER = "# Automatic Code"
+
 
 class BaseFeatureWriter:
     """Abstract features writer.
@@ -118,6 +120,89 @@ class BaseFeatureWriter:
     def _write(self):
         """Subclasses must override this."""
         raise NotImplementedError
+
+    def _insert(self, feaFile, classDefs=None, markClassDefs=None, lookups=None,
+                features=None, insertFeatureMarker=FEATURE_INSERT_MARKER):
+        """Insert feature at insert marker comment"""
+
+        statements = feaFile.statements
+
+        # Find last class definition and insert classDefs
+        if classDefs:
+            # currentClassDefs = [
+            #     cd for cd in ast.iterClassDefinitions(self.context.feaFile)
+            # ]
+            statements.extend(classDefs)
+
+        # Insert markClassDefs
+        if markClassDefs:
+            currentMarkClassDefs = [
+                cd for cd in ast.iterMarkClassDefinitions(feaFile)
+            ]
+            if self.mode == "prepend" and currentMarkClassDefs:
+                index = statements.index(currentMarkClassDefs[-1]) + 1
+                statements = feaFile.statements = (
+                    statements[:index] + markClassDefs + statements[index:]
+                )
+            else:
+                statements.extend(markClassDefs)
+
+        # Collect insert markers in blocks
+        insertComments = dict()
+        for parent, comment in ast.findCommentPattern(feaFile, insertFeatureMarker):
+            if parent is None:
+                # TODO: handle insert markers outside of blocks (when parent is None)
+                pass
+            elif parent.name not in insertComments.keys():
+                insertComments[parent.name] = (parent, comment)
+
+        # Add the lookup blocks
+        if lookups is None:
+            wroteLookups = True
+        elif not insertComments:
+            if statements:
+                statements.append(ast.Comment(""))
+            statements.extend(lookups)
+            wroteLookups = True
+        else:
+            wroteLookups = False
+
+        for _, feature in features:
+            if feature.name in insertComments:
+                block, comment = insertComments[feature.name]
+                index = block.statements.index(comment)
+                # insertMark comment is at the top of the feature block
+                # or only preceded by other comments
+                if all(
+                    isinstance(s, ast.ast.Comment) for s in
+                    block.statements[:index]
+                ):
+                    index = statements.index(block)
+                # insertMark comment is at the bottom of the feature block
+                # or only followed by other comments
+                elif all(
+                    isinstance(s, ast.ast.Comment) for s in
+                    block.statements[index:]
+                ):
+
+                    index = statements.index(block) + 1
+                # insertMark comment is in the middle of the feature block
+                # preceded and followed by statements that are not comments
+                else:
+                    split_block = ast.FeatureBlock(block.name)
+                    split_block.statements = block.statements[index:]
+                    block.statements = block.statements[:index]
+                    index = statements.index(block) + 1
+                    statements.insert(index, split_block)
+            else:
+                index = len(statements)
+
+            statements.insert(index, feature)
+            if not wroteLookups:
+                statements = feaFile.statements = (
+                    statements[:index] + lookups + statements[index:]
+                )
+                wroteLookups = True
 
     def makeUnicodeToGlyphNameMapping(self):
         """Return the Unicode to glyph name mapping for the current font."""

--- a/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
@@ -128,6 +128,16 @@ class BaseFeatureWriter:
 
         statements = feaFile.statements
 
+        # Collect insert markers in blocks
+        insertComments = dict()
+        for parent, comment in ast.findCommentPattern(feaFile, insertFeatureMarker):
+            if parent is None:
+                raise InvalidFeaturesData(
+                    "Invalid insert marker \"%s\" outside of feature block" % str(comment)
+                )
+            elif parent.name not in insertComments.keys():
+                insertComments[parent.name] = (parent, comment)
+
         # Find last class definition and insert classDefs
         if classDefs:
             # currentClassDefs = [
@@ -142,17 +152,6 @@ class BaseFeatureWriter:
             #     cd for cd in ast.iterMarkClassDefinitions(feaFile)
             # ]
             statements.extend(markClassDefs)
-
-        # Collect insert markers in blocks
-        insertComments = dict()
-        for parent, comment in ast.findCommentPattern(feaFile, insertFeatureMarker):
-            if parent is None:
-                # TODO: handle insert markers outside of blocks (when parent is None)
-                raise InvalidFeaturesData(
-                    "Invalid insert marker \"%s\" outside of feature block" % str(comment)
-                )
-            elif parent.name not in insertComments.keys():
-                insertComments[parent.name] = (parent, comment)
 
         # Add the lookup blocks
         if lookups is None:

--- a/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
@@ -41,7 +41,7 @@ class BaseFeatureWriter:
 
     _SUPPORTED_MODES = frozenset(["skip", "append"])
 
-    def __init__(self, features=None, mode=None, insertFeatureMarker=None, **kwargs):
+    def __init__(self, features=None, mode=None, **kwargs):
         if features is not None:
             features = frozenset(features)
             assert features, "features cannot be empty"
@@ -54,9 +54,6 @@ class BaseFeatureWriter:
             self.mode = mode
         if self.mode not in self._SUPPORTED_MODES:
             raise ValueError(self.mode)
-
-        if insertFeatureMarker is not None:
-            self.insertFeatureMarker = insertFeatureMarker
 
         options = dict(self.__class__.options)
         for k in kwargs:
@@ -203,13 +200,15 @@ class BaseFeatureWriter:
                 # This is currently not supported.
                 else:
                     raise InvalidFeaturesData(
-                        "Insert marker has rules before and after, feature %s "
-                        "cannot be inserted." % block.name
+                        "Insert marker has rules before and after, feature "
+                        f"{block.name} cannot be inserted. This is not supported."
                     )
 
             else:
                 index = len(statements)
 
+            # Write classDefs, anchorsDefs, markClassDefs, lookups on the first
+            # iteration.
             if not wroteOthers:
                 others = []
                 # Insert classDefs, anchorsDefs, markClassDefs

--- a/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
@@ -189,28 +189,31 @@ class BaseFeatureWriter:
         for _, feature in features:
             if feature.name in insertComments:
                 block, comment = insertComments[feature.name]
-                index = block.statements.index(comment)
-                # insertMark comment is at the top of the feature block
+                markerIndex = block.statements.index(comment)
+
+                # insertFeatureMarker is at the top of the feature block
                 # or only preceded by other comments
                 if all(
                     isinstance(s, ast.ast.Comment) for s in
-                    block.statements[:index]
+                    block.statements[:markerIndex]
                 ):
                     index = statements.index(block)
-                # insertMark comment is at the bottom of the feature block
+
+                # insertFeatureMarker is at the bottom of the feature block
                 # or only followed by other comments
                 elif all(
                     isinstance(s, ast.ast.Comment) for s in
-                    block.statements[index:]
+                    block.statements[markerIndex:]
                 ):
 
                     index = statements.index(block) + 1
-                # insertMark comment is in the middle of the feature block
+
+                # insertFeatureMarker is in the middle of the feature block
                 # preceded and followed by statements that are not comments
                 else:
                     split_block = ast.FeatureBlock(block.name)
-                    split_block.statements = block.statements[index:]
-                    block.statements = block.statements[:index]
+                    split_block.statements = block.statements[markerIndex:]
+                    block.statements = block.statements[:markerIndex]
                     index = statements.index(block) + 1
                     statements.insert(index, split_block)
             else:

--- a/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
@@ -154,7 +154,13 @@ class BaseFeatureWriter:
         raise NotImplementedError
 
     def _insert(
-        self, feaFile, classDefs=None, markClassDefs=None, lookups=None, features=None
+        self,
+        feaFile,
+        classDefs=None,
+        anchorDefs=None,
+        markClassDefs=None,
+        lookups=None,
+        features=None,
     ):
         """
         Insert feature, its classDefs or markClassDefs and lookups at insert
@@ -228,6 +234,10 @@ class BaseFeatureWriter:
                 # are used, but ufo2ft featureWriters has never done that.
                 if classDefs:
                     others.extend(classDefs)
+                    others.append(ast.Comment(""))
+                # Insert anchorDefs
+                if anchorDefs:
+                    others.extend(anchorDefs)
                     others.append(ast.Comment(""))
                 # Insert markClassDefs
                 if markClassDefs:

--- a/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 from types import SimpleNamespace
 
 from ufo2ft.featureWriters import ast
+from ufo2ft.errors import InvalidFeaturesData
 
 FEATURE_INSERT_MARKER = "# Automatic Code"
 
@@ -136,23 +137,20 @@ class BaseFeatureWriter:
 
         # Insert markClassDefs
         if markClassDefs:
-            currentMarkClassDefs = [
-                cd for cd in ast.iterMarkClassDefinitions(feaFile)
-            ]
-            if self.mode == "prepend" and currentMarkClassDefs:
-                index = statements.index(currentMarkClassDefs[-1]) + 1
-                statements = feaFile.statements = (
-                    statements[:index] + markClassDefs + statements[index:]
-                )
-            else:
-                statements.extend(markClassDefs)
+            markClassDefs.append(ast.Comment(""))
+            # currentMarkClassDefs = [
+            #     cd for cd in ast.iterMarkClassDefinitions(feaFile)
+            # ]
+            statements.extend(markClassDefs)
 
         # Collect insert markers in blocks
         insertComments = dict()
         for parent, comment in ast.findCommentPattern(feaFile, insertFeatureMarker):
             if parent is None:
                 # TODO: handle insert markers outside of blocks (when parent is None)
-                pass
+                raise InvalidFeaturesData(
+                    "Invalid insert marker \"%s\" outside of feature block" % str(comment)
+                )
             elif parent.name not in insertComments.keys():
                 insertComments[parent.name] = (parent, comment)
 

--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
@@ -238,7 +238,6 @@ class KernFeatureWriter(BaseFeatureWriter):
 
         # extend feature file with the new generated statements
         feaFile = self.context.feaFile
-        # statements = feaFile.statements
 
         # first add the glyph class definitions
         side1Classes = self.context.kerning.side1Classes
@@ -255,9 +254,7 @@ class KernFeatureWriter(BaseFeatureWriter):
             feaFile=feaFile,
             classDefs=newClassDefs,
             lookups=lookupGroups,
-            features=sorted(
-                features.items(), key=lambda x: ["kern", "dist"].index(x[0])
-            ),
+            features=[features[tag] for tag in ["kern", "dist"] if tag in features],
         )
         return True
 

--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
@@ -237,25 +237,28 @@ class KernFeatureWriter(BaseFeatureWriter):
             return False
 
         # extend feature file with the new generated statements
-        statements = self.context.feaFile.statements
+        feaFile = self.context.feaFile
+        # statements = feaFile.statements
 
         # first add the glyph class definitions
         side1Classes = self.context.kerning.side1Classes
         side2Classes = self.context.kerning.side2Classes
+        newClassDefs = []
         for classes in (side1Classes, side2Classes):
-            statements.extend([c for _, c in sorted(classes.items())])
+            newClassDefs.extend([c for _, c in sorted(classes.items())])
 
-        # add empty line to separate classes from following statements
-        if statements:
-            statements.append(ast.Comment(""))
-
-        # finally add the lookup and feature blocks
+        lookupGroups = []
         for _, lookupGroup in sorted(lookups.items()):
-            statements.extend(lookupGroup)
-        if "kern" in features:
-            statements.append(features["kern"])
-        if "dist" in features:
-            statements.append(features["dist"])
+            lookupGroups.extend(lookupGroup)
+
+        self._insert(
+            feaFile=feaFile,
+            classDefs=newClassDefs,
+            lookups=lookupGroups,
+            features=sorted(
+                features.items(), key=lambda x: ["kern", "dist"].index(x[0])
+            ),
+        )
         return True
 
     @classmethod

--- a/Lib/ufo2ft/featureWriters/markFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/markFeatureWriter.py
@@ -879,7 +879,7 @@ class MarkFeatureWriter(BaseFeatureWriter):
         self._insert(
             feaFile=feaFile,
             markClassDefs=newClassDefs,
-            features=sorted(features.items()),
+            features=[features[tag] for tag in sorted(features.keys())],
         )
 
         return True

--- a/Lib/ufo2ft/featureWriters/markFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/markFeatureWriter.py
@@ -875,9 +875,11 @@ class MarkFeatureWriter(BaseFeatureWriter):
             return False
 
         feaFile = self.context.feaFile
-        feaFile.statements.extend(newClassDefs)
-        # add empty line to separate classes from following statements
-        feaFile.statements.append(ast.Comment(""))
-        for _, feature in sorted(features.items()):
-            feaFile.statements.append(feature)
+
+        self._insert(
+            feaFile=feaFile,
+            classDefs=newClassDefs,
+            features=sorted(features.items()),
+        )
+
         return True

--- a/Lib/ufo2ft/featureWriters/markFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/markFeatureWriter.py
@@ -878,7 +878,7 @@ class MarkFeatureWriter(BaseFeatureWriter):
 
         self._insert(
             feaFile=feaFile,
-            classDefs=newClassDefs,
+            markClassDefs=newClassDefs,
             features=sorted(features.items()),
         )
 

--- a/tests/featureWriters/kernFeatureWriter_test.py
+++ b/tests/featureWriters/kernFeatureWriter_test.py
@@ -311,6 +311,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
                 #
             } kern;
 
+
             lookup kern_ltr {
                 lookupflag IgnoreMarks;
                 pos seven six 25;

--- a/tests/featureWriters/kernFeatureWriter_test.py
+++ b/tests/featureWriters/kernFeatureWriter_test.py
@@ -258,7 +258,6 @@ class KernFeatureWriterTest(FeatureWriterTest):
 
             feature kern {
                 #
-                # Automatic Code
                 #
                 pos one four' -50 six;
             } kern;
@@ -293,7 +292,6 @@ class KernFeatureWriterTest(FeatureWriterTest):
             feature kern {
                 pos one four' -50 six;
                 #
-                # Automatic Code
                 #
             } kern;
 
@@ -349,7 +347,6 @@ class KernFeatureWriterTest(FeatureWriterTest):
             } kern;
 
             feature kern {
-                # Automatic Code
                 #
                 pos one six' -50 six;
             } kern;

--- a/tests/featureWriters/kernFeatureWriter_test.py
+++ b/tests/featureWriters/kernFeatureWriter_test.py
@@ -267,6 +267,21 @@ class KernFeatureWriterTest(FeatureWriterTest):
 
         assert str(feaFile).strip() == expected.strip()
 
+        # test append mode ignores insert marker
+        generated = self.writeFeatures(ufo, mode="append")
+        assert str(generated) == dedent(
+            """
+            lookup kern_ltr {
+                lookupflag IgnoreMarks;
+                pos seven six 25;
+            } kern_ltr;
+
+            feature kern {
+                lookup kern_ltr;
+            } kern;
+            """
+        )
+
     def test_insert_comment_after(self, FontClass):
         ufo = FontClass()
         for name in ("one", "four", "six", "seven"):
@@ -309,7 +324,22 @@ class KernFeatureWriterTest(FeatureWriterTest):
 
         assert str(feaFile) == expected
 
-    def test_insert_comment_split(self, FontClass):
+        # test append mode ignores insert marker
+        generated = self.writeFeatures(ufo, mode="append")
+        assert str(generated) == dedent(
+            """
+            lookup kern_ltr {
+                lookupflag IgnoreMarks;
+                pos seven six 25;
+            } kern_ltr;
+
+            feature kern {
+                lookup kern_ltr;
+            } kern;
+            """
+        )
+
+    def test_insert_comment_middle(self, FontClass):
         ufo = FontClass()
         for name in ("one", "four", "six", "seven"):
             ufo.newGlyph(name)
@@ -337,9 +367,20 @@ class KernFeatureWriterTest(FeatureWriterTest):
         ):
             writer.write(ufo, feaFile)
 
-        writer = KernFeatureWriter(mode="append")
-        expected = str(feaFile)
-        assert writer.write(ufo, feaFile)
+        # test append mode ignores insert marker
+        generated = self.writeFeatures(ufo, mode="append")
+        assert str(generated) == dedent(
+            """
+            lookup kern_ltr {
+                lookupflag IgnoreMarks;
+                pos seven six 25;
+            } kern_ltr;
+
+            feature kern {
+                lookup kern_ltr;
+            } kern;
+            """
+        )
 
     def test_arabic_numerals(self, FontClass):
         """Test that arabic numerals (with bidi type AN) are kerned LTR.

--- a/tests/featureWriters/markFeatureWriter_test.py
+++ b/tests/featureWriters/markFeatureWriter_test.py
@@ -444,7 +444,7 @@ class MarkFeatureWriterTest(FeatureWriterTest):
 
         with pytest.raises(
             InvalidFeaturesData,
-            match="Invalid insert marker \"# Automatic Code\" outside of "
+            match="Invalid insert marker '# Automatic Code' outside of "
             "feature block",
         ):
             writer.write(testufo, feaFile)
@@ -467,7 +467,7 @@ class MarkFeatureWriterTest(FeatureWriterTest):
 
         with pytest.raises(
             InvalidFeaturesData,
-            match="Invalid insert marker \"# Automatic Code\" outside of "
+            match="Invalid insert marker '# Automatic Code' outside of "
             "feature block",
         ):
             writer.write(testufo, feaFile)

--- a/tests/featureWriters/markFeatureWriter_test.py
+++ b/tests/featureWriters/markFeatureWriter_test.py
@@ -472,66 +472,6 @@ class MarkFeatureWriterTest(FeatureWriterTest):
         ):
             writer.write(testufo, feaFile)
 
-    def test_update_feature(self, testufo):
-        testufo.newGlyph("e")
-        writer = MarkFeatureWriter(
-            mode="append",
-            insertFeatureMarker="#> feature",
-            insertFeatureMarkerEnd="#< feature",
-        )
-        testufo.features.text = dedent(
-            """\
-            markClass acutecomb <anchor 100 200> @MC_top;
-            markClass tildecomb <anchor 100 200> @MC_top;
-
-            feature mark {
-                #> feature
-                #
-                #< feature
-
-            } mark;
-
-            feature mkmk {
-                #> feature
-                #
-                #< feature
-
-            } mkmk;
-            """
-        )
-        feaFile = parseLayoutFeatures(testufo)
-        assert writer.write(testufo, feaFile)
-        assert str(feaFile) == dedent(
-            """\
-            markClass acutecomb <anchor 100 200> @MC_top;
-            markClass tildecomb <anchor 100 200> @MC_top;
-            feature mark {
-                #> feature
-                lookup mark2base {
-                    pos base a <anchor 100 200> mark @MC_top;
-                } mark2base;
-
-                lookup mark2liga {
-                    pos ligature f_i <anchor 100 500> mark @MC_top
-                        ligComponent <anchor 600 500> mark @MC_top;
-                } mark2liga;
-
-                #< feature
-            } mark;
-
-            feature mkmk {
-                #> feature
-                lookup mark2mark_top {
-                    @MFS_mark2mark_top = [acutecomb tildecomb];
-                    lookupflag UseMarkFilteringSet @MFS_mark2mark_top;
-                    pos mark tildecomb <anchor 100 300> mark @MC_top;
-                } mark2mark_top;
-
-                #< feature
-            } mkmk;
-            """
-        )
-
     def test_mark_mkmk_features(self, testufo):
         writer = MarkFeatureWriter()  # by default both mark + mkmk are built
         feaFile = ast.FeatureFile()

--- a/tests/featureWriters/markFeatureWriter_test.py
+++ b/tests/featureWriters/markFeatureWriter_test.py
@@ -309,6 +309,35 @@ class MarkFeatureWriterTest(FeatureWriterTest):
             """
         )
 
+        # test append mode ignores insert marker
+        generated = self.writeFeatures(testufo, mode="append")
+        assert str(generated) == dedent(
+            """\
+            markClass tildecomb <anchor 100 200> @MC_top;
+
+            feature mark {
+                lookup mark2base {
+                    pos base a <anchor 100 200> mark @MC_top;
+                } mark2base;
+
+                lookup mark2liga {
+                    pos ligature f_i <anchor 100 500> mark @MC_top
+                        ligComponent <anchor 600 500> mark @MC_top;
+                } mark2liga;
+
+            } mark;
+
+            feature mkmk {
+                lookup mark2mark_top {
+                    @MFS_mark2mark_top = [acutecomb tildecomb];
+                    lookupflag UseMarkFilteringSet @MFS_mark2mark_top;
+                    pos mark tildecomb <anchor 100 300> mark @MC_top;
+                } mark2mark_top;
+
+            } mkmk;
+            """
+        )
+
     def test_insert_comment_after(self, testufo):
         writer = MarkFeatureWriter()
         testufo.features.text = dedent(
@@ -365,7 +394,36 @@ class MarkFeatureWriterTest(FeatureWriterTest):
             """
         )
 
-    def test_insert_comment_split(self, testufo):
+        # test append mode ignores insert marker
+        generated = self.writeFeatures(testufo, mode="append")
+        assert str(generated) == dedent(
+            """\
+            markClass tildecomb <anchor 100 200> @MC_top;
+
+            feature mark {
+                lookup mark2base {
+                    pos base a <anchor 100 200> mark @MC_top;
+                } mark2base;
+
+                lookup mark2liga {
+                    pos ligature f_i <anchor 100 500> mark @MC_top
+                        ligComponent <anchor 600 500> mark @MC_top;
+                } mark2liga;
+
+            } mark;
+
+            feature mkmk {
+                lookup mark2mark_top {
+                    @MFS_mark2mark_top = [acutecomb tildecomb];
+                    lookupflag UseMarkFilteringSet @MFS_mark2mark_top;
+                    pos mark tildecomb <anchor 100 300> mark @MC_top;
+                } mark2mark_top;
+
+            } mkmk;
+            """
+        )
+
+    def test_insert_comment_middle(self, testufo):
         writer = MarkFeatureWriter()
         testufo.features.text = dedent(
             """\
@@ -392,8 +450,34 @@ class MarkFeatureWriterTest(FeatureWriterTest):
         ):
             writer.write(testufo, feaFile)
 
-        writer = MarkFeatureWriter(mode="append")
-        assert writer.write(testufo, feaFile)
+        # test append mode ignores insert marker
+        generated = self.writeFeatures(testufo, mode="append")
+        assert str(generated) == dedent(
+            """\
+            markClass tildecomb <anchor 100 200> @MC_top;
+
+            feature mark {
+                lookup mark2base {
+                    pos base a <anchor 100 200> mark @MC_top;
+                } mark2base;
+
+                lookup mark2liga {
+                    pos ligature f_i <anchor 100 500> mark @MC_top
+                        ligComponent <anchor 600 500> mark @MC_top;
+                } mark2liga;
+
+            } mark;
+
+            feature mkmk {
+                lookup mark2mark_top {
+                    @MFS_mark2mark_top = [acutecomb tildecomb];
+                    lookupflag UseMarkFilteringSet @MFS_mark2mark_top;
+                    pos mark tildecomb <anchor 100 300> mark @MC_top;
+                } mark2mark_top;
+
+            } mkmk;
+            """
+        )
 
     def test_insert_comment_outside_block(self, testufo):
         writer = MarkFeatureWriter()
@@ -435,6 +519,10 @@ class MarkFeatureWriterTest(FeatureWriterTest):
             "feature block",
         ):
             writer.write(testufo, feaFile)
+
+        # test append mode
+        writer = MarkFeatureWriter(mode="append")
+        assert writer.write(testufo, feaFile)
 
     def test_mark_mkmk_features(self, testufo):
         writer = MarkFeatureWriter()  # by default both mark + mkmk are built

--- a/tests/featureWriters/markFeatureWriter_test.py
+++ b/tests/featureWriters/markFeatureWriter_test.py
@@ -289,7 +289,6 @@ class MarkFeatureWriterTest(FeatureWriterTest):
 
             feature mark {
                 #
-                # Automatic Code
                 #
                 lookup mark1 {
                     pos base a <anchor 100 200> mark @MC_top;
@@ -338,7 +337,6 @@ class MarkFeatureWriterTest(FeatureWriterTest):
                 } mark1;
 
                 #
-                # Automatic Code
                 #
             } mark;
 
@@ -413,7 +411,6 @@ class MarkFeatureWriterTest(FeatureWriterTest):
             } mark;
 
             feature mark {
-                # Automatic Code
                 #
                 lookup mark2 {
                     pos base a <anchor 150 250> mark @MC_top;
@@ -474,6 +471,66 @@ class MarkFeatureWriterTest(FeatureWriterTest):
             "feature block",
         ):
             writer.write(testufo, feaFile)
+
+    def test_update_feature(self, testufo):
+        testufo.newGlyph("e")
+        writer = MarkFeatureWriter(
+            mode="append",
+            insertFeatureMarker="#> feature",
+            insertFeatureMarkerEnd="#< feature",
+        )
+        testufo.features.text = dedent(
+            """\
+            markClass acutecomb <anchor 100 200> @MC_top;
+            markClass tildecomb <anchor 100 200> @MC_top;
+
+            feature mark {
+                #> feature
+                #
+                #< feature
+
+            } mark;
+
+            feature mkmk {
+                #> feature
+                #
+                #< feature
+
+            } mkmk;
+            """
+        )
+        feaFile = parseLayoutFeatures(testufo)
+        assert writer.write(testufo, feaFile)
+        assert str(feaFile) == dedent(
+            """\
+            markClass acutecomb <anchor 100 200> @MC_top;
+            markClass tildecomb <anchor 100 200> @MC_top;
+            feature mark {
+                #> feature
+                lookup mark2base {
+                    pos base a <anchor 100 200> mark @MC_top;
+                } mark2base;
+
+                lookup mark2liga {
+                    pos ligature f_i <anchor 100 500> mark @MC_top
+                        ligComponent <anchor 600 500> mark @MC_top;
+                } mark2liga;
+
+                #< feature
+            } mark;
+
+            feature mkmk {
+                #> feature
+                lookup mark2mark_top {
+                    @MFS_mark2mark_top = [acutecomb tildecomb];
+                    lookupflag UseMarkFilteringSet @MFS_mark2mark_top;
+                    pos mark tildecomb <anchor 100 300> mark @MC_top;
+                } mark2mark_top;
+
+                #< feature
+            } mkmk;
+            """
+        )
 
     def test_mark_mkmk_features(self, testufo):
         writer = MarkFeatureWriter()  # by default both mark + mkmk are built

--- a/tests/featureWriters/markFeatureWriter_test.py
+++ b/tests/featureWriters/markFeatureWriter_test.py
@@ -254,7 +254,7 @@ class MarkFeatureWriterTest(FeatureWriterTest):
         )
 
     def test_insert_comment_before(self, testufo):
-        writer = MarkFeatureWriter(mode="append")
+        writer = MarkFeatureWriter()
         testufo.features.text = dedent(
             """\
             markClass acutecomb <anchor 100 200> @MC_top;
@@ -310,7 +310,7 @@ class MarkFeatureWriterTest(FeatureWriterTest):
         )
 
     def test_insert_comment_after(self, testufo):
-        writer = MarkFeatureWriter(mode="append")
+        writer = MarkFeatureWriter()
         testufo.features.text = dedent(
             """\
             markClass acutecomb <anchor 100 200> @MC_top;
@@ -366,7 +366,7 @@ class MarkFeatureWriterTest(FeatureWriterTest):
         )
 
     def test_insert_comment_split(self, testufo):
-        writer = MarkFeatureWriter(mode="append")
+        writer = MarkFeatureWriter()
         testufo.features.text = dedent(
             """\
             markClass acutecomb <anchor 100 200> @MC_top;
@@ -385,51 +385,15 @@ class MarkFeatureWriterTest(FeatureWriterTest):
         )
         feaFile = parseLayoutFeatures(testufo)
 
+        with pytest.raises(
+            InvalidFeaturesData,
+            match="Insert marker has rules before and after, feature mark "
+            "cannot be inserted.",
+        ):
+            writer.write(testufo, feaFile)
+
+        writer = MarkFeatureWriter(mode="append")
         assert writer.write(testufo, feaFile)
-
-        assert str(feaFile) == dedent(
-            """\
-            markClass acutecomb <anchor 100 200> @MC_top;
-            feature mark {
-                lookup mark1 {
-                    pos base a <anchor 100 200> mark @MC_top;
-                } mark1;
-
-                #
-            } mark;
-
-            feature mark {
-                lookup mark2base {
-                    pos base a <anchor 100 200> mark @MC_top;
-                } mark2base;
-
-                lookup mark2liga {
-                    pos ligature f_i <anchor 100 500> mark @MC_top
-                        ligComponent <anchor 600 500> mark @MC_top;
-                } mark2liga;
-
-            } mark;
-
-            feature mark {
-                #
-                lookup mark2 {
-                    pos base a <anchor 150 250> mark @MC_top;
-                } mark2;
-
-            } mark;
-
-            markClass tildecomb <anchor 100 200> @MC_top;
-
-            feature mkmk {
-                lookup mark2mark_top {
-                    @MFS_mark2mark_top = [acutecomb tildecomb];
-                    lookupflag UseMarkFilteringSet @MFS_mark2mark_top;
-                    pos mark tildecomb <anchor 100 300> mark @MC_top;
-                } mark2mark_top;
-
-            } mkmk;
-            """
-        )
 
     def test_insert_comment_outside_block(self, testufo):
         writer = MarkFeatureWriter()

--- a/tests/featureWriters/markFeatureWriter_test.py
+++ b/tests/featureWriters/markFeatureWriter_test.py
@@ -490,12 +490,7 @@ class MarkFeatureWriterTest(FeatureWriterTest):
         )
         feaFile = parseLayoutFeatures(testufo)
 
-        with pytest.raises(
-            InvalidFeaturesData,
-            match="Invalid insert marker '# Automatic Code' outside of "
-            "feature block",
-        ):
-            writer.write(testufo, feaFile)
+        assert writer.write(testufo, feaFile)
 
         testufo.features.text = dedent(
             """\
@@ -513,12 +508,7 @@ class MarkFeatureWriterTest(FeatureWriterTest):
         )
         feaFile = parseLayoutFeatures(testufo)
 
-        with pytest.raises(
-            InvalidFeaturesData,
-            match="Invalid insert marker '# Automatic Code' outside of "
-            "feature block",
-        ):
-            writer.write(testufo, feaFile)
+        assert writer.write(testufo, feaFile)
 
         # test append mode
         writer = MarkFeatureWriter(mode="append")

--- a/tests/featureWriters/markFeatureWriter_test.py
+++ b/tests/featureWriters/markFeatureWriter_test.py
@@ -275,6 +275,8 @@ class MarkFeatureWriterTest(FeatureWriterTest):
         assert str(feaFile) == dedent(
             """\
             markClass acutecomb <anchor 100 200> @MC_top;
+            markClass tildecomb <anchor 100 200> @MC_top;
+
             feature mark {
                 lookup mark2base {
                     pos base a <anchor 100 200> mark @MC_top;
@@ -295,8 +297,6 @@ class MarkFeatureWriterTest(FeatureWriterTest):
                 } mark1;
 
             } mark;
-
-            markClass tildecomb <anchor 100 200> @MC_top;
 
             feature mkmk {
                 lookup mark2mark_top {
@@ -369,6 +369,8 @@ class MarkFeatureWriterTest(FeatureWriterTest):
                 #
             } mark;
 
+            markClass tildecomb <anchor 100 200> @MC_top;
+
             feature mark {
                 lookup mark2base {
                     pos base a <anchor 100 200> mark @MC_top;
@@ -380,8 +382,6 @@ class MarkFeatureWriterTest(FeatureWriterTest):
                 } mark2liga;
 
             } mark;
-
-            markClass tildecomb <anchor 100 200> @MC_top;
 
             feature mkmk {
                 lookup mark2mark_top {

--- a/tests/featureWriters/markFeatureWriter_test.py
+++ b/tests/featureWriters/markFeatureWriter_test.py
@@ -252,6 +252,187 @@ class MarkFeatureWriterTest(FeatureWriterTest):
             """
         )
 
+    def test_insert_comment_before(self, testufo):
+        writer = MarkFeatureWriter(mode="append")
+        testufo.features.text = dedent(
+            """\
+            markClass acutecomb <anchor 100 200> @MC_top;
+            feature mark {
+                #
+                # Automatic Code
+                #
+                lookup mark1 {
+                    pos base a <anchor 100 200> mark @MC_top;
+                } mark1;
+            } mark;
+            """
+        )
+        feaFile = parseLayoutFeatures(testufo)
+
+        assert writer.write(testufo, feaFile)
+
+        assert str(feaFile) == dedent(
+            """\
+            markClass acutecomb <anchor 100 200> @MC_top;
+            feature mark {
+                lookup mark2base {
+                    pos base a <anchor 100 200> mark @MC_top;
+                } mark2base;
+
+                lookup mark2liga {
+                    pos ligature f_i <anchor 100 500> mark @MC_top
+                        ligComponent <anchor 600 500> mark @MC_top;
+                } mark2liga;
+
+            } mark;
+
+            feature mark {
+                #
+                # Automatic Code
+                #
+                lookup mark1 {
+                    pos base a <anchor 100 200> mark @MC_top;
+                } mark1;
+
+            } mark;
+
+            markClass tildecomb <anchor 100 200> @MC_top;
+
+            feature mkmk {
+                lookup mark2mark_top {
+                    @MFS_mark2mark_top = [acutecomb tildecomb];
+                    lookupflag UseMarkFilteringSet @MFS_mark2mark_top;
+                    pos mark tildecomb <anchor 100 300> mark @MC_top;
+                } mark2mark_top;
+
+            } mkmk;
+            """
+        )
+
+    def test_insert_comment_after(self, testufo):
+        writer = MarkFeatureWriter(mode="append")
+        testufo.features.text = dedent(
+            """\
+            markClass acutecomb <anchor 100 200> @MC_top;
+            feature mark {
+                lookup mark1 {
+                    pos base a <anchor 100 200> mark @MC_top;
+                } mark1;
+                #
+                # Automatic Code
+                #
+            } mark;
+            """
+        )
+        feaFile = parseLayoutFeatures(testufo)
+
+        assert writer.write(testufo, feaFile)
+
+        assert str(feaFile) == dedent(
+            """\
+            markClass acutecomb <anchor 100 200> @MC_top;
+            feature mark {
+                lookup mark1 {
+                    pos base a <anchor 100 200> mark @MC_top;
+                } mark1;
+
+                #
+                # Automatic Code
+                #
+            } mark;
+
+            feature mark {
+                lookup mark2base {
+                    pos base a <anchor 100 200> mark @MC_top;
+                } mark2base;
+
+                lookup mark2liga {
+                    pos ligature f_i <anchor 100 500> mark @MC_top
+                        ligComponent <anchor 600 500> mark @MC_top;
+                } mark2liga;
+
+            } mark;
+
+            markClass tildecomb <anchor 100 200> @MC_top;
+
+            feature mkmk {
+                lookup mark2mark_top {
+                    @MFS_mark2mark_top = [acutecomb tildecomb];
+                    lookupflag UseMarkFilteringSet @MFS_mark2mark_top;
+                    pos mark tildecomb <anchor 100 300> mark @MC_top;
+                } mark2mark_top;
+
+            } mkmk;
+            """
+        )
+
+    def test_insert_comment_split(self, testufo):
+        writer = MarkFeatureWriter(mode="append")
+        testufo.features.text = dedent(
+            """\
+            markClass acutecomb <anchor 100 200> @MC_top;
+            feature mark {
+                lookup mark1 {
+                    pos base a <anchor 100 200> mark @MC_top;
+                } mark1;
+                #
+                # Automatic Code
+                #
+                lookup mark2 {
+                    pos base a <anchor 150 250> mark @MC_top;
+                } mark2;
+            } mark;
+            """
+        )
+        feaFile = parseLayoutFeatures(testufo)
+
+        assert writer.write(testufo, feaFile)
+
+        assert str(feaFile) == dedent(
+            """\
+            markClass acutecomb <anchor 100 200> @MC_top;
+            feature mark {
+                lookup mark1 {
+                    pos base a <anchor 100 200> mark @MC_top;
+                } mark1;
+
+                #
+            } mark;
+
+            feature mark {
+                lookup mark2base {
+                    pos base a <anchor 100 200> mark @MC_top;
+                } mark2base;
+
+                lookup mark2liga {
+                    pos ligature f_i <anchor 100 500> mark @MC_top
+                        ligComponent <anchor 600 500> mark @MC_top;
+                } mark2liga;
+
+            } mark;
+
+            feature mark {
+                # Automatic Code
+                #
+                lookup mark2 {
+                    pos base a <anchor 150 250> mark @MC_top;
+                } mark2;
+
+            } mark;
+
+            markClass tildecomb <anchor 100 200> @MC_top;
+
+            feature mkmk {
+                lookup mark2mark_top {
+                    @MFS_mark2mark_top = [acutecomb tildecomb];
+                    lookupflag UseMarkFilteringSet @MFS_mark2mark_top;
+                    pos mark tildecomb <anchor 100 300> mark @MC_top;
+                } mark2mark_top;
+
+            } mkmk;
+            """
+        )
+
     def test_mark_mkmk_features(self, testufo):
         writer = MarkFeatureWriter()  # by default both mark + mkmk are built
         feaFile = ast.FeatureFile()


### PR DESCRIPTION
This moves and merges the kernFeatureWriter and markFeatureWriter logic for inserting the class definitions, mark class definitions, lookups and feature block into BaseFeatureWriter._insert().
It also add insertFeatureMarker attribute to BaseFeatureWriter.

The insertFeatureMarker can be used like in Glyphs3, a single `\s*# Automatic Code` comment in a feature block.
Depending on where the insertFeatureMarker is found in a comment in a feature block, the BaseFeatureWriter inserts the automatic code before if at the top, after if at the bottom.
At the moment it cannot be in between other rules, for which case Glyphs.app 3 adds new blocks between two blocks split from the original one.

This doesn't handle the FontLab 7 syntax which has a start feature marker and an end feature marker, a pair of `#> feature` and `#< feature` comments in a feature block.

This replaces [Allow insertion markers for autogenerated features #352](https://github.com/googlefonts/ufo2ft/pull/352).
But it instead doesn't allow insertFeatureMarker to be outside a feature block. A blank feature block with the insertFeatureMarker can be used to produce the same effect.

The insertFeatureMarker is only taken into account in the default mode, the "skip" mode.
If a feature block is present but doesn't have an insertFeatureMarker comment, the feature is not inserted.
If a feature block is present and has an insertFeatureMarker comment, the feature is inserted there.
If no feature block is present, the feature is appended.

The append mode does not change and always appends the generated feature block.