### PR TITLE
Consider scripts with no directionality to be LTR

### DIFF
--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
@@ -337,7 +337,10 @@ class KernFeatureWriter(BaseFeatureWriter):
         # direction (DFLT is excluded)
         scriptGroups = {}
         for scriptCode, scriptLangSys in feaScripts.items():
-            direction = unicodedata.script_horizontal_direction(scriptCode)
+            if scriptCode:
+                direction = unicodedata.script_horizontal_direction(scriptCode)
+            else:
+                direction = "LTR"
             if scriptCode in DIST_ENABLED_SCRIPTS:
                 tag = "dist"
             else:

--- a/tests/featureWriters/kernFeatureWriter_test.py
+++ b/tests/featureWriters/kernFeatureWriter_test.py
@@ -499,6 +499,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
             languagesystem arab URD;
             languagesystem deva dflt;
             languagesystem dev2 dflt;
+            languagesystem math dflt;
             """
         )
 
@@ -507,7 +508,10 @@ class KernFeatureWriterTest(FeatureWriterTest):
         scriptGroups = KernFeatureWriter._groupScriptsByTagAndDirection(scripts)
 
         assert "kern" in scriptGroups
-        assert list(scriptGroups["kern"]["LTR"]) == [("latn", ["dflt", "TRK "])]
+        assert list(scriptGroups["kern"]["LTR"]) == [
+            ("latn", ["dflt", "TRK "]),
+            ("math", ["dflt"])
+        ]
         assert list(scriptGroups["kern"]["RTL"]) == [("arab", ["dflt", "URD "])]
 
         assert "dist" in scriptGroups

--- a/tests/featureWriters/kernFeatureWriter_test.py
+++ b/tests/featureWriters/kernFeatureWriter_test.py
@@ -510,7 +510,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
         assert "kern" in scriptGroups
         assert list(scriptGroups["kern"]["LTR"]) == [
             ("latn", ["dflt", "TRK "]),
-            ("math", ["dflt"])
+            ("math", ["dflt"]),
         ]
         assert list(scriptGroups["kern"]["RTL"]) == [("arab", ["dflt", "URD "])]
 


### PR DESCRIPTION
- Test for #575
- Force scripts with no inherent directionality to LTR for kerning purposes; fixes #575
