### PR TITLE
feature writers: more relaxed insertion marks

### DIFF
--- a/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 from ufo2ft.errors import InvalidFeaturesData
 from ufo2ft.featureWriters import ast
 
-INSERT_FEATURE_MARKER = r"\s*# Automatic Code"
+INSERT_FEATURE_MARKER = r"\s*# Automatic Code.*"
 
 
 class BaseFeatureWriter:

--- a/tests/featureWriters/kernFeatureWriter_test.py
+++ b/tests/featureWriters/kernFeatureWriter_test.py
@@ -282,6 +282,48 @@ class KernFeatureWriterTest(FeatureWriterTest):
             """
         )
 
+    def test_insert_comment_before_extended(self, FontClass):
+        ufo = FontClass()
+        for name in ("one", "four", "six", "seven"):
+            ufo.newGlyph(name)
+        existing = dedent(
+            """\
+            feature kern {
+                #
+                # Automatic Code End
+                #
+                pos one four' -50 six;
+            } kern;
+            """
+        )
+        ufo.features.text = existing
+        ufo.kerning.update({("seven", "six"): 25.0})
+
+        writer = KernFeatureWriter()
+        feaFile = parseLayoutFeatures(ufo)
+        assert writer.write(ufo, feaFile)
+
+        expected = dedent(
+            """\
+            lookup kern_ltr {
+                lookupflag IgnoreMarks;
+                pos seven six 25;
+            } kern_ltr;
+
+            feature kern {
+                lookup kern_ltr;
+            } kern;
+
+            feature kern {
+                #
+                #
+                pos one four' -50 six;
+            } kern;
+            """
+        )
+
+        assert str(feaFile).strip() == expected.strip()
+
     def test_insert_comment_after(self, FontClass):
         ufo = FontClass()
         for name in ("one", "four", "six", "seven"):


### PR DESCRIPTION
Ignore the rest of the line, to support `Automatic Code Start`/`Automatic Code End`, see: https://github.com/googlefonts/ufo2ft/issues/351#issuecomment-796598457