### PR TITLE
Don't copy color layer unnecessarily

### DIFF
--- a/Lib/ufo2ft/filters/explodeColorLayerGlyphs.py
+++ b/Lib/ufo2ft/filters/explodeColorLayerGlyphs.py
@@ -69,9 +69,12 @@ class ExplodeColorLayerGlyphsFilter(BaseFilter):
         for layerName, colorID in colorLayerMapping:
             layerGlyphSet = self._getLayer(font, layerName)
             if glyph.name in layerGlyphSet:
-                layerGlyphName = self._copyGlyph(
-                    layerGlyphSet, glyphSet, glyph.name, layerName
-                )
+                if glyph == layerGlyphSet[glyph.name]:
+                    layerGlyphName = glyph.name
+                else:
+                    layerGlyphName = self._copyGlyph(
+                        layerGlyphSet, glyphSet, glyph.name, layerName
+                    )
                 layers.append((layerGlyphName, colorID))
         if layers:
             colorLayers[glyph.name] = layers


### PR DESCRIPTION
If the color layer uses the same UFO layer as the base one, then no need
to copy the layer at all. For example:

      <key>com.github.googlei18n.ufo2ft.colorLayerMapping</key>
      <array>
        <array>
          <string>public.default</string>
          <integer>0</integer>
        </array>
      </array>