### PR TITLE
Check for FontParts font object

### DIFF
--- a/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
@@ -123,6 +123,8 @@ class BaseFeatureWriter:
         were generated.
         """
         self.setContext(font, feaFile, compiler=compiler)
+        if hasattr(font, "naked"):
+            font = font.naked()
         try:
             if self.shouldContinue():
                 return self._write()


### PR DESCRIPTION
FontParts has `naked` method that returns the lower level Defcon object in FontShell. This change would allow the passing of FontParts FontShell font objects to ufo2ft without issues like #443.