### PR TITLE
Fix typo in USE_SCRIPTS list

### DIFF
--- a/Lib/ufo2ft/constants.py
+++ b/Lib/ufo2ft/constants.py
@@ -86,7 +86,7 @@ USE_SCRIPTS = [
     "Mand",  # Mandaic
     "Cakm",  # Chakma
     "Plrd",  # Miao
-    "Shar",  # Sharada
+    "Shrd",  # Sharada
     "Takr",  # Takri
     "Dupl",  # Duployan
     "Gran",  # Grantha


### PR DESCRIPTION
I don't know how I managed to typo the only entry in the list I actually wanted to make sure was there...