### PR TITLE
Drop unused dependency from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fonttools[lxml,ufo]==4.25.1
+fonttools[ufo]==4.25.1
 defcon==0.8.1
 cu2qu==1.6.7
 compreffor==0.5.1


### PR DESCRIPTION
The `requirements.txt` file appears to be out of sync with the dependencies listed in `setup.py`. A searched the project and I don't see any reference to this being used, but I could easily be wrong about that. If this fix is wrong then the correct thing to do with be to add the requirement to `setup.py` so they are at least in sync.