### PR TITLE
Use regular dictionaries instead of OrderedDict

### DIFF
--- a/Lib/ufo2ft/featureCompiler.py
+++ b/Lib/ufo2ft/featureCompiler.py
@@ -1,6 +1,5 @@
 import logging
 import os
-from collections import OrderedDict
 from inspect import isclass
 from io import StringIO
 from tempfile import NamedTemporaryFile
@@ -89,7 +88,7 @@ class BaseFeatureCompiler:
             assert set(glyphOrder) == set(glyphSet.keys())
         else:
             glyphSet = ufo
-        self.glyphSet = OrderedDict((gn, glyphSet[gn]) for gn in glyphOrder)
+        self.glyphSet = {gn: glyphSet[gn] for gn in glyphOrder}
 
     def setupFeatures(self):
         """Make the features source.

--- a/Lib/ufo2ft/featureWriters/ast.py
+++ b/Lib/ufo2ft/featureWriters/ast.py
@@ -22,7 +22,7 @@ def getScriptLanguageSystems(feaFile):
     """Return dictionary keyed by Unicode script code containing lists of
     (OT_SCRIPT_TAG, [OT_LANGUAGE_TAG, ...]) tuples (excluding "DFLT").
     """
-    languagesByScript = collections.OrderedDict()
+    languagesByScript = {}
     for ls in [
         st for st in feaFile.statements if isinstance(st, ast.LanguageSystemStatement)
     ]:
@@ -30,7 +30,7 @@ def getScriptLanguageSystems(feaFile):
             continue
         languagesByScript.setdefault(ls.script, []).append(ls.language)
 
-    langSysMap = collections.OrderedDict()
+    langSysMap = {}
     for script, languages in languagesByScript.items():
         sc = unicodedata.ot_tag_to_script(script)
         langSysMap.setdefault(sc, []).append((script, languages))

--- a/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
@@ -1,5 +1,5 @@
 import logging
-from collections import OrderedDict, namedtuple
+from collections import namedtuple
 from types import SimpleNamespace
 
 from ufo2ft.constants import OPENTYPE_CATEGORIES_KEY
@@ -285,7 +285,7 @@ class BaseFeatureWriter:
         return cmap
 
     def getOrderedGlyphSet(self):
-        """Return OrderedDict[glyphName, glyph] sorted by glyphOrder."""
+        """Return dict[glyphName, glyph] sorted by glyphOrder."""
         compiler = self.context.compiler
         if compiler is not None:
             return compiler.glyphSet
@@ -299,7 +299,7 @@ class BaseFeatureWriter:
             skipExportGlyphs=set(font.lib.get("public.skipExportGlyphs", [])),
         )
         glyphOrder = makeOfficialGlyphOrder(glyphSet, font.glyphOrder)
-        return OrderedDict((gn, glyphSet[gn]) for gn in glyphOrder)
+        return {gn: glyphSet[gn] for gn in glyphOrder}
 
     def compileGSUB(self):
         """Compile a temporary GSUB table from the current feature file."""

--- a/Lib/ufo2ft/featureWriters/markFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/markFeatureWriter.py
@@ -1,6 +1,6 @@
 import itertools
 import re
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 from functools import partial
 
 from fontTools.misc.fixedTools import otRound
@@ -319,11 +319,11 @@ class MarkFeatureWriter(BaseFeatureWriter):
         else:
             # no GDEF table defined in feature file, include all glyphs
             include = None
-        result = OrderedDict()
+        result = {}
         for glyphName, glyph in self.getOrderedGlyphSet().items():
             if include is not None and glyphName not in include:
                 continue
-            anchorDict = OrderedDict()
+            anchorDict = {}
             for anchor in glyph.anchors:
                 anchorName = anchor.name
                 if not anchorName:
@@ -385,7 +385,7 @@ class MarkFeatureWriter(BaseFeatureWriter):
             # Use all mark anchors. The rest of the algorithm will make sure
             # that the generated lookups will not have overlapping mark classes.
             for anchor in markAnchors:
-                group = groups.setdefault(anchor.name, OrderedDict())
+                group = groups.setdefault(anchor.name, {})
                 assert glyphName not in group
                 group[glyphName] = anchor
             markGlyphNames.add(glyphName)


### PR DESCRIPTION
Python 3.7+ dictionaries are guaranteed to keep insertion order.