### PR TITLE
Add translate anchors filter

### DIFF
--- a/Lib/ufo2ft/filters/__init__.py
+++ b/Lib/ufo2ft/filters/__init__.py
@@ -11,6 +11,7 @@ from .decomposeComponents import DecomposeComponentsFilter
 from .decomposeTransformedComponents import DecomposeTransformedComponentsFilter
 from .explodeColorLayerGlyphs import ExplodeColorLayerGlyphsFilter
 from .flattenComponents import FlattenComponentsFilter
+from .optimizeAnchors import OptimizeAnchorsFilter
 from .propagateAnchors import PropagateAnchorsFilter
 from .removeOverlaps import RemoveOverlapsFilter
 from .sortContours import SortContoursFilter
@@ -23,6 +24,7 @@ __all__ = [
     "DecomposeTransformedComponentsFilter",
     "ExplodeColorLayerGlyphsFilter",
     "FlattenComponentsFilter",
+    "OptimizeAnchorsFilter",
     "PropagateAnchorsFilter",
     "RemoveOverlapsFilter",
     "SortContoursFilter",

--- a/Lib/ufo2ft/filters/optimizeAnchors.py
+++ b/Lib/ufo2ft/filters/optimizeAnchors.py
@@ -1,0 +1,27 @@
+from ufo2ft.filters.transformations import TransformationsFilter
+from fontTools.misc.transform import Identity, Transform
+import logging
+
+log = logging.getLogger(__name__)
+
+
+class OptimizeAnchorsFilter(TransformationsFilter):
+    def set_context(self, font, glyphSet):
+        # Skip over transformations filter to base filter
+        return super(TransformationsFilter, self).set_context(font, glyphSet)
+
+    def filter(self, glyph):
+        if len(glyph.anchors) == 0 or any(
+            not (a.name.startswith("_")) for a in glyph.anchors
+        ):
+            # We're a base!
+            return False
+
+        # We are a mark glyph with (at least) one attachment point.
+        theanchor = glyph.anchors[0]
+        self.context.matrix = Identity.translate(-theanchor.x, -theanchor.y)
+        log.warn(
+            "Transforming glyph %s to zero anchor %s: %s"
+            % (glyph.name, theanchor.name, self.context.matrix)
+        )
+        return super().filter(glyph)


### PR DESCRIPTION
This is another experimental filter.

 Mark glyphs with anchor attachment points can kind of be positioned anywhere; they're going to be repositioned when the mark attachment is done. (There's an assumption here that you probably need to test - what if a mark glyph "gets through" without being attached to anything?)

Because of this, we can translate the whole glyph such that the position of their first attaching anchor (`_whatever`) is (0,0). If a lot of anchors end up being zero, they all end up sharing a very small Anchor subtable. This naturally leads to big space savings.