### PR TITLE
Add GDEF feature writer

### DIFF
--- a/Lib/ufo2ft/constants.py
+++ b/Lib/ufo2ft/constants.py
@@ -19,3 +19,5 @@ KEEP_GLYPH_NAMES = UFO2FT_PREFIX + "keepGlyphNames"
 COLOR_LAYERS_KEY = UFO2FT_PREFIX + "colorLayers"
 COLOR_PALETTES_KEY = UFO2FT_PREFIX + "colorPalettes"
 COLOR_LAYER_MAPPING_KEY = UFO2FT_PREFIX + "colorLayerMapping"
+
+OPENTYPE_CATEGORIES_KEY = "public.openTypeCategories"

--- a/Lib/ufo2ft/featureCompiler.py
+++ b/Lib/ufo2ft/featureCompiler.py
@@ -12,6 +12,7 @@ from fontTools.feaLib.parser import Parser
 
 from ufo2ft.constants import MTI_FEATURES_PREFIX
 from ufo2ft.featureWriters import (
+    GdefFeatureWriter,
     KernFeatureWriter,
     MarkFeatureWriter,
     ast,
@@ -147,7 +148,7 @@ class FeatureCompiler(BaseFeatureCompiler):
     Feature File stored in the UFO, using fontTools.feaLib as compiler.
     """
 
-    defaultFeatureWriters = [KernFeatureWriter, MarkFeatureWriter]
+    defaultFeatureWriters = [KernFeatureWriter, MarkFeatureWriter, GdefFeatureWriter]
 
     def __init__(self, ufo, ttFont=None, glyphSet=None, featureWriters=None, **kwargs):
         """

--- a/Lib/ufo2ft/featureWriters/__init__.py
+++ b/Lib/ufo2ft/featureWriters/__init__.py
@@ -6,11 +6,13 @@ from ufo2ft.constants import FEATURE_WRITERS_KEY
 from ufo2ft.util import _loadPluginFromString
 
 from .baseFeatureWriter import BaseFeatureWriter
+from .gdefFeatureWriter import GdefFeatureWriter
 from .kernFeatureWriter import KernFeatureWriter
 from .markFeatureWriter import MarkFeatureWriter
 
 __all__ = [
     "BaseFeatureWriter",
+    "GdefFeatureWriter",
     "KernFeatureWriter",
     "MarkFeatureWriter",
     "loadFeatureWriters",

--- a/Lib/ufo2ft/featureWriters/ast.py
+++ b/Lib/ufo2ft/featureWriters/ast.py
@@ -64,6 +64,12 @@ def findCommentPattern(feaFile, pattern):
                 yield (statement,)
 
 
+def findTable(feaLib, tag):
+    for statement in feaLib.statements:
+        if isinstance(statement, ast.TableBlock) and statement.name == tag:
+            return statement
+
+
 def iterClassDefinitions(feaFile, featureTag=None):
     if featureTag is None:
         # start from top-level class definitions

--- a/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
@@ -328,6 +328,13 @@ class BaseFeatureWriter:
                 marks.add(glyphName)
             elif category == "component":
                 components.add(glyphName)
+            else:
+                self.log.warning(
+                    f"The '{OPENTYPE_CATEGORIES_KEY}' value of {glyphName} in "
+                    f"{font.info.familyName} {font.info.styleName} is '{category}' "
+                    "when it should be 'unassigned', 'base', 'ligature', 'mark' "
+                    "or 'component'."
+                )
         return ast._GDEFGlyphClasses(
             frozenset(bases),
             frozenset(ligatures),

--- a/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
@@ -306,3 +306,24 @@ class BaseFeatureWriter:
         if compiler and not hasattr(compiler, "_gsub"):
             compiler._gsub = gsub
         return gsub
+
+    def compileGDEF(self):
+        """Compile a temporary GDEF table from the current feature file."""
+        from ufo2ft.util import compileGDEF
+
+        compiler = self.context.compiler
+        if compiler is not None:
+            # The result is cached in the compiler instance, so if another
+            # writer requests one it is not compiled again.
+            if hasattr(compiler, "_gdef"):
+                return compiler._gdef
+
+            glyphOrder = compiler.ttFont.getGlyphOrder()
+        else:
+            glyphOrder = sorted(self.context.font.keys())
+
+        gdef = compileGDEF(self.context.feaFile, glyphOrder)
+
+        if compiler:
+            compiler._gdef = gdef
+        return gdef

--- a/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
@@ -336,9 +336,10 @@ class BaseFeatureWriter:
         )
 
     def getGDEFGlyphClasses(self):
-        """Return GDEF GlyphClassDef base/ligature/mark/component glyphs,
-        None if no 'public.openTypeCategories' values are defined or if no GDEF table
-        is defined in the feature file.
+        """Return a tuple of GDEF GlyphClassDef base, ligature, mark, component
+        glyph names.
+        Sets are `None` if no 'public.openTypeCategories' values are defined or
+        if no GDEF table is defined in the feature file.
         """
         feaFile = self.context.feaFile
 

--- a/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
@@ -85,13 +85,15 @@ class BaseFeatureWriter:
         todo = set(self.features)
         insertComments = None
         if self.mode == "skip":
-            insertComments = self.collectInsertMarkers(
-                feaFile, self.insertFeatureMarker, todo
-            )
+            if self.insertFeatureMarker is not None:
+                insertComments = self.collectInsertMarkers(
+                    feaFile, self.insertFeatureMarker, todo
+                )
             # find existing feature blocks
             existing = ast.findFeatureTags(feaFile)
             # ignore features with insert marker
-            existing.difference_update(insertComments.keys())
+            if insertComments:
+                existing.difference_update(insertComments.keys())
             # remove existing feature without insert marker from todo list
             todo.difference_update(existing)
 

--- a/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
@@ -316,7 +316,7 @@ class BaseFeatureWriter:
         openTypeCategories = font.lib.get(OPENTYPE_CATEGORIES_KEY, {})
 
         for glyphName, category in openTypeCategories.items():
-            if category is None or category == "unassigned":
+            if category == "unassigned":
                 continue
             elif category == "base":
                 bases.add(glyphName)
@@ -334,7 +334,7 @@ class BaseFeatureWriter:
         )
 
     def getGDEFGlyphClasses(self):
-        """Return GDEF GlyphClassDef base/ligature/mark/component glyphs, from
+        """Return GDEF GlyphClassDef base/ligature/mark/component glyphs,
         None if no 'public.openTypeCategories' values are defined or if no GDEF table
         is defined in the feature file.
         """

--- a/Lib/ufo2ft/featureWriters/gdefFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/gdefFeatureWriter.py
@@ -1,0 +1,160 @@
+from ufo2ft.constants import OPENTYPE_CATEGORIES_KEY
+from ufo2ft.featureWriters import BaseFeatureWriter, ast
+
+
+class GdefFeatureWriter(BaseFeatureWriter):
+    """Generates a GDEF table based on OpenType Category and glyph anchors.
+
+    There are a few use cases:
+        1. There is no GDEF data in the UFO.
+        2. There is some GDEF data in the UFO, in the UFO lib
+           'public.openTypeCategories' or with ligature caret anchors
+           'caret_<number>'.
+        3. There is a GDEF in the features, and some GDEF data.
+
+    This first generates a GDEF from the features, from the GDEF table
+    definition if present or from the lookups.
+    Then it updates the GDEF with the public.openTypeCategories and the
+    ligature anchors for glyphs that are not already in GlyphClassDefs or
+    do not have ligature carets.
+    """
+
+    tableTag = "GDEF"
+
+    def setContext(self, font, feaFile, compiler=None):
+        ctx = super().setContext(font, feaFile, compiler=compiler)
+        ctx.orderedGlyphSet = self.getOrderedGlyphSet()
+        ctx.skipExportGlyphs = set(font.lib.get("public.skipExportGlyphs", []))
+
+        gdefFea = None
+        for statement in feaFile.statements:
+            if isinstance(statement, ast.TableBlock) and statement.name == "GDEF":
+                gdefFea = statement
+        if gdefFea:
+            ctx.gdefFea = gdefFea
+            ctx.gdefTable = self.compileGDEF()
+        else:
+            ctx.gdefFea = ctx.gdefTable = None
+
+        (
+            ctx.bases,
+            ctx.marks,
+            ctx.ligatures,
+            ctx.components,
+        ) = self._getGDEFGlyphClasses()
+
+        ctx.ligatureCarets = self._getLigatureCarets()
+        ctx.todo = [True]
+
+        return ctx
+
+    def _getGDEFGlyphClasses(self):
+        font = self.context.font
+        bases, ligatures, marks, components = set(), set(), set(), set()
+        gdefTable = self.context.gdefTable
+        if gdefTable:
+            classDefs = gdefTable.table.GlyphClassDef.classDefs
+        else:
+            classDefs = {}
+        openTypeCategories = font.lib.get(OPENTYPE_CATEGORIES_KEY, {})
+
+        for glyphName in self.context.orderedGlyphSet.keys():
+
+            classDef = classDefs.get(glyphName)
+            category = openTypeCategories.get(glyphName)
+
+            if classDef is None and category is None:
+                continue
+            if classDef == 1 or (classDef is None and category == "base"):
+                bases.add(glyphName)
+            elif classDef == 2 or (classDef is None and category == "ligature"):
+                ligatures.add(glyphName)
+            elif classDef == 3 or (classDef is None and category == "mark"):
+                marks.add(glyphName)
+            elif classDef == 4 or (classDef is None and category == "component"):
+                components.add(glyphName)
+
+        return (bases, ligatures, marks, components)
+
+    def _getLigatureCarets(self):
+        carets = dict()
+        if self.context.gdefTable:
+            ligCaretList = self.context.gdefTable.table.LigCaretList
+            for i, glyphName in enumerate(ligCaretList.Coverage.glyphs):
+                carets[glyphName] = [
+                    cv.Coordinate for cv in ligCaretList.LigGlyph[i].CaretValue
+                ]
+        for glyphName, glyph in self.context.orderedGlyphSet.items():
+            # skip glyphs that already have ligatureCarets defined inGDEF
+            if glyphName in carets:
+                continue
+
+            glyphCarets = set()
+            for anchor in glyph.anchors:
+                if (
+                    anchor.name
+                    and anchor.name.startswith("caret_")
+                    and anchor.x is not None
+                ):
+                    glyphCarets.add(round(anchor.x))
+                if (
+                    anchor.name
+                    and anchor.name.startswith("vcaret_")
+                    and anchor.y is not None
+                ):
+                    glyphCarets.add(round(anchor.y))
+
+            if glyphCarets:
+                carets[glyphName] = sorted(glyphCarets)
+
+        if self.context.gdefTable:
+            return {
+                glyphName: carets[glyphName]
+                for glyphName in self.context.orderedGlyphSet
+                if glyphName in carets
+            }
+        else:
+            return carets
+
+    def _sortedGlyphClass(self, glyphNames):
+        return sorted(n for n in self.context.orderedGlyphSet if n in glyphNames)
+
+    def _makeGDEF(self):
+        fea = ast.TableBlock("GDEF")
+
+        bases, ligatures, marks, components = (
+            self._sortedGlyphClass(self.context.bases),
+            self._sortedGlyphClass(self.context.ligatures),
+            self._sortedGlyphClass(self.context.marks),
+            self._sortedGlyphClass(self.context.components),
+        )
+        if bases or ligatures or marks or components:
+            glyphClassDefs = ast.GlyphClassDefStatement(
+                ast.GlyphClass(bases),
+                ast.GlyphClass(ligatures),
+                ast.GlyphClass(marks),
+                ast.GlyphClass(components),
+            )
+            fea.statements.append(glyphClassDefs)
+
+        if self.context.ligatureCarets:
+            ligatureCarets = [
+                ast.LigatureCaretByPosStatement(ast.GlyphName(glyphName), carets)
+                for glyphName, carets in self.context.ligatureCarets.items()
+            ]
+            fea.statements.extend(ligatureCarets)
+
+        if fea.statements:
+            return fea
+
+    def _write(self):
+        feaFile = self.context.feaFile
+        newGdef = self._makeGDEF()
+        if newGdef and self.context.gdefFea:
+            index = feaFile.statements.index(self.context.gdefFea)
+            del feaFile.statements[index]
+            feaFile.statements.insert(index, newGdef)
+            return True
+        elif newGdef:
+            feaFile.statements.append(newGdef)
+            return True

--- a/Lib/ufo2ft/featureWriters/gdefFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/gdefFeatureWriter.py
@@ -22,33 +22,27 @@ class GdefFeatureWriter(BaseFeatureWriter):
         if ctx.gdefTableBlock:
             for fea in ctx.gdefTableBlock.statements:
                 if isinstance(fea, ast.GlyphClassDefStatement):
-                    ctx.todo.remove("GlyphClassDefs")
+                    ctx.todo.discard("GlyphClassDefs")
                 elif isinstance(fea, ast.LigatureCaretByIndexStatement) or isinstance(
                     fea, ast.LigatureCaretByPosStatement
                 ):
-                    ctx.todo.remove("LigatureCarets")
+                    ctx.todo.discard("LigatureCarets")
+
+                if not ctx.todo:
+                    break
 
         ctx.orderedGlyphSet = self.getOrderedGlyphSet()
 
         if "GlyphClassDefs" in ctx.todo:
             ctx.openTypeCategories = self.getOpenTypeCategories()
+            if not any(ctx.openTypeCategories):
+                ctx.todo.remove("GlyphClassDefs")
         if "LigatureCarets" in ctx.todo:
             ctx.ligatureCarets = self._getLigatureCarets()
+            if not ctx.ligatureCarets:
+                ctx.todo.remove("LigatureCarets")
 
         return ctx
-
-    def shouldContinue(self):
-        todo = self.context.todo
-        if not todo:
-            return super().shouldContinue()
-
-        if "LigatureCarets" in todo and not self.context.ligatureCarets:
-            todo.remove("LigatureCarets")
-
-        if "GlyphClassDefs" in todo and not any(self.context.openTypeCategories):
-            todo.remove("GlyphClassDefs")
-
-        return super().shouldContinue()
 
     def _getLigatureCarets(self):
         carets = dict()
@@ -77,10 +71,12 @@ class GdefFeatureWriter(BaseFeatureWriter):
     def _sortedGlyphClass(self, glyphNames):
         return sorted(n for n in self.context.orderedGlyphSet if n in glyphNames)
 
-    def _makeGDEF(self):
+    def _write(self):
+        feaFile = self.context.feaFile
         gdefTableBlock = self.context.gdefTableBlock
         if not gdefTableBlock:
             gdefTableBlock = ast.TableBlock("GDEF")
+            feaFile.statements.append(gdefTableBlock)
 
         if "GlyphClassDefs" in self.context.todo:
             categories = self.context.openTypeCategories
@@ -98,14 +94,5 @@ class GdefFeatureWriter(BaseFeatureWriter):
                 for glyphName, carets in self.context.ligatureCarets.items()
             ]
             gdefTableBlock.statements.extend(ligatureCarets)
-
-        return gdefTableBlock
-
-    def _write(self):
-        feaFile = self.context.feaFile
-        if self.context.gdefTableBlock:
-            self._makeGDEF()
-        else:
-            feaFile.statements.append(self._makeGDEF())
 
         return True

--- a/Lib/ufo2ft/featureWriters/gdefFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/gdefFeatureWriter.py
@@ -5,18 +5,11 @@ from ufo2ft.featureWriters import BaseFeatureWriter, ast
 class GdefFeatureWriter(BaseFeatureWriter):
     """Generates a GDEF table based on OpenType Category and glyph anchors.
 
-    There are a few use cases:
-        1. There is no GDEF data in the UFO.
-        2. There is some GDEF data in the UFO, in the UFO lib
-           'public.openTypeCategories' or with ligature caret anchors
-           'caret_<number>'.
-        3. There is a GDEF in the features, and some GDEF data.
+    It skips generating the GDEF if a GDEF is defined in the features.
 
-    This first generates a GDEF from the features, from the GDEF table
-    definition if present or from the lookups.
-    Then it updates the GDEF with the public.openTypeCategories and the
-    ligature anchors for glyphs that are not already in GlyphClassDefs or
-    do not have ligature carets.
+    It uses the 'public.openTypeCategories' values to create the GDEF ClassDefs
+    and the ligature caret anchors to create the GDEF ligature carets.
+
     """
 
     tableTag = "GDEF"
@@ -24,108 +17,60 @@ class GdefFeatureWriter(BaseFeatureWriter):
     def setContext(self, font, feaFile, compiler=None):
         ctx = super().setContext(font, feaFile, compiler=compiler)
         ctx.orderedGlyphSet = self.getOrderedGlyphSet()
-        ctx.skipExportGlyphs = set(font.lib.get("public.skipExportGlyphs", []))
-
-        gdefFea = None
-        for statement in feaFile.statements:
-            if isinstance(statement, ast.TableBlock) and statement.name == "GDEF":
-                gdefFea = statement
-                break
-
-        if gdefFea:
-            ctx.gdefFea = gdefFea
-            ctx.gdefTable = self.compileGDEF()
-        else:
-            ctx.gdefFea = ctx.gdefTable = None
-
+        ctx.ligatureCarets = self._getLigatureCarets()
         (
             ctx.bases,
-            ctx.marks,
             ctx.ligatures,
+            ctx.marks,
             ctx.components,
-        ) = self.getGDEFGlyphClasses(feaFile)
-
-        ctx.ligatureCarets = self._getLigatureCarets()
-        ctx.todo = [True]
+        ) = self._getOpenTypeCategories()
+        ctx.todo = {"GlyphClassDefs", "LigatureCarets"}
 
         return ctx
 
-    def getGDEFGlyphClasses(self, feaFile):
-        """Return GDEF GlyphClassDef base/mark/ligature/component glyphs, or
-        None if no GDEF table is defined in the feature file or generated from
-        the lookups in the feature file.
+    def shouldContinue(self):
+        # skip if a GDEF is in the features
+        for statement in self.context.feaFile.statements:
+            if isinstance(statement, ast.TableBlock) and statement.name == "GDEF":
+                self.context.todo.clear()
+                return super().shouldContinue()
+
+        if not self.context.ligatureCarets:
+            self.context.todo.remove("LigatureCarets")
+
+        if not self.context.font.lib.get(OPENTYPE_CATEGORIES_KEY):
+            self.context.todo.remove("GlyphClassDefs")
+
+        return super().shouldContinue()
+
+    def _getOpenTypeCategories(self):
+        """Return GDEF GlyphClassDef base/ligature/mark/component glyphs based
+        on 'public.openTypeCategories' values.
         """
         font = self.context.font
-        bases, ligatures, marks, components = set(), set(), set(), set()
-        gdefTable = self.context.gdefTable
-        if gdefTable:
-            classDefs = gdefTable.table.GlyphClassDef.classDefs
-        else:
-            classDefs = {}
+        bases, ligatures, marks, components = list(), list(), list(), list()
         openTypeCategories = font.lib.get(OPENTYPE_CATEGORIES_KEY, {})
 
         for glyphName in self.context.orderedGlyphSet.keys():
             category = openTypeCategories.get(glyphName)
-            classDef = classDefs.get(glyphName)
 
-            if classDef is None and category is None:
+            if category is None or category == "unassigned":
                 continue
-            elif classDef == 1 or (classDef is None and category == "base"):
-                bases.add(glyphName)
-            elif classDef == 2 or (classDef is None and category == "ligature"):
-                ligatures.add(glyphName)
-            elif classDef == 3 or (classDef is None and category == "mark"):
-                marks.add(glyphName)
-            elif classDef == 4 or (classDef is None and category == "component"):
-                components.add(glyphName)
+            elif category == "base":
+                bases.append(glyphName)
+            elif category == "ligature":
+                ligatures.append(glyphName)
+            elif category == "mark":
+                marks.append(glyphName)
+            elif category == "component":
+                components.append(glyphName)
 
-        return (
-            frozenset(bases),
-            frozenset(ligatures),
-            frozenset(marks),
-            frozenset(components),
-        )
-
-    def compileGDEF(self):
-        """Compile a temporary GDEF table from the current feature file
-        or from a given GDEF Table Block object."""
-        from ufo2ft.util import compileGDEF
-
-        compiler = self.context.compiler
-        if compiler is not None:
-            # The result is cached in the compiler instance, so if another
-            # writer requests one it is not compiled again.
-            if hasattr(compiler, "_gdef"):
-                return compiler._gdef
-
-            glyphOrder = compiler.ttFont.getGlyphOrder()
-        else:
-            glyphOrder = sorted(self.context.font.keys())
-
-        if self.context.gdefFea:
-            feaFile = ast.FeatureFile()
-            feaFile.statements.append(self.context.gdefFea)
-            gdef = compileGDEF(feaFile, glyphOrder)
-        else:
-            gdef = compileGDEF(self.context.feaFile, glyphOrder)
-
-        if compiler:
-            compiler._gdef = gdef
-        return gdef
+        return (bases, ligatures, marks, components)
 
     def _getLigatureCarets(self):
         carets = dict()
-        if self.context.gdefTable:
-            ligCaretList = self.context.gdefTable.table.LigCaretList
-            for i, glyphName in enumerate(ligCaretList.Coverage.glyphs):
-                carets[glyphName] = [
-                    cv.Coordinate for cv in ligCaretList.LigGlyph[i].CaretValue
-                ]
-        for glyphName, glyph in self.context.orderedGlyphSet.items():
-            # skip glyphs that already have ligatureCarets defined inGDEF
-            if glyphName in carets:
-                continue
 
+        for glyphName, glyph in self.context.orderedGlyphSet.items():
             glyphCarets = set()
             for anchor in glyph.anchors:
                 if (
@@ -134,7 +79,7 @@ class GdefFeatureWriter(BaseFeatureWriter):
                     and anchor.x is not None
                 ):
                     glyphCarets.add(round(anchor.x))
-                if (
+                elif (
                     anchor.name
                     and anchor.name.startswith("vcaret_")
                     and anchor.y is not None
@@ -144,54 +89,31 @@ class GdefFeatureWriter(BaseFeatureWriter):
             if glyphCarets:
                 carets[glyphName] = sorted(glyphCarets)
 
-        if self.context.gdefTable:
-            return {
-                glyphName: carets[glyphName]
-                for glyphName in self.context.orderedGlyphSet
-                if glyphName in carets
-            }
-        else:
-            return carets
-
-    def _sortedGlyphClass(self, glyphNames):
-        return sorted(n for n in self.context.orderedGlyphSet if n in glyphNames)
+        return carets
 
     def _makeGDEF(self):
         fea = ast.TableBlock("GDEF")
 
-        bases, ligatures, marks, components = (
-            self._sortedGlyphClass(self.context.bases),
-            self._sortedGlyphClass(self.context.ligatures),
-            self._sortedGlyphClass(self.context.marks),
-            self._sortedGlyphClass(self.context.components),
-        )
-        if bases or ligatures or marks or components:
+        if "GlyphClassDefs" in self.context.todo:
             glyphClassDefs = ast.GlyphClassDefStatement(
-                ast.GlyphClass(bases),
-                ast.GlyphClass(ligatures),
-                ast.GlyphClass(marks),
-                ast.GlyphClass(components),
+                ast.GlyphClass(self.context.bases),
+                ast.GlyphClass(self.context.marks),
+                ast.GlyphClass(self.context.ligatures),
+                ast.GlyphClass(self.context.components),
             )
             fea.statements.append(glyphClassDefs)
 
-        if self.context.ligatureCarets:
+        if "LigatureCarets" in self.context.todo:
             ligatureCarets = [
                 ast.LigatureCaretByPosStatement(ast.GlyphName(glyphName), carets)
                 for glyphName, carets in self.context.ligatureCarets.items()
             ]
             fea.statements.extend(ligatureCarets)
 
-        if fea.statements:
-            return fea
+        return fea
 
     def _write(self):
         feaFile = self.context.feaFile
-        newGdef = self._makeGDEF()
-        if newGdef and self.context.gdefFea:
-            index = feaFile.statements.index(self.context.gdefFea)
-            del feaFile.statements[index]
-            feaFile.statements.insert(index, newGdef)
-            return True
-        elif newGdef:
-            feaFile.statements.append(newGdef)
-            return True
+        feaFile.statements.append(self._makeGDEF())
+
+        return True

--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
@@ -203,7 +203,7 @@ class KernFeatureWriter(BaseFeatureWriter):
 
     def setContext(self, font, feaFile, compiler=None):
         ctx = super().setContext(font, feaFile, compiler=compiler)
-        ctx.gdefClasses = self.getGDEFGlyphClasses(feaFile)
+        ctx.gdefClasses = self.getGDEFGlyphClasses()
         ctx.kerning = self.getKerningData(font, feaFile, self.getOrderedGlyphSet())
 
         feaScripts = ast.getScriptLanguageSystems(feaFile)

--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
@@ -203,7 +203,7 @@ class KernFeatureWriter(BaseFeatureWriter):
 
     def setContext(self, font, feaFile, compiler=None):
         ctx = super().setContext(font, feaFile, compiler=compiler)
-        ctx.gdefClasses = ast.getGDEFGlyphClasses(feaFile)
+        ctx.gdefClasses = self.getGDEFGlyphClasses(feaFile)
         ctx.kerning = self.getKerningData(font, feaFile, self.getOrderedGlyphSet())
 
         feaScripts = ast.getScriptLanguageSystems(feaFile)

--- a/Lib/ufo2ft/featureWriters/markFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/markFeatureWriter.py
@@ -296,7 +296,7 @@ class MarkFeatureWriter(BaseFeatureWriter):
 
     def setContext(self, font, feaFile, compiler=None):
         ctx = super().setContext(font, feaFile, compiler=compiler)
-        ctx.gdefClasses = ast.getGDEFGlyphClasses(feaFile)
+        ctx.gdefClasses = self.getGDEFGlyphClasses(feaFile)
         ctx.anchorLists = self._getAnchorLists()
         ctx.anchorPairs = self._getAnchorPairs()
 

--- a/Lib/ufo2ft/featureWriters/markFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/markFeatureWriter.py
@@ -296,7 +296,7 @@ class MarkFeatureWriter(BaseFeatureWriter):
 
     def setContext(self, font, feaFile, compiler=None):
         ctx = super().setContext(font, feaFile, compiler=compiler)
-        ctx.gdefClasses = self.getGDEFGlyphClasses(feaFile)
+        ctx.gdefClasses = self.getGDEFGlyphClasses()
         ctx.anchorLists = self._getAnchorLists()
         ctx.anchorPairs = self._getAnchorPairs()
 

--- a/Lib/ufo2ft/util.py
+++ b/Lib/ufo2ft/util.py
@@ -228,6 +228,26 @@ def compileGSUB(featureFile, glyphOrder):
     return font.get("GSUB")
 
 
+def compileGDEF(featureFile, glyphOrder):
+    """Compile and return a GDEF table from `featureFile` (feaLib FeatureFile),
+    using the given `glyphOrder` (list of glyph names).
+    """
+    from fontTools.feaLib.ast import TableBlock
+
+    font = ttLib.TTFont()
+    font.setGlyphOrder(glyphOrder)
+    gdefDefined = False
+    for statement in featureFile.statements:
+        if isinstance(statement, TableBlock) and statement.name == "GDEF":
+            gdefDefined = True
+
+    if not gdefDefined:
+        addOpenTypeFeatures(font, featureFile, tables={"GDEF", "GPOS", "GSUB"})
+    else:
+        addOpenTypeFeatures(font, featureFile, tables={"GDEF"})
+    return font.get("GDEF")
+
+
 def closeGlyphsOverGSUB(gsub, glyphs):
     """Use the FontTools subsetter to perform a closure over the GSUB table
     given the initial `glyphs` (set of glyph names, str). Update the set

--- a/tests/featureWriters/gdefFeatureWriter_test.py
+++ b/tests/featureWriters/gdefFeatureWriter_test.py
@@ -1,0 +1,174 @@
+from textwrap import dedent
+
+import pytest
+
+from ufo2ft.featureCompiler import parseLayoutFeatures
+from ufo2ft.featureWriters import GdefFeatureWriter
+
+from . import FeatureWriterTest
+
+
+@pytest.fixture
+def testufo(FontClass):
+    ufo = FontClass()
+    ufo.newGlyph("a")
+    ufo.newGlyph("f")
+    ufo.newGlyph("f.component")
+    ufo.newGlyph("i")
+    liga = ufo.newGlyph("f_f_i")
+    liga.appendAnchor({"name": "caret_2", "x": 400, "y": 0})
+    liga.appendAnchor({"name": "caret_1", "x": 200, "y": 0})
+    liga = ufo.newGlyph("f_i")
+    liga.appendAnchor({"name": "caret_", "x": 200, "y": 0})
+    ufo.newGlyph("acutecomb")
+    ufo.newGlyph("tildecomb")
+
+    ufo.lib["public.glyphOrder"] = [
+        "a",
+        "f",
+        "f.component",
+        "i",
+        "f_f_i",
+        "f_i",
+        "acutecomb",
+        "tildecomb",
+    ]
+    return ufo
+
+
+class GdefFeatureWriterTest(FeatureWriterTest):
+
+    FeatureWriter = GdefFeatureWriter
+
+    @classmethod
+    def writeGDEF(cls, ufo, **kwargs):
+        writer = cls.FeatureWriter(**kwargs)
+        feaFile = parseLayoutFeatures(ufo)
+        if writer.write(ufo, feaFile):
+            return feaFile
+
+    def test_no_GDEF_no_openTypeCategories_in_font(self, testufo):
+        newFea = self.writeGDEF(testufo)
+        assert str(newFea) == dedent(
+            """\
+            table GDEF {
+                LigatureCaretByPos f_f_i 200 400;
+                LigatureCaretByPos f_i 200;
+            } GDEF;
+            """
+        )
+
+    def test_GDEF_in_font(self, testufo):
+        testufo.features.text = dedent(
+            """\
+            table GDEF {
+                GlyphClassDef [a], [], [acutecomb], [];
+                LigatureCaretByPos f_i 300;
+            } GDEF;
+            """
+        )
+        newFea = self.writeGDEF(testufo)
+        assert str(newFea) == dedent(
+            """\
+            table GDEF {
+                GlyphClassDef [a], [], [acutecomb], [];
+                LigatureCaretByPos f_f_i 200 400;
+                LigatureCaretByPos f_i 300;
+            } GDEF;
+            """
+        )
+
+    def test_openTypeCategories_in_font(self, testufo):
+        testufo.lib["public.openTypeCategories"] = {
+            "a": "base",
+            "f.component": "component",
+            "f_i": "ligature",
+            "acutecomb": "mark",
+        }
+        newFea = self.writeGDEF(testufo)
+        assert str(newFea) == dedent(
+            """\
+            table GDEF {
+                GlyphClassDef [a], [f_i], [acutecomb], [f.component];
+                LigatureCaretByPos f_f_i 200 400;
+                LigatureCaretByPos f_i 200;
+            } GDEF;
+            """
+        )
+
+    def test_GDEF_and_openTypeCategories_in_font(self, testufo):
+        testufo.lib["public.openTypeCategories"] = {
+            "a": "base",
+            "f.component": "component",
+            "f_i": "ligature",
+            "acutecomb": "mark",
+        }
+        testufo.features.text = dedent(
+            """\
+            table GDEF {
+                 GlyphClassDef [i], [], [tildecomb], [];
+                 LigatureCaretByPos f_i 100;
+             } GDEF;
+             """
+        )
+        newFea = self.writeGDEF(testufo)
+        assert str(newFea) == dedent(
+            """\
+            table GDEF {
+                GlyphClassDef [a i], [f_i], [acutecomb tildecomb], [f.component];
+                LigatureCaretByPos f_f_i 200 400;
+                LigatureCaretByPos f_i 100;
+            } GDEF;
+            """
+        )
+
+    def test_mark_and_openTypeCategories_in_font(self, testufo):
+        testufo.lib["public.openTypeCategories"] = {
+            "a": "base",
+            "f.component": "component",
+            "f_f_i": "base",
+            "f_i": "ligature",
+            "acutecomb": "mark",
+            "tildecomb": "component",
+        }
+        testufo.features.text = old = dedent(
+            """\
+            feature mark {
+                markClass tildecomb <anchor 0 500> @TOP_MARKS;
+                pos base a <anchor 250 500> mark @TOP_MARKS;
+                pos base f <anchor 250 500> mark @TOP_MARKS;
+                pos ligature f_f_i <anchor 150 700> mark @TOP_MARKS
+                    ligComponent <anchor 450 700> mark @TOP_MARKS
+                    ligComponent <anchor 600 700> mark @TOP_MARKS;
+            } mark;
+            """
+        )
+        newFea = self.writeGDEF(testufo)
+        assert str(newFea) == old + "\n" + dedent(
+            """\
+            table GDEF {
+                GlyphClassDef [a f_f_i], [f_i], [acutecomb], [f.component tildecomb];
+                LigatureCaretByPos f_f_i 200 400;
+                LigatureCaretByPos f_i 200;
+            } GDEF;
+            """
+        )
+
+    def test_vertical_carets(self, testufo):
+        vliga = testufo.newGlyph("vi_li_ga")
+        vliga.appendAnchor({"name": "vcaret_1", "x": 0, "y": 100})
+        vliga.appendAnchor({"name": "vcaret_2", "x": 0, "y": 200})
+        vliga = testufo.newGlyph("vli_ga")
+        vliga.appendAnchor({"name": "vcaret_", "x": 0, "y": 100})
+
+        newFea = self.writeGDEF(testufo)
+        assert str(newFea) == dedent(
+            """\
+            table GDEF {
+                LigatureCaretByPos f_f_i 200 400;
+                LigatureCaretByPos f_i 200;
+                LigatureCaretByPos vi_li_ga 100 200;
+                LigatureCaretByPos vli_ga 100;
+            } GDEF;
+            """
+        )

--- a/tests/featureWriters/gdefFeatureWriter_test.py
+++ b/tests/featureWriters/gdefFeatureWriter_test.py
@@ -104,6 +104,55 @@ class GdefFeatureWriterTest(FeatureWriterTest):
         )
         assert self.writeGDEF(testufo) is None
 
+    def test_GDEF_LigatureCarets_and_openTypeCategories_in_font(self, testufo):
+        testufo.lib["public.openTypeCategories"] = {
+            "a": "base",
+            "f.component": "component",
+            "f_i": "ligature",
+            "acutecomb": "mark",
+        }
+        testufo.features.text = dedent(
+            """\
+            table GDEF {
+                LigatureCaretByPos f_i 100;
+            } GDEF;
+             """
+        )
+        newFea = self.writeGDEF(testufo)
+        assert str(newFea) == dedent(
+            """\
+            table GDEF {
+                LigatureCaretByPos f_i 100;
+                GlyphClassDef [a], [f_i], [acutecomb], [f.component];
+            } GDEF;
+            """
+        )
+
+    def test_GDEF_GlyphClassDef_and_carets_in_font(self, testufo):
+        testufo.lib["public.openTypeCategories"] = {
+            "a": "base",
+            "f.component": "component",
+            "f_i": "ligature",
+            "acutecomb": "mark",
+        }
+        testufo.features.text = dedent(
+            """\
+            table GDEF {
+                GlyphClassDef [], [], [acutecomb tildecomb], [];
+            } GDEF;
+             """
+        )
+        newFea = self.writeGDEF(testufo)
+        assert str(newFea) == dedent(
+            """\
+            table GDEF {
+                GlyphClassDef [], [], [acutecomb tildecomb], [];
+                LigatureCaretByPos f_f_i 200 400;
+                LigatureCaretByPos f_i 200;
+            } GDEF;
+            """
+        )
+
     def test_mark_and_openTypeCategories_in_font(self, testufo):
         testufo.lib["public.openTypeCategories"] = {
             "a": "base",

--- a/tests/featureWriters/gdefFeatureWriter_test.py
+++ b/tests/featureWriters/gdefFeatureWriter_test.py
@@ -1,3 +1,4 @@
+import logging
 from textwrap import dedent
 
 import pytest
@@ -203,3 +204,21 @@ class GdefFeatureWriterTest(FeatureWriterTest):
             } GDEF;
             """
         )
+
+    def test_getOpenTypeCategories_invalid(self, testufo, caplog):
+        caplog.set_level(logging.WARNING)
+        testufo.lib["public.openTypeCategories"] = {
+            "a": "base",
+            "f.component": "component",
+            "f_f_i": "base",
+            "f_i": "ligature",
+            "acutecomb": "mark",
+            "tildecomb": "components",
+        }
+        logger = "ufo2ft.featureWriters.gdefFeatureWriter.GdefFeatureWriter"
+        with caplog.at_level(logging.WARNING, logger=logger):
+            self.writeGDEF(testufo)
+
+        assert len(caplog.records) == 1
+        assert "The 'public.openTypeCategories' value of tildecomb in" in caplog.text
+        assert "is 'components' when it should be" in caplog.text

--- a/tests/featureWriters/gdefFeatureWriter_test.py
+++ b/tests/featureWriters/gdefFeatureWriter_test.py
@@ -67,16 +67,7 @@ class GdefFeatureWriterTest(FeatureWriterTest):
             } GDEF;
             """
         )
-        newFea = self.writeGDEF(testufo)
-        assert str(newFea) == dedent(
-            """\
-            table GDEF {
-                GlyphClassDef [a], [], [acutecomb], [];
-                LigatureCaretByPos f_f_i 200 400;
-                LigatureCaretByPos f_i 300;
-            } GDEF;
-            """
-        )
+        assert self.writeGDEF(testufo) is None
 
     def test_openTypeCategories_in_font(self, testufo):
         testufo.lib["public.openTypeCategories"] = {
@@ -111,16 +102,7 @@ class GdefFeatureWriterTest(FeatureWriterTest):
              } GDEF;
              """
         )
-        newFea = self.writeGDEF(testufo)
-        assert str(newFea) == dedent(
-            """\
-            table GDEF {
-                GlyphClassDef [a i], [f_i], [acutecomb tildecomb], [f.component];
-                LigatureCaretByPos f_f_i 200 400;
-                LigatureCaretByPos f_i 100;
-            } GDEF;
-            """
-        )
+        assert self.writeGDEF(testufo) is None
 
     def test_mark_and_openTypeCategories_in_font(self, testufo):
         testufo.lib["public.openTypeCategories"] = {

--- a/tests/featureWriters/markFeatureWriter_test.py
+++ b/tests/featureWriters/markFeatureWriter_test.py
@@ -955,10 +955,11 @@ class MarkFeatureWriterTest(FeatureWriterTest):
             {"name": "_top", "x": 0, "y": 0},
             {"name": "top", "x": 0, "y": 300},
         ]
+        # will be ignored because in GDEF table below
         testufo.lib["public.openTypeCategories"] = {
             "D": "base",
             "dotaccentcomb": "mark",
-            "tildecomb": "base",  # will be ignored because in GDEF table below
+            "tildecomb": "base",
         }
         testufo.features.text = dedent(
             """\
@@ -984,20 +985,13 @@ class MarkFeatureWriterTest(FeatureWriterTest):
 
         assert str(generated) == dedent(
             """\
-            markClass dotaccentcomb <anchor 0 0> @MC_center;
             markClass acutecomb <anchor 100 200> @MC_top;
-            markClass dotaccentcomb <anchor 0 0> @MC_top;
             markClass tildecomb <anchor 100 200> @MC_top;
 
             feature mark {
                 lookup mark2base {
-                    pos base D <anchor 320 360> mark @MC_center;
-                } mark2base;
-
-                lookup mark2base_1 {
-                    pos base D <anchor 300 700> mark @MC_top;
                     pos base a <anchor 100 200> mark @MC_top;
-                } mark2base_1;
+                } mark2base;
 
                 lookup mark2liga {
                     pos ligature f_i <anchor 100 500> mark @MC_top
@@ -1008,9 +1002,8 @@ class MarkFeatureWriterTest(FeatureWriterTest):
 
             feature mkmk {
                 lookup mark2mark_top {
-                    @MFS_mark2mark_top = [acutecomb dotaccentcomb tildecomb];
+                    @MFS_mark2mark_top = [acutecomb tildecomb];
                     lookupflag UseMarkFilteringSet @MFS_mark2mark_top;
-                    pos mark dotaccentcomb <anchor 0 300> mark @MC_top;
                     pos mark tildecomb <anchor 100 300> mark @MC_top;
                 } mark2mark_top;
 


### PR DESCRIPTION
Fixes #456.
This adds a GDEF feature writer to the default feature writers (kern feature writer, mark feature writer).


The GdefFeatureWriter first compiles the GDEF from the feature code (feaLib uses the GDEF table definition or builds it from lookups) and uses it to get Glyph Class Definitions (bases, ligatures, marks, components) and Ligature Carets.
It then updates the Glyph Class Definitions with the UFO lib "public.openTypeCategories" data, except for glyphs already defined, and updates the Ligature Carets with the UFO anchors with names starting with "caret_" and "vcaret_", except for glyphs with ligature carets already defined.