### PR TITLE
Run filter from CLI

### DIFF
--- a/Lib/ufo2ft/filters/__main__.py
+++ b/Lib/ufo2ft/filters/__main__.py
@@ -1,23 +1,24 @@
-from ufo2ft.filters import getFilterClass, logger
-import logging
-import defcon
 import argparse
-from fontTools.misc.cliTools import makeOutputFileName
 import importlib
+import logging
+
+import defcon
+from fontTools.misc.cliTools import makeOutputFileName
+
+from ufo2ft.filters import getFilterClass, logger
 
 logging.basicConfig(level=logging.INFO)
 
-parser = argparse.ArgumentParser(description='Filter a UFO file')
-parser.add_argument('--output', '-o', metavar='OUTPUT',
-                    help='output file name')
-parser.add_argument('--include', metavar='GLYPHS',
-                    help='comma-separated list of glyphs to filter')
-parser.add_argument('--exclude', metavar='GLYPHS',
-                    help='comma-separated list of glyphs to not filter')
-parser.add_argument('ufo', metavar='UFO',
-                    help='UFO file')
-parser.add_argument('filters', metavar='FILTER', nargs='+',
-                    help='filter name')
+parser = argparse.ArgumentParser(description="Filter a UFO file")
+parser.add_argument("--output", "-o", metavar="OUTPUT", help="output file name")
+parser.add_argument(
+    "--include", metavar="GLYPHS", help="comma-separated list of glyphs to filter"
+)
+parser.add_argument(
+    "--exclude", metavar="GLYPHS", help="comma-separated list of glyphs to not filter"
+)
+parser.add_argument("ufo", metavar="UFO", help="UFO file")
+parser.add_argument("filters", metavar="FILTER", nargs="+", help="filter name")
 
 args = parser.parse_args()
 if not args.output:

--- a/Lib/ufo2ft/filters/__main__.py
+++ b/Lib/ufo2ft/filters/__main__.py
@@ -1,0 +1,49 @@
+from ufo2ft.filters import getFilterClass, logger
+import logging
+import defcon
+import argparse
+from fontTools.misc.cliTools import makeOutputFileName
+import importlib
+
+logging.basicConfig(level=logging.INFO)
+
+parser = argparse.ArgumentParser(description='Filter a UFO file')
+parser.add_argument('--output', '-o', metavar='OUTPUT',
+                    help='output file name')
+parser.add_argument('--include', metavar='GLYPHS',
+                    help='comma-separated list of glyphs to filter')
+parser.add_argument('--exclude', metavar='GLYPHS',
+                    help='comma-separated list of glyphs to not filter')
+parser.add_argument('ufo', metavar='UFO',
+                    help='UFO file')
+parser.add_argument('filters', metavar='FILTER', nargs='+',
+                    help='filter name')
+
+args = parser.parse_args()
+if not args.output:
+    args.output = makeOutputFileName(args.ufo)
+
+ufo = defcon.Font(args.ufo)
+
+filterargs = {}
+if args.include:
+    filterargs["include"] = args.include.split(",")
+if args.exclude:
+    filterargs["exclude"] = args.exclude.split(",")
+
+
+for filtername in args.filters:
+    try:
+        if "." in filtername:
+            module = importlib.import_module(filtername)
+            shortfiltername = (filtername.split("."))[-1]
+            className = shortfiltername[0].upper() + shortfiltername[1:] + "Filter"
+            f = getattr(module, className)(**filterargs)
+        else:
+            f = getFilterClass(filtername)(**filterargs)
+    except Exception as e:
+        raise ValueError("Couldn't find filter %s: %s" % (filtername, e))
+    f(ufo)
+
+logger.info("Written on %s" % args.output)
+ufo.save(args.output)

--- a/Lib/ufo2ft/filters/__main__.py
+++ b/Lib/ufo2ft/filters/__main__.py
@@ -1,10 +1,9 @@
 import argparse
-import importlib
 import logging
 
 from fontTools.misc.cliTools import makeOutputFileName
 
-from ufo2ft.filters import getFilterClass, loadFilterFromString, logger
+from ufo2ft.filters import loadFilterFromString, logger
 
 try:
     import ufoLib2

--- a/Lib/ufo2ft/filters/__main__.py
+++ b/Lib/ufo2ft/filters/__main__.py
@@ -4,7 +4,7 @@ import logging
 
 from fontTools.misc.cliTools import makeOutputFileName
 
-from ufo2ft.filters import getFilterClass, logger, loadFilterFromString
+from ufo2ft.filters import getFilterClass, loadFilterFromString, logger
 
 try:
     import ufoLib2


### PR DESCRIPTION
This allows the user to run a ufo2ft filter (or filters) on a UFO file and save it from the command line. This is helpful for testing and debugging filters, as well as doing general filter-based operations on fonts.

```
$ python3 -m ufo2ft.filters ../glyphsLib/master_ufo/Nunito-M1000.ufo glyphsLib.filters.eraseOpenCorners
INFO:ufo2ft.filters:Running EraseOpenCornersFilter on Nunito-M1000
INFO:ufo2ft.filters:Written on ../glyphsLib/master_ufo/Nunito-M1000#1.ufo
```