### PR TITLE
uvsDict uses list of tuples instead of dict

### DIFF
--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -517,15 +517,22 @@ class BaseOutlineCompiler:
             cmap14_0_5.platformID = 0
             cmap14_0_5.platEncID = 5
             cmap14_0_5.language = 0
+            cmap14_0_5.cmap = {}
             if nonBMP:
                 mapping = nonBMP
-            cmap14_0_5.uvsDict = {
-                uvs: {
-                    uv: None if glyphName == mapping[uv] else glyphName
-                    for (uv, glyphName) in glyphMapping.items()
-                }
-                for (uvs, glyphMapping) in uvsMapping.items()
-            }
+            uvsDict = dict()
+            # public.unicodeVariationSequences uses hex strings as keys and
+            # a dict of dicts, while cmap uses ints and a dict of tuples.
+            for hexvs, glyphMapping in uvsMapping.items():
+                uvsList = []
+                for hexvalue, glyphName in glyphMapping.items():
+                    value = int(hexvalue, 16)
+                    if glyphName == mapping[value]:
+                        uvsList.append((value, None))
+                    else:
+                        uvsList.append((value, glyphName))
+                uvsDict[int(hexvs, 16)] = uvsList
+            cmap14_0_5.uvsDict = uvsDict
             # update tables registry
             cmap.tables.append(cmap14_0_5)
 

--- a/tests/outlineCompiler_test.py
+++ b/tests/outlineCompiler_test.py
@@ -839,12 +839,11 @@ class CmapTest:
         }
 
         compiler = OutlineOTFCompiler(testufo)
-        otf = compiler.otf = TTFont(sfntVersion="OTTO")
-
-        compiler.setupTable_cmap()
+        otf = compiler.compile()
 
         assert "cmap" in otf
         cmap = otf["cmap"]
+        cmap.compile(otf)
         assert len(cmap.tables) == 5
         cmap4_0_3 = cmap.tables[0]
         cmap4_3_1 = cmap.tables[1]

--- a/tests/outlineCompiler_test.py
+++ b/tests/outlineCompiler_test.py
@@ -830,11 +830,11 @@ class CmapTest:
         u1F170.unicode = 0x1F170
         testufo.newGlyph("u1F170.text")
         testufo.lib["public.unicodeVariationSequences"] = {
-            0xFE0E: {
-                0x1F170: "u1F170.text",
+            "FE0E": {
+                "1F170": "u1F170.text",
             },
-            0xFE0F: {
-                0x1F170: "u1F170",
+            "FE0F": {
+                "1F170": "u1F170",
             },
         }
 
@@ -846,10 +846,10 @@ class CmapTest:
         cmap.compile(otf)
         assert len(cmap.tables) == 5
         cmap4_0_3 = cmap.tables[0]
-        cmap4_3_1 = cmap.tables[1]
-        cmap12_0_4 = cmap.tables[2]
-        cmap12_3_10 = cmap.tables[3]
-        cmap14_0_5 = cmap.tables[4]
+        cmap12_0_4 = cmap.tables[1]
+        cmap14_0_5 = cmap.tables[2]
+        cmap4_3_1 = cmap.tables[3]
+        cmap12_3_10 = cmap.tables[4]
 
         assert (cmap4_0_3.platformID, cmap4_0_3.platEncID) == (0, 3)
         assert (cmap4_3_1.platformID, cmap4_3_1.platEncID) == (3, 1)
@@ -871,8 +871,8 @@ class CmapTest:
         assert (cmap14_0_5.platformID, cmap14_0_5.platEncID) == (0, 5)
         assert cmap14_0_5.language == 0
         assert cmap14_0_5.uvsDict == {
-            0xFE0E: {0x1F170: "u1F170.text"},
-            0xFE0F: {0x1F170: None},
+            0xFE0E: [(0x1F170, "u1F170.text")],
+            0xFE0F: [(0x1F170, None)],
         }
 
 


### PR DESCRIPTION
[FontTools cmap](https://github.com/fonttools/fonttools/blob/3cfc87be711756baede6059d088cc2a2ebd20605/Lib/fontTools/ttLib/tables/_c_m_a_p.py#L1119) uses list of tuples instead of a dict for the UVS mapping.