### PR TITLE
[preProcessoer] Apply ExplodeColorLayerGlyphsFilter to interpolatable TTFs

### DIFF
--- a/Lib/ufo2ft/preProcessor.py
+++ b/Lib/ufo2ft/preProcessor.py
@@ -253,6 +253,11 @@ class TTFInterpolatablePreProcessor:
         self._reverseDirection = reverseDirection
         self._rememberCurveType = rememberCurveType
 
+        self.defaultFilters = []
+        for ufo in ufos:
+            self.defaultFilters.append([])
+            _init_explode_color_layer_glyphs_filter(ufo, self.defaultFilters[-1])
+
         self.preFilters, self.postFilters = [], []
         if filters is None:
             for ufo in ufos:
@@ -271,6 +276,11 @@ class TTFInterpolatablePreProcessor:
 
         # first apply all custom pre-filters
         for funcs, ufo, glyphSet in zip(self.preFilters, self.ufos, self.glyphSets):
+            for func in funcs:
+                func(ufo, glyphSet)
+
+        # then apply all default filters
+        for funcs, ufo, glyphSet in zip(self.defaultFilters, self.ufos, self.glyphSets):
             for func in funcs:
                 func(ufo, glyphSet)
 

--- a/tests/outlineCompiler_test.py
+++ b/tests/outlineCompiler_test.py
@@ -847,6 +847,40 @@ class ColrCpalTest:
         }
         assert layers == {"a": [("a.color1", 0), ("a.color2", 1)]}
 
+    def test_colr_cpal_otf(self, FontClass):
+        testufo = FontClass(getpath("ColorTest.ufo"))
+        assert "com.github.googlei18n.ufo2ft.colorLayerMapping" in testufo.lib
+        assert "com.github.googlei18n.ufo2ft.colorPalettes" in testufo.lib
+        result = compileOTF(testufo)
+        assert "COLR" in result
+        assert "CPAL" in result
+        layers = {
+            gn: [(layer.name, layer.colorID) for layer in layers]
+            for gn, layers in result["COLR"].ColorLayers.items()
+        }
+        assert layers == {
+            "a": [("a.color1", 0), ("a.color2", 1)],
+            "b": [("b.color1", 1), ("b.color2", 0)],
+            "c": [("c.color2", 1), ("c.color1", 0)],
+        }
+
+    def test_colr_cpal_interpolatable_ttf(self, FontClass):
+        testufo = FontClass(getpath("ColorTest.ufo"))
+        assert "com.github.googlei18n.ufo2ft.colorLayerMapping" in testufo.lib
+        assert "com.github.googlei18n.ufo2ft.colorPalettes" in testufo.lib
+        result = list(compileInterpolatableTTFs([testufo]))[0]
+        assert "COLR" in result
+        assert "CPAL" in result
+        layers = {
+            gn: [(layer.name, layer.colorID) for layer in layers]
+            for gn, layers in result["COLR"].ColorLayers.items()
+        }
+        assert layers == {
+            "a": [("a.color1", 0), ("a.color2", 1)],
+            "b": [("b.color1", 1), ("b.color2", 0)],
+            "c": [("c.color2", 1), ("c.color1", 0)],
+        }
+
 
 class CmapTest:
     def test_cmap_BMP(self, testufo):


### PR DESCRIPTION
Fixes https://github.com/googlefonts/ufo2ft/issues/537