### PR TITLE
[markFeatureWriter] skip ignorable anchors

### DIFF
--- a/Lib/ufo2ft/featureWriters/markFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/markFeatureWriter.py
@@ -326,6 +326,10 @@ class MarkFeatureWriter(BaseFeatureWriter):
                         "unnamed anchor discarded in glyph '%s'", glyphName
                     )
                     continue
+                # Skip anchors not meant for export
+                # See https://github.com/googlefonts/ufo2ft/issues/477
+                if anchorName.startswith(("#", "_#")):
+                    continue
                 if anchorName in anchorDict:
                     self.log.warning(
                         "duplicate anchor '%s' in glyph '%s'", anchorName, glyphName

--- a/tests/featureWriters/markFeatureWriter_test.py
+++ b/tests/featureWriters/markFeatureWriter_test.py
@@ -1238,6 +1238,44 @@ class MarkFeatureWriterTest(FeatureWriterTest):
             """
         )
 
+    def test_ignorableAnchors(self, testufo):
+        testufo["a"].appendAnchor({"name": "#top", "x": 123, "y": 456})
+        testufo["acutecomb"].appendAnchor({"name": "_#top", "x": 321, "y": 654})
+
+        generated = self.writeFeatures(testufo)
+
+        assert str(generated) == dedent(
+            """\
+            markClass acutecomb <anchor 100 200> @MC_top;
+            markClass tildecomb <anchor 100 200> @MC_top;
+
+            feature mark {
+                lookup mark2base {
+                    pos base a
+                        <anchor 100 200> mark @MC_top;
+                } mark2base;
+
+                lookup mark2liga {
+                    pos ligature f_i
+                            <anchor 100 500> mark @MC_top
+                        ligComponent
+                            <anchor 600 500> mark @MC_top;
+                } mark2liga;
+
+            } mark;
+
+            feature mkmk {
+                lookup mark2mark_top {
+                    @MFS_mark2mark_top = [acutecomb tildecomb];
+                    lookupflag UseMarkFilteringSet @MFS_mark2mark_top;
+                    pos mark tildecomb
+                        <anchor 100 300> mark @MC_top;
+                } mark2mark_top;
+
+            } mkmk;
+            """
+        )
+
 
 if __name__ == "__main__":
     import sys

--- a/tests/featureWriters/markFeatureWriter_test.py
+++ b/tests/featureWriters/markFeatureWriter_test.py
@@ -1220,7 +1220,7 @@ class MarkFeatureWriterTest(FeatureWriterTest):
 
     def test_skipExportGlyphs(self, testufo):
         testufo.lib["public.skipExportGlyphs"] = ["f_i", "tildecomb"]
-        testufo.glyphOrder = ["a", "f_i", "acutecomb", "tildcomb"]
+        testufo.glyphOrder = ["a", "f_i", "acutecomb", "tildecomb"]
 
         generated = self.writeFeatures(testufo)
 


### PR DESCRIPTION
Glyphs.app doesn't export anchors with names starting with "#" or "_#".

See also https://github.com/googlefonts/ufo2ft/issues/477