### PR TITLE
Maintain order of features when writing

### DIFF
--- a/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
@@ -157,9 +157,7 @@ class BaseFeatureWriter:
         """
 
         statements = feaFile.statements
-
-        for feature in features:
-            feature._inserted = False
+        inserted = {}
 
         # First handle those with a known location, i.e. insert markers
         insertComments = self.context.insertComments
@@ -211,21 +209,21 @@ class BaseFeatureWriter:
 
                 statements.insert(index, feature)
                 indices.append(index)
-                feature._inserted = True
+                inserted[id(feature)] = True
 
                 # Now walk feature list backwards and insert any dependent features
                 for i in range(ix - 1, -1, -1):
-                    if features[i]._inserted:
+                    if id(features[i]) in inserted:
                         break
                     # Insert this before the current one i.e. at same array index
                     statements.insert(index, features[i])
                     # All the indices recorded previously have now shifted up by one
                     indices = [index] + [j + 1 for j in indices]
-                    features[i]._inserted = True
+                    inserted[id(features[i])] = True
 
         # Finally, deal with any remaining features
         for feature in features:
-            if feature._inserted:
+            if id(feature) in inserted:
                 continue
             index = len(statements)
             statements.insert(index, feature)

--- a/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
@@ -214,13 +214,13 @@ class BaseFeatureWriter:
                 feature._inserted = True
 
                 # Now walk feature list backwards and insert any dependent features
-                for i in range(ix-1, -1, -1):
+                for i in range(ix - 1, -1, -1):
                     if features[i]._inserted:
                         break
                     # Insert this before the current one i.e. at same array index
                     statements.insert(index, features[i])
                     # All the indices recorded previously have now shifted up by one
-                    indices = [index] + [j+1 for j in indices]
+                    indices = [index] + [j + 1 for j in indices]
                     features[i]._inserted = True
 
         # Finally, deal with any remaining features

--- a/tests/featureWriters/markFeatureWriter_test.py
+++ b/tests/featureWriters/markFeatureWriter_test.py
@@ -573,6 +573,21 @@ class MarkFeatureWriterTest(FeatureWriterTest):
             markClass acutecomb <anchor 100 200> @MC_top;
             markClass tildecomb <anchor 100 200> @MC_top;
 
+            feature mark {
+                lookup mark2base {
+                    pos base a
+                        <anchor 100 200> mark @MC_top;
+                } mark2base;
+
+                lookup mark2liga {
+                    pos ligature f_i
+                            <anchor 100 500> mark @MC_top
+                        ligComponent
+                            <anchor 600 500> mark @MC_top;
+                } mark2liga;
+
+            } mark;
+
             feature mkmk {
                 lookup mark2mark_top {
                     @MFS_mark2mark_top = [acutecomb tildecomb];
@@ -591,21 +606,6 @@ class MarkFeatureWriterTest(FeatureWriterTest):
                 } move_acutecomb;
 
             } mkmk;
-
-            feature mark {
-                lookup mark2base {
-                    pos base a
-                        <anchor 100 200> mark @MC_top;
-                } mark2base;
-
-                lookup mark2liga {
-                    pos ligature f_i
-                            <anchor 100 500> mark @MC_top
-                        ligComponent
-                            <anchor 600 500> mark @MC_top;
-                } mark2liga;
-
-            } mark;
             """
         )
 


### PR DESCRIPTION
This fixes bug #506. When multiple features are being written to the feature file, this ensures that those which appear earlier in the `features` parameter are placed in the output file before those which have location markers.

i.e. given

```
feature mkmk {
   # Automatic Code
} mkmk;
```

and when writing two features `mark` and `mkmk`, this PR will first place the `mkmk` feature in the appropriate place and then go back and insert the `mark` feature just before it.