### PR TITLE
drop Python 3.6, require >= 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
     strategy:
       matrix:
-        python-version: [3.6, 3.9]
+        python-version: [3.7, 3.9]
         platform: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "cffsubr": [],  # keep empty for backward compat
         "compreffor": ["compreffor>=0.4.6"],
     },
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Console",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint, py{36,39}-cov, htmlcov
+envlist = lint, py3{7,8,9}-cov, htmlcov
 skip_missing_interpreters = true
 
 [testenv]
@@ -11,7 +11,7 @@ download = true
 commands =
     # run the test suite against the package installed inside tox env.
     # We use parallel mode and then combine later so that coverage.py will take
-    # paths like .tox/py36/lib/python3.6/site-packages/fontTools and collapse
+    # paths like .tox/py37/lib/python3.7/site-packages/fontTools and collapse
     # them into Lib/fontTools.
     cov: coverage run --parallel-mode -m pytest {posargs}
     !cov: pytest {posargs}


### PR DESCRIPTION
3.10 is out next week, while 3.6 reaches end of life at the end of this year.
It's time to require 3.7 or greater, so we can finally use built-in dataclasses and more.

fontmake is also dropping 3.6 support: https://github.com/googlefonts/fontmake/pull/809