### PR TITLE
setup.py: make cffsubr required and compreffor optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,12 +31,13 @@ setup(
     install_requires=[
         "fonttools[ufo]>=4.21.1",
         "cu2qu>=1.6.7",
-        "compreffor>=0.4.6",
+        "cffsubr>=0.2.8",
         "booleanOperations>=0.9.0",
     ],
     extras_require={
         "pathops": ["skia-pathops>=0.5.1"],
-        "cffsubr": ["cffsubr>=0.2.8"],
+        "cffsubr": [],  # keep empty for backward compat
+        "compreffor": ["compreffor>=0.4.6"],
     },
     python_requires=">=3.6",
     classifiers=[


### PR DESCRIPTION
In https://github.com/googlefonts/ufo2ft/pull/465, Khaled changed to use cffsubr by default for both CFF 1.0 and CFF2, so compreffor has now become optional. It makes sense to only install upon request, if 'compreffor' extra is used.
We keep an empty 'cffsubr' entry in extras_require to make sure that if one asks for 'ufo2ft[cffsubr]' it will continue to work as noop.