### PR TITLE
Preserve file name for debugging

### DIFF
--- a/Lib/ufo2ft/postProcessor.py
+++ b/Lib/ufo2ft/postProcessor.py
@@ -43,6 +43,7 @@ class PostProcessor:
         stream = BytesIO()
         otf.save(stream)
         stream.seek(0)
+        stream.name = ufo.path
         self.otf = TTFont(stream)
         self._postscriptNames = ufo.lib.get("public.postscriptNames")
 


### PR DESCRIPTION
When there are errors to do with a generated TTF, it's nice to have way to refer to what file the font came from even if it was never saved to disk. This will copy the UFO's filename into the TTFont object so that it can be used later.