### PR TITLE
Fix filter application using newer ufoLib2 dep

### DIFF
--- a/Lib/ufo2ft/filters/__main__.py
+++ b/Lib/ufo2ft/filters/__main__.py
@@ -42,7 +42,6 @@ if args.include:
     def include(g):
         return g.name in include_set
 
-
 elif args.exclude:
     exclude_set = set(args.exclude.split(","))
 

--- a/Lib/ufo2ft/filters/__main__.py
+++ b/Lib/ufo2ft/filters/__main__.py
@@ -8,7 +8,7 @@ from ufo2ft.filters import loadFilterFromString, logger
 try:
     import ufoLib2
 
-    loader = ufoLib2.Font
+    loader = ufoLib2.Font.open
 except ImportError:
     import defcon
 

--- a/tests/featureWriters/featureWriters_test.py
+++ b/tests/featureWriters/featureWriters_test.py
@@ -11,7 +11,6 @@ try:
     def readPlistFromString(s):
         return loads(s, fmt=FMT_XML)
 
-
 except ImportError:
     from plistlib import readPlistFromString
 


### PR DESCRIPTION
ufoLib2's `Font` now requires client code to use `open`.