### PR TITLE
Add quantized mark feature writer

### DIFF
--- a/Lib/ufo2ft/featureWriters/quantizedMarkFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/quantizedMarkFeatureWriter.py
@@ -1,0 +1,41 @@
+from ufo2ft.featureWriters import MarkFeatureWriter
+import math
+from collections import OrderedDict
+
+def quantize(number, degree):
+    return degree * math.floor(number / degree)
+
+class QuantizedMarkFeatureWriter(MarkFeatureWriter):
+    options = dict(quantization=10)
+
+    def _getAnchorLists(self):
+        gdefClasses = self.context.gdefClasses
+        if gdefClasses.base is not None:
+            # only include the glyphs listed in the GDEF.GlyphClassDef groups
+            include = gdefClasses.base | gdefClasses.ligature | gdefClasses.mark
+        else:
+            # no GDEF table defined in feature file, include all glyphs
+            include = None
+        result = OrderedDict()
+        for glyphName, glyph in self.getOrderedGlyphSet().items():
+            if include is not None and glyphName not in include:
+                continue
+            anchorDict = OrderedDict()
+            for anchor in glyph.anchors:
+                anchorName = anchor.name
+                if not anchorName:
+                    self.log.warning(
+                        "unnamed anchor discarded in glyph '%s'", glyphName
+                    )
+                    continue
+                if anchorName in anchorDict:
+                    self.log.warning(
+                        "duplicate anchor '%s' in glyph '%s'", anchorName, glyphName
+                    )
+                x = quantize(anchor.x, self.options.quantization)
+                y = quantize(anchor.y, self.options.quantization)
+                a = self.NamedAnchor(name=anchorName, x=x, y=y)
+                anchorDict[anchorName] = a
+            if anchorDict:
+                result[glyphName] = list(anchorDict.values())
+        return result


### PR DESCRIPTION
So, this is something of an experimental one. It's the same as the normal mark feature writer, but before emitting the anchor positions it quantises them to a given number of units. When you add this to your feature writers lib key:

```xml
        <dict>
          <key>module</key>
          <string>ufo2ft.featureWriters.quantizedMarkFeatureWriter</string>
          <key>class</key>
          <string>QuantizedMarkFeatureWriter</string>
          <key>options</key>
          <dict>
            <key>mode</key>
            <string>skip</string>
            <key>quantization</key>
            <integer>10</integer>
          </dict>
        </dict>
```

the anchors will be quantised to the nearest ten units. In a large file, this allows "nearby" anchors to share anchor subtables, reducing the file size quite impressively, at a *slight* cost in visual fidelity.