### PR TITLE
Refactor argument passing

### DIFF
--- a/Lib/ufo2ft/__init__.py
+++ b/Lib/ufo2ft/__init__.py
@@ -1,6 +1,5 @@
 import logging
 from enum import IntEnum
-from typing import Any, Optional
 
 from fontTools import varLib
 
@@ -19,8 +18,8 @@ from ufo2ft.preProcessor import (
 )
 from ufo2ft.util import (
     _getDefaultNotdefGlyph,
-    getDefaultMasterFont,
     filter_kwargs,
+    getDefaultMasterFont,
     inherit_dict,
 )
 

--- a/Lib/ufo2ft/__init__.py
+++ b/Lib/ufo2ft/__init__.py
@@ -17,7 +17,12 @@ from ufo2ft.preProcessor import (
     TTFInterpolatablePreProcessor,
     TTFPreProcessor,
 )
-from ufo2ft.util import _getDefaultNotdefGlyph, getDefaultMasterFont
+from ufo2ft.util import (
+    _getDefaultNotdefGlyph,
+    getDefaultMasterFont,
+    filter_kwargs,
+    inherit_dict,
+)
 
 try:
     from ._version import version as __version__
@@ -34,29 +39,36 @@ class CFFOptimization(IntEnum):
     SUBROUTINIZE = 2
 
 
-def compileOTF(
-    ufo,
-    preProcessorClass=OTFPreProcessor,
-    outlineCompilerClass=OutlineOTFCompiler,
+base_args = dict(
+    postProcessorClass=PostProcessor,
     featureCompilerClass=None,
     featureWriters=None,
     filters=None,
     glyphOrder=None,
     useProductionNames=None,
-    optimizeCFF=CFFOptimization.SUBROUTINIZE,
-    roundTolerance=None,
     removeOverlaps=False,
     overlapsBackend=None,
     inplace=False,
     layerName=None,
     skipExportGlyphs=None,
     debugFeatureFile=None,
+    notdefGlyph=None,
+)
+
+
+compileOTF_args = inherit_dict(
+    base_args,
+    preProcessorClass=OTFPreProcessor,
+    outlineCompilerClass=OutlineOTFCompiler,
+    optimizeCFF=CFFOptimization.SUBROUTINIZE,
+    roundTolerance=None,
     cffVersion=1,
     subroutinizer=None,
-    notdefGlyph=None,
-    postProcessorClass: Optional[Any] = PostProcessor,
     _tables=None,
-):
+)
+
+
+def compileOTF(ufo, **kwargs):
     """Create FontTools CFF font from a UFO.
 
     *removeOverlaps* performs a union operation on all the glyphs' contours.
@@ -116,80 +128,56 @@ def compileOTF(
       currently doesn't support it.
     """
     logger.info("Pre-processing glyphs")
+    kwargs = filter_kwargs(kwargs, compileOTF_args)
+    optimizeCFF = kwargs["optimizeCFF"]
 
-    if skipExportGlyphs is None:
-        skipExportGlyphs = ufo.lib.get("public.skipExportGlyphs", [])
+    if kwargs["skipExportGlyphs"] is None:
+        kwargs["skipExportGlyphs"] = ufo.lib.get("public.skipExportGlyphs", [])
 
-    preProcessor = preProcessorClass(
-        ufo,
-        inplace=inplace,
-        removeOverlaps=removeOverlaps,
-        overlapsBackend=overlapsBackend,
-        layerName=layerName,
-        skipExportGlyphs=skipExportGlyphs,
-        filters=filters,
-    )
+    preProcessor = kwargs["preProcessorClass"](ufo, **kwargs)
     glyphSet = preProcessor.process()
 
     logger.info("Building OpenType tables")
     optimizeCFF = CFFOptimization(optimizeCFF)
-    outlineCompiler = outlineCompilerClass(
+    outlineCompiler = kwargs["outlineCompilerClass"](
         ufo,
         glyphSet=glyphSet,
-        glyphOrder=glyphOrder,
-        notdefGlyph=notdefGlyph,
-        roundTolerance=roundTolerance,
-        optimizeCFF=optimizeCFF >= CFFOptimization.SPECIALIZE,
-        tables=_tables,
+        **inherit_dict(
+            kwargs,
+            optimizeCFF=optimizeCFF >= CFFOptimization.SPECIALIZE,
+            tables=kwargs["_tables"],
+        )
     )
     otf = outlineCompiler.compile()
 
     # Only the default layer is likely to have all glyphs used in feature code.
-    if layerName is None:
-        compileFeatures(
-            ufo,
-            otf,
-            glyphSet=glyphSet,
-            featureWriters=featureWriters,
-            featureCompilerClass=featureCompilerClass,
-            debugFeatureFile=debugFeatureFile,
-        )
+    if kwargs["layerName"] is None:
+        compileFeatures(ufo, otf, glyphSet=glyphSet, **kwargs)
 
-    if postProcessorClass is not None:
-        postProcessor = postProcessorClass(otf, ufo, glyphSet=glyphSet)
+    if kwargs["postProcessorClass"] is not None:
+        postProcessor = kwargs["postProcessorClass"](otf, ufo, glyphSet=glyphSet)
         otf = postProcessor.process(
-            useProductionNames,
-            optimizeCFF=optimizeCFF >= CFFOptimization.SUBROUTINIZE,
-            subroutinizer=subroutinizer,
-            cffVersion=cffVersion,
+            **inherit_dict(
+                kwargs, optimizeCFF=optimizeCFF >= CFFOptimization.SUBROUTINIZE,
+            )
         )
 
     return otf
 
 
-def compileTTF(
-    ufo,
+compileTTF_args = inherit_dict(
+    base_args,
     preProcessorClass=TTFPreProcessor,
     outlineCompilerClass=OutlineTTFCompiler,
-    featureCompilerClass=None,
-    featureWriters=None,
-    filters=None,
-    glyphOrder=None,
-    useProductionNames=None,
     convertCubics=True,
     cubicConversionError=None,
     reverseDirection=True,
     rememberCurveType=True,
-    removeOverlaps=False,
-    overlapsBackend=None,
     flattenComponents=False,
-    inplace=False,
-    layerName=None,
-    skipExportGlyphs=None,
-    debugFeatureFile=None,
-    notdefGlyph=None,
-    postProcessorClass: Optional[Any] = PostProcessor,
-):
+)
+
+
+def compileTTF(ufo, **kwargs):
     """Create FontTools TrueType font from a UFO.
 
     *removeOverlaps* performs a union operation on all the glyphs' contours.
@@ -211,69 +199,46 @@ def compileTTF(
     glyphs.
     """
     logger.info("Pre-processing glyphs")
+    kwargs = filter_kwargs(kwargs, compileTTF_args)
 
-    if skipExportGlyphs is None:
-        skipExportGlyphs = ufo.lib.get("public.skipExportGlyphs", [])
+    if kwargs["skipExportGlyphs"] is None:
+        kwargs["skipExportGlyphs"] = ufo.lib.get("public.skipExportGlyphs", [])
 
-    preProcessor = preProcessorClass(
-        ufo,
-        inplace=inplace,
-        removeOverlaps=removeOverlaps,
-        overlapsBackend=overlapsBackend,
-        flattenComponents=flattenComponents,
-        convertCubics=convertCubics,
-        conversionError=cubicConversionError,
-        reverseDirection=reverseDirection,
-        rememberCurveType=rememberCurveType,
-        layerName=layerName,
-        skipExportGlyphs=skipExportGlyphs,
-        filters=filters,
-    )
+    preProcessor = kwargs["preProcessorClass"](ufo, **kwargs)
     glyphSet = preProcessor.process()
 
     logger.info("Building OpenType tables")
-    outlineCompiler = outlineCompilerClass(
-        ufo, glyphSet=glyphSet, glyphOrder=glyphOrder, notdefGlyph=notdefGlyph
+    outlineCompiler = kwargs["outlineCompilerClass"](
+        ufo,
+        glyphSet=glyphSet,
+        glyphOrder=kwargs["glyphOrder"],
+        notdefGlyph=kwargs["notdefGlyph"],
     )
     otf = outlineCompiler.compile()
 
     # Only the default layer is likely to have all glyphs used in feature code.
-    if layerName is None:
-        compileFeatures(
-            ufo,
-            otf,
-            glyphSet=glyphSet,
-            featureWriters=featureWriters,
-            featureCompilerClass=featureCompilerClass,
-            debugFeatureFile=debugFeatureFile,
-        )
+    if kwargs["layerName"] is None:
+        compileFeatures(ufo, otf, glyphSet=glyphSet, **kwargs)
 
-    if postProcessorClass is not None:
-        postProcessor = postProcessorClass(otf, ufo, glyphSet=glyphSet)
-        otf = postProcessor.process(useProductionNames)
+    if kwargs["postProcessorClass"] is not None:
+        postProcessor = kwargs["postProcessorClass"](otf, ufo, glyphSet=glyphSet)
+        otf = postProcessor.process(kwargs["useProductionNames"])
 
     return otf
 
 
-def compileInterpolatableTTFs(
-    ufos,
+compileInterpolatableTTFs_args = inherit_dict(
+    base_args,
     preProcessorClass=TTFInterpolatablePreProcessor,
     outlineCompilerClass=OutlineTTFCompiler,
-    featureCompilerClass=None,
-    featureWriters=None,
-    glyphOrder=None,
-    useProductionNames=None,
     cubicConversionError=None,
-    filters=None,
     reverseDirection=True,
     flattenComponents=False,
-    inplace=False,
     layerNames=None,
-    skipExportGlyphs=None,
-    debugFeatureFile=None,
-    notdefGlyph=None,
-    postProcessorClass: Optional[Any] = PostProcessor,
-):
+)
+
+
+def compileInterpolatableTTFs(ufos, **kwargs):
     """Create FontTools TrueType fonts from a list of UFOs with interpolatable
     outlines. Cubic curves are converted compatibly to quadratic curves using
     the Cu2Qu conversion algorithm.
@@ -297,61 +262,48 @@ def compileInterpolatableTTFs(
     """
     from ufo2ft.util import _LazyFontName
 
-    if layerNames is None:
-        layerNames = [None] * len(ufos)
-    assert len(ufos) == len(layerNames)
+    kwargs = filter_kwargs(kwargs, compileInterpolatableTTFs_args)
 
-    if skipExportGlyphs is None:
-        skipExportGlyphs = set()
+    if kwargs["layerNames"] is None:
+        kwargs["layerNames"] = [None] * len(ufos)
+    assert len(ufos) == len(kwargs["layerNames"])
+
+    if kwargs["skipExportGlyphs"] is None:
+        kwargs["skipExportGlyphs"] = set()
         for ufo in ufos:
-            skipExportGlyphs.update(ufo.lib.get("public.skipExportGlyphs", []))
+            kwargs["skipExportGlyphs"].update(
+                ufo.lib.get("public.skipExportGlyphs", [])
+            )
 
     logger.info("Pre-processing glyphs")
-    preProcessor = preProcessorClass(
-        ufos,
-        inplace=inplace,
-        conversionError=cubicConversionError,
-        flattenComponents=flattenComponents,
-        reverseDirection=reverseDirection,
-        layerNames=layerNames,
-        skipExportGlyphs=skipExportGlyphs,
-        filters=filters,
-    )
+    preProcessor = kwargs["preProcessorClass"](ufos, **kwargs)
     glyphSets = preProcessor.process()
 
-    for ufo, glyphSet, layerName in zip(ufos, glyphSets, layerNames):
+    for ufo, glyphSet, layerName in zip(ufos, glyphSets, kwargs["layerNames"]):
         fontName = _LazyFontName(ufo)
         if layerName is not None:
             logger.info("Building OpenType tables for %s-%s", fontName, layerName)
         else:
             logger.info("Building OpenType tables for %s", fontName)
 
-        outlineCompiler = outlineCompilerClass(
+        outlineCompiler = kwargs["outlineCompilerClass"](
             ufo,
             glyphSet=glyphSet,
-            glyphOrder=glyphOrder,
-            notdefGlyph=notdefGlyph,
             tables=SPARSE_TTF_MASTER_TABLES if layerName else None,
+            **kwargs
         )
         ttf = outlineCompiler.compile()
 
         # Only the default layer is likely to have all glyphs used in feature
         # code.
         if layerName is None:
-            if debugFeatureFile:
-                debugFeatureFile.write("\n### %s ###\n" % fontName)
-            compileFeatures(
-                ufo,
-                ttf,
-                glyphSet=glyphSet,
-                featureWriters=featureWriters,
-                featureCompilerClass=featureCompilerClass,
-                debugFeatureFile=debugFeatureFile,
-            )
+            if kwargs["debugFeatureFile"]:
+                kwargs["debugFeatureFile"].write("\n### %s ###\n" % fontName)
+            compileFeatures(ufo, ttf, glyphSet=glyphSet, **kwargs)
 
-        if postProcessorClass is not None:
-            postProcessor = postProcessorClass(ttf, ufo, glyphSet=glyphSet)
-            ttf = postProcessor.process(useProductionNames)
+        if kwargs["postProcessorClass"] is not None:
+            postProcessor = kwargs["postProcessorClass"](ttf, ufo, glyphSet=glyphSet)
+            ttf = postProcessor.process(kwargs["useProductionNames"])
 
         if layerName is not None:
             # for sparse masters (i.e. containing only a subset of the glyphs), we
@@ -367,23 +319,7 @@ def compileInterpolatableTTFs(
         yield ttf
 
 
-def compileInterpolatableTTFsFromDS(
-    designSpaceDoc,
-    preProcessorClass=TTFInterpolatablePreProcessor,
-    outlineCompilerClass=OutlineTTFCompiler,
-    featureCompilerClass=None,
-    featureWriters=None,
-    glyphOrder=None,
-    useProductionNames=None,
-    cubicConversionError=None,
-    filters=None,
-    reverseDirection=True,
-    flattenComponents=False,
-    inplace=False,
-    debugFeatureFile=None,
-    notdefGlyph=None,
-    postProcessorClass: Optional[Any] = PostProcessor,
-):
+def compileInterpolatableTTFsFromDS(designSpaceDoc, **kwargs):
     """Create FontTools TrueType fonts from the DesignSpaceDocument UFO sources
     with interpolatable outlines. Cubic curves are converted compatibly to
     quadratic curves using the Cu2Qu conversion algorithm.
@@ -408,7 +344,8 @@ def compileInterpolatableTTFsFromDS(
     object will contain only a minimum set of tables ("head", "hmtx", "glyf", "loca",
     "maxp", "post" and "vmtx"), and no OpenType layout tables.
     """
-    ufos, layerNames = [], []
+    kwargs = filter_kwargs(kwargs, compileInterpolatableTTFs_args)
+    ufos, kwargs["layerNames"] = [], []
     for source in designSpaceDoc.sources:
         if source.font is None:
             raise AttributeError(
@@ -417,34 +354,16 @@ def compileInterpolatableTTFsFromDS(
             )
         ufos.append(source.font)
         # 'layerName' is None for the default layer
-        layerNames.append(source.layerName)
+        kwargs["layerNames"].append(source.layerName)
 
-    skipExportGlyphs = designSpaceDoc.lib.get("public.skipExportGlyphs", [])
+    kwargs["skipExportGlyphs"] = designSpaceDoc.lib.get("public.skipExportGlyphs", [])
 
-    if notdefGlyph is None:
-        notdefGlyph = _getDefaultNotdefGlyph(designSpaceDoc)
+    if kwargs["notdefGlyph"] is None:
+        kwargs["notdefGlyph"] = _getDefaultNotdefGlyph(designSpaceDoc)
 
-    ttfs = compileInterpolatableTTFs(
-        ufos,
-        preProcessorClass=preProcessorClass,
-        outlineCompilerClass=outlineCompilerClass,
-        featureCompilerClass=featureCompilerClass,
-        featureWriters=featureWriters,
-        glyphOrder=glyphOrder,
-        useProductionNames=useProductionNames,
-        cubicConversionError=cubicConversionError,
-        filters=filters,
-        reverseDirection=reverseDirection,
-        flattenComponents=flattenComponents,
-        inplace=inplace,
-        layerNames=layerNames,
-        skipExportGlyphs=skipExportGlyphs,
-        debugFeatureFile=debugFeatureFile,
-        notdefGlyph=notdefGlyph,
-        postProcessorClass=postProcessorClass,
-    )
+    ttfs = compileInterpolatableTTFs(ufos, **kwargs)
 
-    if inplace:
+    if kwargs["inplace"]:
         result = designSpaceDoc
     else:
         # TODO try a more efficient copy method that doesn't involve (de)serializing
@@ -454,21 +373,17 @@ def compileInterpolatableTTFsFromDS(
     return result
 
 
-def compileInterpolatableOTFsFromDS(
-    designSpaceDoc,
+compileInterpolatableOTFs_args = inherit_dict(
+    base_args,
     preProcessorClass=OTFPreProcessor,
     outlineCompilerClass=OutlineOTFCompiler,
     featureCompilerClass=None,
-    featureWriters=None,
-    filters=None,
-    glyphOrder=None,
-    useProductionNames=None,
     roundTolerance=None,
-    inplace=False,
-    debugFeatureFile=None,
-    notdefGlyph=None,
-    postProcessorClass: Optional[Any] = PostProcessor,
-):
+    optimizeCFF=CFFOptimization.NONE,
+)
+
+
+def compileInterpolatableOTFsFromDS(designSpaceDoc, **kwargs):
     """Create FontTools CFF fonts from the DesignSpaceDocument UFO sources
     with interpolatable outlines.
 
@@ -495,6 +410,7 @@ def compileInterpolatableOTFsFromDS(
     object will contain only a minimum set of tables ("head", "hmtx", "CFF ", "maxp",
     "vmtx" and "VORG"), and no OpenType layout tables.
     """
+    kwargs = filter_kwargs(kwargs, compileInterpolatableOTFs_args)
     for source in designSpaceDoc.sources:
         if source.font is None:
             raise AttributeError(
@@ -502,38 +418,28 @@ def compileInterpolatableOTFsFromDS(
                 % getattr(source, "name", "<Unknown>")
             )
 
-    skipExportGlyphs = designSpaceDoc.lib.get("public.skipExportGlyphs", [])
+    kwargs["skipExportGlyphs"] = designSpaceDoc.lib.get("public.skipExportGlyphs", [])
 
-    if notdefGlyph is None:
-        notdefGlyph = _getDefaultNotdefGlyph(designSpaceDoc)
+    if kwargs["notdefGlyph"] is None:
+        kwargs["notdefGlyph"] = _getDefaultNotdefGlyph(designSpaceDoc)
 
     otfs = []
     for source in designSpaceDoc.sources:
         otfs.append(
             compileOTF(
                 ufo=source.font,
-                layerName=source.layerName,
-                preProcessorClass=preProcessorClass,
-                outlineCompilerClass=outlineCompilerClass,
-                featureCompilerClass=featureCompilerClass,
-                featureWriters=featureWriters,
-                glyphOrder=glyphOrder,
-                useProductionNames=useProductionNames,
-                optimizeCFF=CFFOptimization.NONE,
-                roundTolerance=roundTolerance,
-                filters=filters,
-                removeOverlaps=False,
-                overlapsBackend=None,
-                inplace=inplace,
-                skipExportGlyphs=skipExportGlyphs,
-                debugFeatureFile=debugFeatureFile,
-                notdefGlyph=notdefGlyph,
-                _tables=SPARSE_OTF_MASTER_TABLES if source.layerName else None,
-                postProcessorClass=postProcessorClass,
+                **inherit_dict(
+                    kwargs,
+                    layerName=source.layerName,
+                    removeOverlaps=False,
+                    overlapsBackend=None,
+                    optimizeCFF=CFFOptimization.NONE,
+                    _tables=SPARSE_OTF_MASTER_TABLES if source.layerName else None,
+                )
             )
         )
 
-    if inplace:
+    if kwargs["inplace"]:
         result = designSpaceDoc
     else:
         # TODO try a more efficient copy method that doesn't involve (de)serializing
@@ -552,6 +458,7 @@ def compileFeatures(
     featureWriters=None,
     featureCompilerClass=None,
     debugFeatureFile=None,
+    **kwargs
 ):
     """Compile OpenType Layout features from `ufo` into FontTools OTL tables.
     If `ttFont` is None, a new TTFont object is created containing the new
@@ -590,25 +497,17 @@ def compileFeatures(
     return otFont
 
 
-def compileVariableTTF(
-    designSpaceDoc,
+compileVariableTTF_args = inherit_dict(
+    base_args,
     preProcessorClass=TTFInterpolatablePreProcessor,
     outlineCompilerClass=OutlineTTFCompiler,
-    featureCompilerClass=None,
-    featureWriters=None,
-    glyphOrder=None,
-    useProductionNames=None,
-    cubicConversionError=None,
-    filters=None,
     reverseDirection=True,
     excludeVariationTables=(),
     optimizeGvar=True,
-    flattenComponents=False,
-    inplace=False,
-    debugFeatureFile=None,
-    notdefGlyph=None,
-    postProcessorClass: Optional[Any] = PostProcessor,
-):
+)
+
+
+def compileVariableTTF(designSpaceDoc, **kwargs):
     """Create FontTools TrueType variable font from the DesignSpaceDocument UFO sources
     with interpolatable outlines, using fontTools.varLib.build.
 
@@ -622,57 +521,45 @@ def compileVariableTTF(
 
     Returns a new variable TTFont object.
     """
+    kwargs = filter_kwargs(kwargs, compileVariableTTF_args)
     baseUfo = getDefaultMasterFont(designSpaceDoc)
 
     ttfDesignSpace = compileInterpolatableTTFsFromDS(
         designSpaceDoc,
-        preProcessorClass=preProcessorClass,
-        outlineCompilerClass=outlineCompilerClass,
-        featureCompilerClass=featureCompilerClass,
-        featureWriters=featureWriters,
-        glyphOrder=glyphOrder,
-        useProductionNames=False,  # will rename glyphs after varfont is built
-        cubicConversionError=cubicConversionError,
-        filters=filters,
-        reverseDirection=reverseDirection,
-        flattenComponents=flattenComponents,
-        inplace=inplace,
-        debugFeatureFile=debugFeatureFile,
-        notdefGlyph=notdefGlyph,
-        # No need to post-process intermediate fonts.
-        postProcessorClass=None,
+        **inherit_dict(
+            kwargs,
+            useProductionNames=False,  # will rename glyphs after varfont is built
+            # No need to post-process intermediate fonts.
+            postProcessorClass=None,
+        )
     )
 
     logger.info("Building variable TTF font")
 
     varfont = varLib.build(
-        ttfDesignSpace, exclude=excludeVariationTables, optimize=optimizeGvar
+        ttfDesignSpace,
+        exclude=kwargs["excludeVariationTables"],
+        optimize=kwargs["optimizeGvar"],
     )[0]
 
-    if postProcessorClass is not None:
-        postProcessor = postProcessorClass(varfont, baseUfo)
-        varfont = postProcessor.process(useProductionNames)
+    if kwargs["postProcessorClass"] is not None:
+        postProcessor = kwargs["postProcessorClass"](varfont, baseUfo)
+        varfont = postProcessor.process(**kwargs)
 
     return varfont
 
 
-def compileVariableCFF2(
-    designSpaceDoc,
+compileVariableCFF2_args = inherit_dict(
+    base_args,
     preProcessorClass=OTFPreProcessor,
     outlineCompilerClass=OutlineOTFCompiler,
-    featureCompilerClass=None,
-    featureWriters=None,
-    glyphOrder=None,
-    useProductionNames=None,
     roundTolerance=None,
-    filters=None,
     excludeVariationTables=(),
-    inplace=False,
-    debugFeatureFile=None,
     optimizeCFF=CFFOptimization.SPECIALIZE,
-    notdefGlyph=None,
-    postProcessorClass: Optional[Any] = PostProcessor,
-):
+)
+
+
+def compileVariableCFF2(designSpaceDoc, **kwargs):
     """Create FontTools CFF2 variable font from the DesignSpaceDocument UFO sources
     with interpolatable outlines, using fontTools.varLib.build.
 
@@ -691,42 +578,37 @@ def compileVariableCFF2(
 
     Returns a new variable TTFont object.
     """
+    kwargs = filter_kwargs(kwargs, compileVariableCFF2_args)
     baseUfo = getDefaultMasterFont(designSpaceDoc)
 
     otfDesignSpace = compileInterpolatableOTFsFromDS(
         designSpaceDoc,
-        preProcessorClass=preProcessorClass,
-        outlineCompilerClass=outlineCompilerClass,
-        featureCompilerClass=featureCompilerClass,
-        featureWriters=featureWriters,
-        filters=filters,
-        glyphOrder=glyphOrder,
-        useProductionNames=False,  # will rename glyphs after varfont is built
-        roundTolerance=roundTolerance,
-        inplace=inplace,
-        debugFeatureFile=debugFeatureFile,
-        notdefGlyph=notdefGlyph,
-        # No need to post-process intermediate fonts.
-        postProcessorClass=None,
+        **inherit_dict(
+            kwargs,
+            useProductionNames=False,  # will rename glyphs after varfont is built
+            # No need to post-process intermediate fonts.
+            postProcessorClass=None,
+        )
     )
 
     logger.info("Building variable CFF2 font")
 
-    optimizeCFF = CFFOptimization(optimizeCFF)
+    optimizeCFF = CFFOptimization(kwargs["optimizeCFF"])
 
     varfont = varLib.build(
         otfDesignSpace,
-        exclude=excludeVariationTables,
+        exclude=kwargs["excludeVariationTables"],
         # NOTE optimize=False won't change anything until this PR is merged
         # https://github.com/fonttools/fonttools/pull/1979
         optimize=optimizeCFF >= CFFOptimization.SPECIALIZE,
     )[0]
 
-    if postProcessorClass is not None:
-        postProcessor = postProcessorClass(varfont, baseUfo)
+    if kwargs["postProcessorClass"] is not None:
+        postProcessor = kwargs["postProcessorClass"](varfont, baseUfo)
         varfont = postProcessor.process(
-            useProductionNames,
-            optimizeCFF=optimizeCFF >= CFFOptimization.SUBROUTINIZE,
+            **inherit_dict(
+                kwargs, optimizeCFF=optimizeCFF >= CFFOptimization.SUBROUTINIZE,
+            )
         )
 
     return varfont

--- a/Lib/ufo2ft/__init__.py
+++ b/Lib/ufo2ft/__init__.py
@@ -16,12 +16,7 @@ from ufo2ft.preProcessor import (
     TTFInterpolatablePreProcessor,
     TTFPreProcessor,
 )
-from ufo2ft.util import (
-    _getDefaultNotdefGlyph,
-    filter_kwargs,
-    getDefaultMasterFont,
-    inherit_dict,
-)
+from ufo2ft.util import _getDefaultNotdefGlyph, filter_kwargs, getDefaultMasterFont
 
 try:
     from ._version import version as __version__
@@ -58,7 +53,7 @@ def call_preprocessor(ufo_or_ufos, kwargs):
 
 def call_outline_compiler(ufo, glyphSet, kwargs, **overrides):
     outlineCompiler = kwargs["outlineCompilerClass"](
-        ufo, glyphSet=glyphSet, **inherit_dict(kwargs, **overrides)
+        ufo, glyphSet=glyphSet, **{**kwargs, **overrides}
     )
     return outlineCompiler.compile()
 
@@ -66,7 +61,7 @@ def call_outline_compiler(ufo, glyphSet, kwargs, **overrides):
 def call_postprocessor(otf, ufo, glyphSet, kwargs, **overrides):
     if kwargs["postProcessorClass"] is not None:
         postProcessor = kwargs["postProcessorClass"](otf, ufo, glyphSet=glyphSet)
-        otf = postProcessor.process(**inherit_dict(kwargs, **overrides))
+        otf = postProcessor.process(**{**kwargs, **overrides})
     return otf
 
 
@@ -86,16 +81,18 @@ base_args = dict(
     notdefGlyph=None,
 )
 
-compileOTF_args = inherit_dict(
-    base_args,
-    preProcessorClass=OTFPreProcessor,
-    outlineCompilerClass=OutlineOTFCompiler,
-    optimizeCFF=CFFOptimization.SUBROUTINIZE,
-    roundTolerance=None,
-    cffVersion=1,
-    subroutinizer=None,
-    _tables=None,
-)
+compileOTF_args = {
+    **base_args,
+    **dict(
+        preProcessorClass=OTFPreProcessor,
+        outlineCompilerClass=OutlineOTFCompiler,
+        optimizeCFF=CFFOptimization.SUBROUTINIZE,
+        roundTolerance=None,
+        cffVersion=1,
+        subroutinizer=None,
+        _tables=None,
+    ),
+}
 
 
 def compileOTF(ufo, **kwargs):
@@ -183,16 +180,18 @@ def compileOTF(ufo, **kwargs):
     )
 
 
-compileTTF_args = inherit_dict(
-    base_args,
-    preProcessorClass=TTFPreProcessor,
-    outlineCompilerClass=OutlineTTFCompiler,
-    convertCubics=True,
-    cubicConversionError=None,
-    reverseDirection=True,
-    rememberCurveType=True,
-    flattenComponents=False,
-)
+compileTTF_args = {
+    **base_args,
+    **dict(
+        preProcessorClass=TTFPreProcessor,
+        outlineCompilerClass=OutlineTTFCompiler,
+        convertCubics=True,
+        cubicConversionError=None,
+        reverseDirection=True,
+        rememberCurveType=True,
+        flattenComponents=False,
+    ),
+}
 
 
 def compileTTF(ufo, **kwargs):
@@ -230,15 +229,17 @@ def compileTTF(ufo, **kwargs):
     return call_postprocessor(otf, ufo, glyphSet, kwargs)
 
 
-compileInterpolatableTTFs_args = inherit_dict(
-    base_args,
-    preProcessorClass=TTFInterpolatablePreProcessor,
-    outlineCompilerClass=OutlineTTFCompiler,
-    cubicConversionError=None,
-    reverseDirection=True,
-    flattenComponents=False,
-    layerNames=None,
-)
+compileInterpolatableTTFs_args = {
+    **base_args,
+    **dict(
+        preProcessorClass=TTFInterpolatablePreProcessor,
+        outlineCompilerClass=OutlineTTFCompiler,
+        cubicConversionError=None,
+        reverseDirection=True,
+        flattenComponents=False,
+        layerNames=None,
+    ),
+}
 
 
 def compileInterpolatableTTFs(ufos, **kwargs):
@@ -364,14 +365,16 @@ def compileInterpolatableTTFsFromDS(designSpaceDoc, **kwargs):
     return result
 
 
-compileInterpolatableOTFs_args = inherit_dict(
-    base_args,
-    preProcessorClass=OTFPreProcessor,
-    outlineCompilerClass=OutlineOTFCompiler,
-    featureCompilerClass=None,
-    roundTolerance=None,
-    optimizeCFF=CFFOptimization.NONE,
-)
+compileInterpolatableOTFs_args = {
+    **base_args,
+    **dict(
+        preProcessorClass=OTFPreProcessor,
+        outlineCompilerClass=OutlineOTFCompiler,
+        featureCompilerClass=None,
+        roundTolerance=None,
+        optimizeCFF=CFFOptimization.NONE,
+    ),
+}
 
 
 def compileInterpolatableOTFsFromDS(designSpaceDoc, **kwargs):
@@ -419,14 +422,16 @@ def compileInterpolatableOTFsFromDS(designSpaceDoc, **kwargs):
         otfs.append(
             compileOTF(
                 ufo=source.font,
-                **inherit_dict(
-                    kwargs,
-                    layerName=source.layerName,
-                    removeOverlaps=False,
-                    overlapsBackend=None,
-                    optimizeCFF=CFFOptimization.NONE,
-                    _tables=SPARSE_OTF_MASTER_TABLES if source.layerName else None,
-                )
+                **{
+                    **kwargs,
+                    **dict(
+                        layerName=source.layerName,
+                        removeOverlaps=False,
+                        overlapsBackend=None,
+                        optimizeCFF=CFFOptimization.NONE,
+                        _tables=SPARSE_OTF_MASTER_TABLES if source.layerName else None,
+                    ),
+                }
             )
         )
 
@@ -488,14 +493,16 @@ def compileFeatures(
     return otFont
 
 
-compileVariableTTF_args = inherit_dict(
-    base_args,
-    preProcessorClass=TTFInterpolatablePreProcessor,
-    outlineCompilerClass=OutlineTTFCompiler,
-    reverseDirection=True,
-    excludeVariationTables=(),
-    optimizeGvar=True,
-)
+compileVariableTTF_args = {
+    **base_args,
+    **dict(
+        preProcessorClass=TTFInterpolatablePreProcessor,
+        outlineCompilerClass=OutlineTTFCompiler,
+        reverseDirection=True,
+        excludeVariationTables=(),
+        optimizeGvar=True,
+    ),
+}
 
 
 def compileVariableTTF(designSpaceDoc, **kwargs):
@@ -517,12 +524,14 @@ def compileVariableTTF(designSpaceDoc, **kwargs):
 
     ttfDesignSpace = compileInterpolatableTTFsFromDS(
         designSpaceDoc,
-        **inherit_dict(
-            kwargs,
-            useProductionNames=False,  # will rename glyphs after varfont is built
-            # No need to post-process intermediate fonts.
-            postProcessorClass=None,
-        )
+        **{
+            **kwargs,
+            **dict(
+                useProductionNames=False,  # will rename glyphs after varfont is built
+                # No need to post-process intermediate fonts.
+                postProcessorClass=None,
+            ),
+        }
     )
 
     logger.info("Building variable TTF font")
@@ -536,14 +545,16 @@ def compileVariableTTF(designSpaceDoc, **kwargs):
     return call_postprocessor(varfont, baseUfo, None, kwargs)
 
 
-compileVariableCFF2_args = inherit_dict(
-    base_args,
-    preProcessorClass=OTFPreProcessor,
-    outlineCompilerClass=OutlineOTFCompiler,
-    roundTolerance=None,
-    excludeVariationTables=(),
-    optimizeCFF=CFFOptimization.SPECIALIZE,
-)
+compileVariableCFF2_args = {
+    **base_args,
+    **dict(
+        preProcessorClass=OTFPreProcessor,
+        outlineCompilerClass=OutlineOTFCompiler,
+        roundTolerance=None,
+        excludeVariationTables=(),
+        optimizeCFF=CFFOptimization.SPECIALIZE,
+    ),
+}
 
 
 def compileVariableCFF2(designSpaceDoc, **kwargs):
@@ -570,12 +581,14 @@ def compileVariableCFF2(designSpaceDoc, **kwargs):
 
     otfDesignSpace = compileInterpolatableOTFsFromDS(
         designSpaceDoc,
-        **inherit_dict(
-            kwargs,
-            useProductionNames=False,  # will rename glyphs after varfont is built
-            # No need to post-process intermediate fonts.
-            postProcessorClass=None,
-        )
+        **{
+            **kwargs,
+            **dict(
+                useProductionNames=False,  # will rename glyphs after varfont is built
+                # No need to post-process intermediate fonts.
+                postProcessorClass=None,
+            ),
+        }
     )
 
     logger.info("Building variable CFF2 font")

--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -99,7 +99,7 @@ class BaseOutlineCompiler:
         glyphOrder=None,
         tables=None,
         notdefGlyph=None,
-        **kwargs
+        **kwargs,
     ):
         self.ufo = font
         # use the previously filtered glyphSet, if any
@@ -1088,7 +1088,7 @@ class OutlineOTFCompiler(BaseOutlineCompiler):
         notdefGlyph=None,
         roundTolerance=None,
         optimizeCFF=True,
-        **kwargs
+        **kwargs,
     ):
         if roundTolerance is not None:
             self.roundTolerance = float(roundTolerance)

--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -99,6 +99,7 @@ class BaseOutlineCompiler:
         glyphOrder=None,
         tables=None,
         notdefGlyph=None,
+        **kwargs
     ):
         self.ufo = font
         # use the previously filtered glyphSet, if any
@@ -1087,6 +1088,7 @@ class OutlineOTFCompiler(BaseOutlineCompiler):
         notdefGlyph=None,
         roundTolerance=None,
         optimizeCFF=True,
+        **kwargs
     ):
         if roundTolerance is not None:
             self.roundTolerance = float(roundTolerance)

--- a/Lib/ufo2ft/postProcessor.py
+++ b/Lib/ufo2ft/postProcessor.py
@@ -57,7 +57,7 @@ class PostProcessor:
         optimizeCFF=True,
         cffVersion=None,
         subroutinizer=None,
-        **kwargs
+        **kwargs,
     ):
         """
         useProductionNames (Optional[bool]):

--- a/Lib/ufo2ft/postProcessor.py
+++ b/Lib/ufo2ft/postProcessor.py
@@ -57,6 +57,7 @@ class PostProcessor:
         optimizeCFF=True,
         cffVersion=None,
         subroutinizer=None,
+        **kwargs
     ):
         """
         useProductionNames (Optional[bool]):

--- a/Lib/ufo2ft/preProcessor.py
+++ b/Lib/ufo2ft/preProcessor.py
@@ -6,7 +6,7 @@ from ufo2ft.constants import (
 from ufo2ft.filters import loadFilters
 from ufo2ft.filters.decomposeComponents import DecomposeComponentsFilter
 from ufo2ft.fontInfoData import getAttrWithFallback
-from ufo2ft.util import _GlyphSet
+from ufo2ft.util import _GlyphSet, filter_kwargs
 
 
 class BasePreProcessor:
@@ -29,6 +29,7 @@ class BasePreProcessor:
     These are specified in the UFO lib.plist under the private key
     "com.github.googlei18n.ufo2ft.filters".
     """
+    allowed_kwargs = {}
 
     def __init__(
         self,
@@ -45,7 +46,7 @@ class BasePreProcessor:
         self.glyphSet = _GlyphSet.from_layer(
             ufo, layerName, copy=not inplace, skipExportGlyphs=skipExportGlyphs
         )
-        self.defaultFilters = self.initDefaultFilters(**kwargs)
+        self.defaultFilters = self.initDefaultFilters(**filter_kwargs(kwargs, self.allowed_kwargs))
         if filters is None:
             self.preFilters, self.postFilters = loadFilters(ufo)
         else:
@@ -94,6 +95,7 @@ class OTFPreProcessor(BasePreProcessor):
     skia-pathops by setting ``overlapsBackend`` to the enum value
     ``RemoveOverlapsFilter.SKIA_PATHOPS``, or the string "pathops".
     """
+    allowed_kwargs = dict(removeOverlaps=False, overlapsBackend=None)
 
     def initDefaultFilters(self, removeOverlaps=False, overlapsBackend=None):
         filters = []
@@ -148,6 +150,13 @@ class TTFPreProcessor(OTFPreProcessor):
     preprocessor will not try to convert them again if the curve type is
     already set to "quadratic".
     """
+    allowed_kwargs = dict(removeOverlaps=False,
+        overlapsBackend=None,
+        flattenComponents=False,
+        convertCubics=True,
+        conversionError=None,
+        reverseDirection=True,
+        rememberCurveType=True,)
 
     def initDefaultFilters(
         self,
@@ -227,6 +236,7 @@ class TTFInterpolatablePreProcessor:
         layerNames=None,
         skipExportGlyphs=None,
         filters=None,
+        **kwargs
     ):
         from cu2qu.ufo import DEFAULT_MAX_ERR
 

--- a/Lib/ufo2ft/preProcessor.py
+++ b/Lib/ufo2ft/preProcessor.py
@@ -29,6 +29,7 @@ class BasePreProcessor:
     These are specified in the UFO lib.plist under the private key
     "com.github.googlei18n.ufo2ft.filters".
     """
+
     allowed_kwargs = {}
 
     def __init__(
@@ -46,7 +47,9 @@ class BasePreProcessor:
         self.glyphSet = _GlyphSet.from_layer(
             ufo, layerName, copy=not inplace, skipExportGlyphs=skipExportGlyphs
         )
-        self.defaultFilters = self.initDefaultFilters(**filter_kwargs(kwargs, self.allowed_kwargs))
+        self.defaultFilters = self.initDefaultFilters(
+            **filter_kwargs(kwargs, self.allowed_kwargs)
+        )
         if filters is None:
             self.preFilters, self.postFilters = loadFilters(ufo)
         else:
@@ -95,6 +98,7 @@ class OTFPreProcessor(BasePreProcessor):
     skia-pathops by setting ``overlapsBackend`` to the enum value
     ``RemoveOverlapsFilter.SKIA_PATHOPS``, or the string "pathops".
     """
+
     allowed_kwargs = dict(removeOverlaps=False, overlapsBackend=None)
 
     def initDefaultFilters(self, removeOverlaps=False, overlapsBackend=None):
@@ -150,13 +154,16 @@ class TTFPreProcessor(OTFPreProcessor):
     preprocessor will not try to convert them again if the curve type is
     already set to "quadratic".
     """
-    allowed_kwargs = dict(removeOverlaps=False,
+
+    allowed_kwargs = dict(
+        removeOverlaps=False,
         overlapsBackend=None,
         flattenComponents=False,
         convertCubics=True,
         conversionError=None,
         reverseDirection=True,
-        rememberCurveType=True,)
+        rememberCurveType=True,
+    )
 
     def initDefaultFilters(
         self,

--- a/Lib/ufo2ft/util.py
+++ b/Lib/ufo2ft/util.py
@@ -495,7 +495,7 @@ def inherit_dict(base_dict, **extra):
 
 def filter_kwargs(kwargs, defaults):
     new_kwargs = {}
-    for k,v in defaults.items():
+    for k, v in defaults.items():
         if k in kwargs:
             new_kwargs[k] = kwargs[k]
         else:

--- a/Lib/ufo2ft/util.py
+++ b/Lib/ufo2ft/util.py
@@ -487,3 +487,17 @@ def _loadPluginFromString(spec, moduleName, isValidFunc):
 def quantize(number, factor):
     """Round to a multiple of the given parameter"""
     return factor * otRound(number / factor)
+
+
+def inherit_dict(base_dict, **extra):
+    return {**base_dict, **extra}
+
+
+def filter_kwargs(kwargs, defaults):
+    new_kwargs = {}
+    for k,v in defaults.items():
+        if k in kwargs:
+            new_kwargs[k] = kwargs[k]
+        else:
+            new_kwargs[k] = v
+    return new_kwargs

--- a/Lib/ufo2ft/util.py
+++ b/Lib/ufo2ft/util.py
@@ -489,10 +489,6 @@ def quantize(number, factor):
     return factor * otRound(number / factor)
 
 
-def inherit_dict(base_dict, **extra):
-    return {**base_dict, **extra}
-
-
 def filter_kwargs(kwargs, defaults):
     new_kwargs = {}
     for k, v in defaults.items():


### PR DESCRIPTION
I've always found ufo2ft hard to follow, because *so much* of the main code is dedicated to passing arguments to pre/post/outline-processor classes. It's just a horrible mess of `foo=foo, bar=bar` which obscures the differences and commonalities between each function. And if a new argument needs adding, it has to get copy-and-pasted in [*everywhere*](https://github.com/googlefonts/ufo2ft/pull/438/files).

This PR refactors argument passing using the `**kwargs` dictionary. This also allows refactoring out common calls to the pre/post/outline-processors, which I've done.