### PR TITLE
Add dotted circle filter

### DIFF
--- a/Lib/ufo2ft/filters/__init__.py
+++ b/Lib/ufo2ft/filters/__init__.py
@@ -9,6 +9,7 @@ from .base import BaseFilter
 from .cubicToQuadratic import CubicToQuadraticFilter
 from .decomposeComponents import DecomposeComponentsFilter
 from .decomposeTransformedComponents import DecomposeTransformedComponentsFilter
+from .dottedCircleFilter import DottedCircleFilter
 from .explodeColorLayerGlyphs import ExplodeColorLayerGlyphsFilter
 from .flattenComponents import FlattenComponentsFilter
 from .propagateAnchors import PropagateAnchorsFilter
@@ -21,6 +22,7 @@ __all__ = [
     "CubicToQuadraticFilter",
     "DecomposeComponentsFilter",
     "DecomposeTransformedComponentsFilter",
+    "DottedCircleFilter",
     "ExplodeColorLayerGlyphsFilter",
     "FlattenComponentsFilter",
     "PropagateAnchorsFilter",

--- a/Lib/ufo2ft/filters/dottedCircleFilter.py
+++ b/Lib/ufo2ft/filters/dottedCircleFilter.py
@@ -116,6 +116,9 @@ class DottedCircleFilter(BaseFilter):
 
         added_anchors = self.check_and_add_anchors(dotted_circle)
 
+        if added_anchors:
+            self.ensure_base(dotted_circle)
+
         if added_glyph or added_anchors:
             return [dotted_circle]
         else:
@@ -206,8 +209,6 @@ class DottedCircleFilter(BaseFilter):
                 }
             )
             any_added = True
-        if any_added:
-            self.ensure_base(dotted_circle)
         return any_added
 
     # We have added some anchors to the dotted circle glyph. Now we need to

--- a/Lib/ufo2ft/filters/dottedCircleFilter.py
+++ b/Lib/ufo2ft/filters/dottedCircleFilter.py
@@ -59,13 +59,20 @@ class DottedCircleFilter(BaseFilter):
             glyphSet = _GlyphSet.from_layer(font)
 
         self.set_context(font, glyphSet)
+        added_glyph = False
         dotted_circle = self.check_dotted_circle()
         if not dotted_circle:
             dotted_circle = self.draw_dotted_circle(glyphSet)
+            added_glyph = True
 
-        return self.check_dotted_circle_anchors(dotted_circle)
+        added_anchors = self.check_and_add_anchors(dotted_circle)
 
-    def check_dotted_circle(self, glyphSet):
+        if added_glyph or added_anchors:
+            return [dotted_circle]
+        else:
+            return []
+
+    def check_dotted_circle(self):
         font = self.context.font
         dotted_circle = next((g for g in font if 0x25CC in g.unicodes), None)
         if dotted_circle:
@@ -95,7 +102,7 @@ class DottedCircleFilter(BaseFilter):
         glyphSet["uni25CC"] = glyph
         return "uni25CC"
 
-    def check_dotted_circle_anchors(self, dotted_circle):
+    def check_and_add_anchors(self, dotted_circle):
         font = self.context.font
         all_anchors = {}
         any_added = False
@@ -142,9 +149,7 @@ class DottedCircleFilter(BaseFilter):
             any_added = True
         if any_added:
             self.ensure_base(dotted_circle)
-            return dotted_circle
-        else:
-            return []
+        return any_added
 
     # We need to ensure the glyph is a base or else it won't feature
     # in the mark features writer. And if it previously had no anchors,

--- a/Lib/ufo2ft/filters/dottedCircleFilter.py
+++ b/Lib/ufo2ft/filters/dottedCircleFilter.py
@@ -137,7 +137,10 @@ class DottedCircleFilter(BaseFilter):
         dotted_circle = next((g.name for g in font if 0x25CC in g.unicodes), None)
         if dotted_circle:
             if dotted_circle not in glyphset:
-                logger.debug("Found dotted circle glyph %s in font but not in glyphset", dotted_circle)
+                logger.debug(
+                    "Found dotted circle glyph %s in font but not in glyphset",
+                    dotted_circle,
+                )
                 return DO_NOTHING
             logger.debug("Found dotted circle glyph %s", dotted_circle)
             return glyphset[dotted_circle]

--- a/Lib/ufo2ft/filters/dottedCircleFilter.py
+++ b/Lib/ufo2ft/filters/dottedCircleFilter.py
@@ -2,12 +2,12 @@ import logging
 import math
 
 from fontTools.misc.transform import Transform
-from ufoLib2.objects import Glyph, Anchor
+from ufoLib2.objects import Anchor, Glyph
 
-from ufo2ft.filters import BaseFilter
-from ufo2ft.util import _GlyphSet, _LazyFontName
 from ufo2ft.featureCompiler import parseLayoutFeatures
 from ufo2ft.featureWriters import ast
+from ufo2ft.filters import BaseFilter
+from ufo2ft.util import _GlyphSet, _LazyFontName
 
 logger = logging.getLogger(__name__)
 CIRCULAR_SUPERNESS = 0.551784777779014

--- a/Lib/ufo2ft/filters/dottedCircleFilter.py
+++ b/Lib/ufo2ft/filters/dottedCircleFilter.py
@@ -178,10 +178,12 @@ class DottedCircleFilter(BaseFilter):
             width = None
             try:
                 bounds = glyph.getBounds(font)
-                width = bounds.xMax - bounds.xMin
+                if bounds:
+                    width = bounds.xMax - bounds.xMin
             except AttributeError:
                 bounds = glyph.bounds
-                width = bounds[2] - bounds[0]
+                if bounds:
+                    width = bounds[2] - bounds[0]
             if width is None:
                 width = glyph.width
             for anchor in glyph.anchors:

--- a/Lib/ufo2ft/filters/dottedCircleFilter.py
+++ b/Lib/ufo2ft/filters/dottedCircleFilter.py
@@ -109,18 +109,18 @@ class DottedCircleFilter(BaseFilter):
 
         self.set_context(font, glyphSet)
         added_glyph = False
-        dsglyph = self.check_dotted_circle()
-        if not dsglyph:
-            dsglyph = self.draw_dotted_circle(glyphSet)
+        dotted_circle_glyph = self.check_dotted_circle()
+        if not dotted_circle_glyph:
+            dotted_circle_glyph = self.draw_dotted_circle(glyphSet)
             added_glyph = True
 
-        added_anchors = self.check_and_add_anchors(dsglyph)
+        added_anchors = self.check_and_add_anchors(dotted_circle_glyph)
 
         if added_anchors:
-            self.ensure_base(dsglyph)
+            self.ensure_base(dotted_circle_glyph)
 
         if added_glyph or added_anchors:
-            return [dsglyph.name]
+            return [dotted_circle_glyph.name]
         else:
             return []
 
@@ -157,7 +157,7 @@ class DottedCircleFilter(BaseFilter):
         glyphSet["uni25CC"] = glyph
         return glyph
 
-    def check_and_add_anchors(self, dsglyph):
+    def check_and_add_anchors(self, dotted_circle_glyph):
         """Check that all mark-attached anchors are present on the dotted
         circle glyph, synthesizing a position for any missing anchors."""
         font = self.context.font
@@ -193,7 +193,7 @@ class DottedCircleFilter(BaseFilter):
                 all_anchors.setdefault(anchor.name, []).append((x_percentage, anchor.y))
 
         # Now we move to the dotted circle. What anchors do we have already?
-        dsanchors = set([a.name for a in dsglyph.anchors])
+        dsanchors = set([a.name for a in dotted_circle_glyph.anchors])
         for anchor, positions in all_anchors.items():
             # Skip existing anchors on the dotted-circle, and any anchors
             # which don't have a matching mark glyph (mark-to-lig etc.).
@@ -201,7 +201,7 @@ class DottedCircleFilter(BaseFilter):
                 continue
 
             # And now we're creating a new one
-            anchor_x = dsglyph.width * mean([v[0] for v in positions])
+            anchor_x = dotted_circle_glyph.width * mean([v[0] for v in positions])
             anchor_y = mean([v[1] for v in positions])
             logger.debug(
                 "Adding anchor %s to dotted circle glyph at %i,%i",
@@ -216,7 +216,7 @@ class DottedCircleFilter(BaseFilter):
             except TypeError:
                 newanchor = anchorclass(otRound(anchor_x), otRound(anchor_y))
             newanchor.name = anchor
-            dsglyph.appendAnchor(newanchor)
+            dotted_circle_glyph.appendAnchor(newanchor)
             any_added = True
         return any_added
 
@@ -229,8 +229,8 @@ class DottedCircleFilter(BaseFilter):
     # be a base if it has anchors, and it might not have had any when glyphsLib
     # wrote the GDEF table.
     # So we have to go digging around for a GDEF table and modify it.
-    def ensure_base(self, dsglyph):
-        dotted_circle = dsglyph.name
+    def ensure_base(self, dotted_circle_glyph):
+        dotted_circle = dotted_circle_glyph.name
         font = self.context.font
         feaFile = parseLayoutFeatures(font)
         if ast.findTable(feaFile, "GDEF") is None:

--- a/Lib/ufo2ft/filters/dottedCircleFilter.py
+++ b/Lib/ufo2ft/filters/dottedCircleFilter.py
@@ -1,0 +1,161 @@
+import logging
+import math
+
+from fontTools.misc.transform import Transform
+from ufoLib2.objects import Glyph, Anchor
+
+from ufo2ft.filters import BaseFilter
+from ufo2ft.util import _GlyphSet, _LazyFontName
+from ufo2ft.featureCompiler import parseLayoutFeatures
+from ufo2ft.featureWriters import ast
+
+logger = logging.getLogger(__name__)
+CIRCULAR_SUPERNESS = 0.551784777779014
+
+
+def average(lst):
+    return sum(lst) / len(lst)
+
+
+def circle(pen, origin, radius):
+    w = (origin[0] - radius, origin[1])
+    n = (origin[0], origin[1] + radius)
+    e = (origin[0] + radius, origin[1])
+    s = (origin[0], origin[1] - radius)
+
+    pen.moveTo(w)
+    pen.curveTo(
+        (w[0], w[1] + radius * CIRCULAR_SUPERNESS),
+        (n[0] - radius * CIRCULAR_SUPERNESS, n[1]),
+        n,
+    )
+    pen.curveTo(
+        (n[0] + radius * CIRCULAR_SUPERNESS, n[1]),
+        (e[0], e[1] + radius * CIRCULAR_SUPERNESS),
+        e,
+    )
+    pen.curveTo(
+        (e[0], e[1] - radius * CIRCULAR_SUPERNESS),
+        (s[0] + radius * CIRCULAR_SUPERNESS, s[1]),
+        s,
+    )
+    pen.curveTo(
+        (s[0] - radius * CIRCULAR_SUPERNESS, s[1]),
+        (w[0], w[1] - radius * CIRCULAR_SUPERNESS),
+        w,
+    )
+    pen.closePath()
+
+
+class DottedCircleFilter(BaseFilter):
+
+    _kwargs = {"border": 80, "sidebearing": 160, "dots": 12}
+
+    def __call__(self, font, glyphSet=None):
+        fontName = _LazyFontName(font)
+        if glyphSet is not None and getattr(glyphSet, "name", None):
+            logger.info("Running %s on %s-%s", self.name, fontName, glyphSet.name)
+        else:
+            logger.info("Running %s on %s", self.name, fontName)
+
+        if glyphSet is None:
+            glyphSet = _GlyphSet.from_layer(font)
+
+        context = self.set_context(font, glyphSet)
+        dotted_circle = self.check_dotted_circle(glyphSet)
+        return self.check_dotted_circle_anchors(dotted_circle)
+
+    def check_dotted_circle(self, glyphSet):
+        font = self.context.font
+        dotted_circle = [g for g in font.keys() if font[g].unicode == 0x25CC]
+        if dotted_circle:
+            logger.info("Found dotted circle glyph %s", dotted_circle)
+            return dotted_circle[0]
+        glyph = Glyph(name="uni25CC", unicodes=[0x25CC])
+        glyph.unicodes = [0x25CC]
+        pen = glyph.getPen()
+
+        bigradius = (font.info.xHeight - 2 * self.options.border) / 2
+        littleradius = bigradius / 6
+        left = self.options.sidebearing + littleradius
+        right = self.options.sidebearing + bigradius * 2 - littleradius
+        middleY = font.info.xHeight / 2
+        middleX = (left + right) / 2
+        top = font.info.xHeight - self.options.border
+        bottom = self.options.border
+        subangle = 2 * math.pi / self.options.dots
+        for t in range(self.options.dots):
+            angle = t * subangle
+            cx = middleX + bigradius * math.cos(angle)
+            cy = middleY + bigradius * math.sin(angle)
+            circle(pen, (cx, cy), littleradius)
+
+        glyph.setRightMargin(self.options.sidebearing)
+        font.addGlyph(glyph)
+        glyphSet["uni25CC"] = glyph
+        return "uni25CC"
+
+    def check_dotted_circle_anchors(self, dotted_circle):
+        font = self.context.font
+        all_anchors = {}
+        any_added = False
+        for glyph in font:
+            bounds = glyph.getBounds(font)
+            if bounds:
+                width = bounds.xMax
+            else:
+                width = glyph.width
+            for anchor in glyph.anchors:
+                if anchor.name.startswith("_"):
+                    # We don't want their coordinates, just their names
+                    # so we can match them with base anchors later.
+                    all_anchors[anchor.name] = []
+                    continue
+                if not width:
+                    continue
+                x_percentage = anchor.x / width
+                all_anchors.setdefault(anchor.name, []).append(
+                    (glyph.name, x_percentage, anchor.y)
+                )
+        dsglyph = font[dotted_circle]
+        dsanchors = set([a.name for a in dsglyph.anchors])
+        for anchor, vals in all_anchors.items():
+            # Skip existing anchors on the dotted-circle, and any anchors
+            # which don't have a matching mark glyph.
+            if anchor in dsanchors or f"_{anchor}" not in all_anchors:
+                continue
+            average_x = average([v[1] for v in vals])
+            average_y = average([v[2] for v in vals])
+            logger.debug("Adding anchor %s to dotted circle glyph", anchor)
+            dsglyph.appendAnchor(
+                {
+                    "name": anchor,
+                    "x": int(dsglyph.width * average_x),
+                    "y": int(average_y),
+                }
+            )
+            any_added = True
+        if any_added:
+            self.ensure_base(dotted_circle)
+            return dotted_circle
+        else:
+            return []
+
+    # We need to ensure the glyph is a base or else it won't feature
+    # in the mark features writer. And if it previously had no anchors,
+    # glyphsLib does not consider it a base.
+    def ensure_base(self, dotted_circle):
+        font = self.context.font
+        feaFile = parseLayoutFeatures(font)
+        if ast.findTable(feaFile, "GDEF") is None:
+            return
+        for st in feaFile.statements:
+            if isinstance(st, ast.TableBlock) and st.name == "GDEF":
+                for st in st.statements:
+                    if isinstance(st, ast.GlyphClassDefStatement):
+                        if (
+                            st.baseGlyphs
+                            and dotted_circle not in st.baseGlyphs.glyphSet()
+                        ):
+                            st.baseGlyphs.glyphs.append(dotted_circle)
+        font.features.text = feaFile.asFea()

--- a/Lib/ufo2ft/filters/dottedCircleFilter.py
+++ b/Lib/ufo2ft/filters/dottedCircleFilter.py
@@ -1,8 +1,7 @@
 import logging
 import math
 
-from fontTools.misc.transform import Transform
-from ufoLib2.objects import Anchor, Glyph
+from ufoLib2.objects import Glyph
 
 from ufo2ft.featureCompiler import parseLayoutFeatures
 from ufo2ft.featureWriters import ast
@@ -61,7 +60,7 @@ class DottedCircleFilter(BaseFilter):
         if glyphSet is None:
             glyphSet = _GlyphSet.from_layer(font)
 
-        context = self.set_context(font, glyphSet)
+        self.set_context(font, glyphSet)
         dotted_circle = self.check_dotted_circle(glyphSet)
         return self.check_dotted_circle_anchors(dotted_circle)
 
@@ -81,8 +80,6 @@ class DottedCircleFilter(BaseFilter):
         right = self.options.sidebearing + bigradius * 2 - littleradius
         middleY = font.info.xHeight / 2
         middleX = (left + right) / 2
-        top = font.info.xHeight - self.options.border
-        bottom = self.options.border
         subangle = 2 * math.pi / self.options.dots
         for t in range(self.options.dots):
             angle = t * subangle

--- a/Lib/ufo2ft/filters/dottedCircleFilter.py
+++ b/Lib/ufo2ft/filters/dottedCircleFilter.py
@@ -2,6 +2,7 @@ from statistics import mean
 import logging
 import math
 
+from fontTools.misc.fixedTools import otRound
 from ufoLib2.objects import Glyph
 
 from ufo2ft.featureCompiler import parseLayoutFeatures
@@ -128,8 +129,8 @@ class DottedCircleFilter(BaseFilter):
             dsglyph.appendAnchor(
                 {
                     "name": anchor,
-                    "x": int(dsglyph.width * average_x),
-                    "y": int(average_y),
+                    "x": otRound(dsglyph.width * average_x),
+                    "y": otRound(average_y),
                 }
             )
             any_added = True

--- a/Lib/ufo2ft/filters/dottedCircleFilter.py
+++ b/Lib/ufo2ft/filters/dottedCircleFilter.py
@@ -59,15 +59,21 @@ class DottedCircleFilter(BaseFilter):
             glyphSet = _GlyphSet.from_layer(font)
 
         self.set_context(font, glyphSet)
-        dotted_circle = self.check_dotted_circle(glyphSet)
+        dotted_circle = self.check_dotted_circle()
+        if not dotted_circle:
+            dotted_circle = self.draw_dotted_circle(glyphSet)
+
         return self.check_dotted_circle_anchors(dotted_circle)
 
     def check_dotted_circle(self, glyphSet):
         font = self.context.font
-        dotted_circle = [g for g in font.keys() if font[g].unicode == 0x25CC]
+        dotted_circle = next((g for g in font if 0x25CC in g.unicodes), None)
         if dotted_circle:
-            logger.info("Found dotted circle glyph %s", dotted_circle)
-            return dotted_circle[0]
+            logger.debug("Found dotted circle glyph %s", dotted_circle.name)
+            return dotted_circle.name
+
+    def draw_dotted_circle(self, glyphSet):
+        logger.debug("Adding dotted circle glyph")
         glyph = Glyph(name="uni25CC", unicodes=[0x25CC])
         pen = glyph.getPen()
 

--- a/Lib/ufo2ft/filters/dottedCircleFilter.py
+++ b/Lib/ufo2ft/filters/dottedCircleFilter.py
@@ -43,9 +43,9 @@ dots
     Number of dots in the circle.
 
 """
-from statistics import mean
 import logging
 import math
+from statistics import mean
 
 from fontTools.misc.fixedTools import otRound
 from ufoLib2.objects import Glyph

--- a/Lib/ufo2ft/filters/dottedCircleFilter.py
+++ b/Lib/ufo2ft/filters/dottedCircleFilter.py
@@ -45,7 +45,7 @@ def circle(pen, origin, radius):
 
 class DottedCircleFilter(BaseFilter):
 
-    _kwargs = {"border": 80, "sidebearing": 160, "dots": 12}
+    _kwargs = {"margin": 80, "sidebearing": 160, "dots": 12}
 
     def __call__(self, font, glyphSet=None):
         fontName = _LazyFontName(font)
@@ -71,7 +71,7 @@ class DottedCircleFilter(BaseFilter):
         glyph.unicodes = [0x25CC]
         pen = glyph.getPen()
 
-        bigradius = (font.info.xHeight - 2 * self.options.border) / 2
+        bigradius = (font.info.xHeight - 2 * self.options.margin) / 2
         littleradius = bigradius / 6
         left = self.options.sidebearing + littleradius
         right = self.options.sidebearing + bigradius * 2 - littleradius

--- a/Lib/ufo2ft/filters/dottedCircleFilter.py
+++ b/Lib/ufo2ft/filters/dottedCircleFilter.py
@@ -68,7 +68,6 @@ class DottedCircleFilter(BaseFilter):
             logger.info("Found dotted circle glyph %s", dotted_circle)
             return dotted_circle[0]
         glyph = Glyph(name="uni25CC", unicodes=[0x25CC])
-        glyph.unicodes = [0x25CC]
         pen = glyph.getPen()
 
         bigradius = (font.info.xHeight - 2 * self.options.margin) / 2

--- a/Lib/ufo2ft/filters/dottedCircleFilter.py
+++ b/Lib/ufo2ft/filters/dottedCircleFilter.py
@@ -134,6 +134,7 @@ class DottedCircleFilter(BaseFilter):
 
     def draw_dotted_circle(self, glyphSet):
         """Add a new dotted circle glyph, drawing its outlines"""
+        font = self.context.font
         logger.debug("Adding dotted circle glyph")
         glyph = Glyph(name="uni25CC", unicodes=[0x25CC])
         pen = glyph.getPen()

--- a/Lib/ufo2ft/filters/dottedCircleFilter.py
+++ b/Lib/ufo2ft/filters/dottedCircleFilter.py
@@ -179,7 +179,7 @@ class DottedCircleFilter(BaseFilter):
             try:
                 bounds = glyph.getBounds(font)
                 width = bounds.xMax - bounds.xMin
-            except Exception as e:
+            except AttributeError:
                 bounds = glyph.bounds
                 width = bounds[2] - bounds[0]
             if width is None:
@@ -244,12 +244,12 @@ class DottedCircleFilter(BaseFilter):
         # ourselves to the baseGlyphs set.
         for st in feaFile.statements:
             if isinstance(st, ast.TableBlock) and st.name == "GDEF":
-                for st in st.statements:
-                    if isinstance(st, ast.GlyphClassDefStatement):
+                for st2 in st.statements:
+                    if isinstance(st2, ast.GlyphClassDefStatement):
                         if (
-                            st.baseGlyphs
-                            and dotted_circle not in st.baseGlyphs.glyphSet()
+                            st2.baseGlyphs
+                            and dotted_circle not in st2.baseGlyphs.glyphSet()
                         ):
-                            st.baseGlyphs.glyphs.append(dotted_circle)
+                            st2.baseGlyphs.glyphs.append(dotted_circle)
         # And then put the modified feature file back into the font
         font.features.text = feaFile.asFea()

--- a/Lib/ufo2ft/filters/dottedCircleFilter.py
+++ b/Lib/ufo2ft/filters/dottedCircleFilter.py
@@ -74,10 +74,10 @@ class DottedCircleFilter(BaseFilter):
 
     def check_dotted_circle(self):
         font = self.context.font
-        dotted_circle = next((g for g in font if 0x25CC in g.unicodes), None)
+        dotted_circle = next((g.name for g in font if 0x25CC in g.unicodes), None)
         if dotted_circle:
-            logger.debug("Found dotted circle glyph %s", dotted_circle.name)
-            return dotted_circle.name
+            logger.debug("Found dotted circle glyph %s", dotted_circle)
+            return dotted_circle
 
     def draw_dotted_circle(self, glyphSet):
         logger.debug("Adding dotted circle glyph")

--- a/Lib/ufo2ft/filters/dottedCircleFilter.py
+++ b/Lib/ufo2ft/filters/dottedCircleFilter.py
@@ -130,7 +130,7 @@ class DottedCircleFilter(BaseFilter):
         dotted_circle = next((g.name for g in font if 0x25CC in g.unicodes), None)
         if dotted_circle:
             logger.debug("Found dotted circle glyph %s", dotted_circle)
-            return font[dotted_circle]
+            return self.context.glyphSet[dotted_circle]
 
     def draw_dotted_circle(self, glyphSet):
         """Add a new dotted circle glyph, drawing its outlines"""

--- a/Lib/ufo2ft/filters/dottedCircleFilter.py
+++ b/Lib/ufo2ft/filters/dottedCircleFilter.py
@@ -1,3 +1,4 @@
+from statistics import mean
 import logging
 import math
 
@@ -10,10 +11,6 @@ from ufo2ft.util import _GlyphSet, _LazyFontName
 
 logger = logging.getLogger(__name__)
 CIRCULAR_SUPERNESS = 0.551784777779014
-
-
-def average(lst):
-    return sum(lst) / len(lst)
 
 
 def circle(pen, origin, radius):
@@ -121,9 +118,14 @@ class DottedCircleFilter(BaseFilter):
             # which don't have a matching mark glyph.
             if anchor in dsanchors or f"_{anchor}" not in all_anchors:
                 continue
-            average_x = average([v[1] for v in vals])
-            average_y = average([v[2] for v in vals])
-            logger.debug("Adding anchor %s to dotted circle glyph", anchor)
+            average_x = mean([v[1] for v in vals])
+            average_y = mean([v[2] for v in vals])
+            logger.debug(
+                "Adding anchor %s to dotted circle glyph at %i,%i",
+                anchor,
+                dsglyph.width * average_x,
+                average_y,
+            )
             dsglyph.appendAnchor(
                 {
                     "name": anchor,

--- a/tests/data/DottedCircleTest.ufo/fontinfo.plist
+++ b/tests/data/DottedCircleTest.ufo/fontinfo.plist
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>ascender</key>
+	<integer>800</integer>
+	<key>capHeight</key>
+	<integer>700</integer>
+	<key>descender</key>
+	<integer>-200</integer>
+	<key>familyName</key>
+	<string>Dotted Circle Test</string>
+	<key>openTypeHeadCreated</key>
+	<string>2022/04/18 20:12:58</string>
+	<key>postscriptBlueValues</key>
+	<array>
+		<real>-16.0</real>
+		<real>0.0</real>
+		<real>500.0</real>
+		<real>516.0</real>
+		<real>700.0</real>
+		<real>716.0</real>
+		<real>800.0</real>
+		<real>816.0</real>
+	</array>
+	<key>postscriptFontName</key>
+	<string>DottedCircleTest-Regular</string>
+	<key>postscriptOtherBlues</key>
+	<array>
+		<real>-216.0</real>
+		<real>-200.0</real>
+	</array>
+	<key>styleName</key>
+	<string>Regular</string>
+	<key>unitsPerEm</key>
+	<integer>1000</integer>
+	<key>versionMajor</key>
+	<integer>1</integer>
+	<key>versionMinor</key>
+	<integer>0</integer>
+	<key>xHeight</key>
+	<integer>500</integer>
+</dict>
+</plist>

--- a/tests/data/DottedCircleTest.ufo/glyphs/a.glif
+++ b/tests/data/DottedCircleTest.ufo/glyphs/a.glif
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="a" format="2">
+	<advance width="600"/>
+	<unicode hex="0061"/>
+	<anchor x="346" y="546" name="top"/>
+	<anchor x="289" y="-11" name="bottom"/>
+	<outline>
+		<contour>
+			<point x="413" y="74" type="curve"/>
+			<point x="413" y="8"/>
+			<point x="432" y="-14"/>
+			<point x="465" y="-14" type="curve" smooth="yes"/>
+			<point x="477" y="-14"/>
+			<point x="503" y="-10"/>
+			<point x="503" y="33" type="curve" smooth="yes"/>
+			<point x="503" y="369" type="line"/>
+			<point x="503" y="500"/>
+			<point x="397" y="529"/>
+			<point x="320" y="529" type="curve" smooth="yes"/>
+			<point x="230" y="529"/>
+			<point x="121" y="487"/>
+			<point x="121" y="423" type="curve" smooth="yes"/>
+			<point x="121" y="389"/>
+			<point x="152" y="384"/>
+			<point x="174" y="388" type="curve" smooth="yes"/>
+			<point x="230" y="399"/>
+			<point x="200" y="472"/>
+			<point x="293" y="472" type="curve" smooth="yes"/>
+			<point x="412" y="472"/>
+			<point x="410" y="374"/>
+			<point x="410" y="343" type="curve"/>
+			<point x="215" y="316"/>
+			<point x="80" y="257"/>
+			<point x="80" y="113" type="curve" smooth="yes"/>
+			<point x="80" y="28"/>
+			<point x="136" y="-11"/>
+			<point x="219" y="-11" type="curve" smooth="yes"/>
+			<point x="289" y="-11"/>
+			<point x="364" y="2"/>
+		</contour>
+		<contour>
+			<point x="402" y="105"/>
+			<point x="318" y="42"/>
+			<point x="236" y="49" type="curve" smooth="yes"/>
+			<point x="194" y="53"/>
+			<point x="166" y="66"/>
+			<point x="166" y="130" type="curve" smooth="yes"/>
+			<point x="166" y="225"/>
+			<point x="283" y="261"/>
+			<point x="407" y="290" type="curve"/>
+			<point x="406" y="121" type="line"/>
+		</contour>
+	</outline>
+	<lib>
+		<dict>
+			<key>com.schriftgestaltung.Glyphs.lastChange</key>
+			<string>2022-04-18 20:32:56 +0000</string>
+		</dict>
+	</lib>
+</glyph>

--- a/tests/data/DottedCircleTest.ufo/glyphs/acutecomb.glif
+++ b/tests/data/DottedCircleTest.ufo/glyphs/acutecomb.glif
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="acutecomb" format="2">
+	<advance width="0"/>
+	<unicode hex="0301"/>
+	<anchor x="0" y="503" name="_top"/>
+	<outline>
+		<contour>
+			<point x="-90" y="651" type="line"/>
+			<point x="-59" y="586" type="line"/>
+			<point x="95" y="645" type="line"/>
+			<point x="57" y="751" type="line"/>
+		</contour>
+	</outline>
+	<lib>
+		<dict>
+			<key>com.schriftgestaltung.Glyphs.lastChange</key>
+			<string>2022-04-18 20:15:50 +0000</string>
+		</dict>
+	</lib>
+</glyph>

--- a/tests/data/DottedCircleTest.ufo/glyphs/c.glif
+++ b/tests/data/DottedCircleTest.ufo/glyphs/c.glif
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="c" format="2">
+	<advance width="487"/>
+	<unicode hex="0063"/>
+	<anchor x="273" y="-24" name="bottom"/>
+	<outline>
+		<contour>
+			<point x="51" y="233" type="curve" smooth="yes"/>
+			<point x="51" y="65"/>
+			<point x="119" y="-14"/>
+			<point x="263" y="-14" type="curve" smooth="yes"/>
+			<point x="333" y="-14"/>
+			<point x="396" y="11"/>
+			<point x="432" y="53" type="curve" smooth="yes"/>
+			<point x="447" y="71"/>
+			<point x="462" y="89"/>
+			<point x="462" y="104" type="curve" smooth="yes"/>
+			<point x="462" y="120"/>
+			<point x="441" y="116"/>
+			<point x="441" y="116" type="curve" smooth="yes"/>
+			<point x="414" y="110"/>
+			<point x="362" y="43"/>
+			<point x="278" y="43" type="curve" smooth="yes"/>
+			<point x="183" y="43"/>
+			<point x="148" y="118"/>
+			<point x="148" y="269" type="curve" smooth="yes"/>
+			<point x="148" y="410"/>
+			<point x="192" y="472"/>
+			<point x="290" y="472" type="curve" smooth="yes"/>
+			<point x="331" y="472"/>
+			<point x="351" y="460"/>
+			<point x="368" y="425" type="curve" smooth="yes"/>
+			<point x="382" y="397"/>
+			<point x="397" y="387"/>
+			<point x="422" y="387" type="curve" smooth="yes"/>
+			<point x="455" y="387"/>
+			<point x="462" y="393"/>
+			<point x="462" y="423" type="curve" smooth="yes"/>
+			<point x="462" y="487"/>
+			<point x="394" y="529"/>
+			<point x="290" y="529" type="curve" smooth="yes"/>
+			<point x="137" y="529"/>
+			<point x="51" y="422"/>
+		</contour>
+	</outline>
+	<lib>
+		<dict>
+			<key>com.schriftgestaltung.Glyphs.lastChange</key>
+			<string>2022-04-18 20:34:17 +0000</string>
+		</dict>
+	</lib>
+</glyph>

--- a/tests/data/DottedCircleTest.ufo/glyphs/contents.plist
+++ b/tests/data/DottedCircleTest.ufo/glyphs/contents.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>a</key>
+	<string>a.glif</string>
+	<key>acutecomb</key>
+	<string>acutecomb.glif</string>
+	<key>c</key>
+	<string>c.glif</string>
+	<key>dotbelowcomb</key>
+	<string>dotbelowcomb.glif</string>
+</dict>
+</plist>

--- a/tests/data/DottedCircleTest.ufo/glyphs/dotbelowcomb.glif
+++ b/tests/data/DottedCircleTest.ufo/glyphs/dotbelowcomb.glif
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="dotbelowcomb" format="2">
+	<advance width="0"/>
+	<unicode hex="0323"/>
+	<anchor x="0" y="0" name="_bottom"/>
+	<outline>
+		<contour>
+			<point x="0" y="-175" type="curve" smooth="yes"/>
+			<point x="29" y="-175"/>
+			<point x="52" y="-152"/>
+			<point x="52" y="-123" type="curve" smooth="yes"/>
+			<point x="52" y="-94"/>
+			<point x="29" y="-71"/>
+			<point x="0" y="-71" type="curve" smooth="yes"/>
+			<point x="-29" y="-71"/>
+			<point x="-52" y="-94"/>
+			<point x="-52" y="-123" type="curve" smooth="yes"/>
+			<point x="-52" y="-152"/>
+			<point x="-29" y="-175"/>
+		</contour>
+	</outline>
+	<lib>
+		<dict>
+			<key>com.schriftgestaltung.Glyphs.lastChange</key>
+			<string>2022-04-18 20:32:37 +0000</string>
+		</dict>
+	</lib>
+</glyph>

--- a/tests/data/DottedCircleTest.ufo/layercontents.plist
+++ b/tests/data/DottedCircleTest.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<array>
+		<string>public.default</string>
+		<string>glyphs</string>
+	</array>
+</array>
+</plist>

--- a/tests/data/DottedCircleTest.ufo/lib.plist
+++ b/tests/data/DottedCircleTest.ufo/lib.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.schriftgestaltung.DisplayStrings</key>
+	<array>
+		<string>cacacaa</string>
+	</array>
+	<key>com.schriftgestaltung.disablesAutomaticAlignment</key>
+	<false/>
+	<key>com.schriftgestaltung.fontMasterID</key>
+	<string>m01</string>
+	<key>com.schriftgestaltung.glyphOrder</key>
+	<false/>
+	<key>com.schriftgestaltung.useNiceNames</key>
+	<true/>
+	<key>public.glyphOrder</key>
+	<array>
+		<string>a</string>
+		<string>c</string>
+		<string>acutecomb</string>
+		<string>dotbelowcomb</string>
+	</array>
+</dict>
+</plist>

--- a/tests/data/DottedCircleTest.ufo/metainfo.plist
+++ b/tests/data/DottedCircleTest.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>creator</key>
+	<string>com.schriftgestaltung.GlyphsUFOExport</string>
+	<key>formatVersion</key>
+	<integer>3</integer>
+</dict>
+</plist>

--- a/tests/filters/dottedCircle_test.py
+++ b/tests/filters/dottedCircle_test.py
@@ -1,7 +1,3 @@
-import pytest
-from fontTools.misc.loggingTools import CapturingLogHandler
-
-import ufo2ft.filters
 from ufo2ft.filters.dottedCircleFilter import DottedCircleFilter
 
 

--- a/tests/filters/dottedCircle_test.py
+++ b/tests/filters/dottedCircle_test.py
@@ -1,4 +1,5 @@
 from ufo2ft.filters.dottedCircleFilter import DottedCircleFilter
+from ufo2ft.util import _GlyphSet
 
 
 def test_dotted_circle_filter(FontClass, datadir):
@@ -6,7 +7,7 @@ def test_dotted_circle_filter(FontClass, datadir):
     font = FontClass(ufo_path)
     assert "uni25CC" not in font
     philter = DottedCircleFilter()
-    glyphset = {}
+    glyphset = _GlyphSet.from_layer(font)
     modified = philter(font, glyphset)
     assert "uni25CC" in modified
     anchors = list(sorted(glyphset["uni25CC"].anchors, key=lambda x: x.name))

--- a/tests/filters/dottedCircle_test.py
+++ b/tests/filters/dottedCircle_test.py
@@ -1,0 +1,24 @@
+import pytest
+from fontTools.misc.loggingTools import CapturingLogHandler
+
+import ufo2ft.filters
+from ufo2ft.filters.dottedCircleFilter import DottedCircleFilter, logger
+
+def test_dotted_circle_filter(FontClass, datadir):
+    ufo_path = datadir.join("DottedCircleTest.ufo")
+    font = FontClass(ufo_path)
+    assert "uni25CC" not in font
+    philter = DottedCircleFilter()
+    modified = philter(font)
+    assert "uni25CC" in modified
+    anchors = list(sorted(font["uni25CC"].anchors, key=lambda x:x.name))
+    assert anchors[0].x == 464
+    assert anchors[0].y == -17
+    assert anchors[0].name == "bottom"
+
+    assert anchors[1].x == 563
+    assert anchors[1].y == 546
+    assert anchors[1].name == "top"
+
+    assert len(font["uni25CC"]) == 12
+    assert int(font["uni25CC"].width) == 688

--- a/tests/filters/dottedCircle_test.py
+++ b/tests/filters/dottedCircle_test.py
@@ -6,9 +6,10 @@ def test_dotted_circle_filter(FontClass, datadir):
     font = FontClass(ufo_path)
     assert "uni25CC" not in font
     philter = DottedCircleFilter()
-    modified = philter(font)
+    glyphset = {}
+    modified = philter(font, glyphset)
     assert "uni25CC" in modified
-    anchors = list(sorted(font["uni25CC"].anchors, key=lambda x: x.name))
+    anchors = list(sorted(glyphset["uni25CC"].anchors, key=lambda x: x.name))
     assert anchors[0].x == 464
     assert anchors[0].y == -17
     assert anchors[0].name == "bottom"
@@ -17,5 +18,5 @@ def test_dotted_circle_filter(FontClass, datadir):
     assert anchors[1].y == 546
     assert anchors[1].name == "top"
 
-    assert len(font["uni25CC"]) == 12
-    assert int(font["uni25CC"].width) == 688
+    assert len(glyphset["uni25CC"]) == 12
+    assert int(glyphset["uni25CC"].width) == 688

--- a/tests/filters/dottedCircle_test.py
+++ b/tests/filters/dottedCircle_test.py
@@ -2,7 +2,8 @@ import pytest
 from fontTools.misc.loggingTools import CapturingLogHandler
 
 import ufo2ft.filters
-from ufo2ft.filters.dottedCircleFilter import DottedCircleFilter, logger
+from ufo2ft.filters.dottedCircleFilter import DottedCircleFilter
+
 
 def test_dotted_circle_filter(FontClass, datadir):
     ufo_path = datadir.join("DottedCircleTest.ufo")
@@ -11,7 +12,7 @@ def test_dotted_circle_filter(FontClass, datadir):
     philter = DottedCircleFilter()
     modified = philter(font)
     assert "uni25CC" in modified
-    anchors = list(sorted(font["uni25CC"].anchors, key=lambda x:x.name))
+    anchors = list(sorted(font["uni25CC"].anchors, key=lambda x: x.name))
     assert anchors[0].x == 464
     assert anchors[0].y == -17
     assert anchors[0].name == "bottom"


### PR DESCRIPTION
Google Fonts' fontbakery tool has recently made it mandatory for fonts supporting complex scripts to contain a dotted circle (U+25CC) glyph, and for this glyph to have appropriate anchors for all attachable marks.

This is a boring job to do manually, and both the drawing and the anchor positioning can be automated.

This PR introduces a filter which can be called at font build time (`--filter "ufo2ft.filters.dottedCircleFilter::DottedCircleFilter(pre=True)"`) which checks for the presence of a dotted circle glyph, adds one if there is not one present, computes average anchor positions for attaching anchors and adds any missing anchors to the dotted circle glyph.

Example:

```
$ fontmake -o ttf -g src/NotoNastaliqUrdu.glyphs --filter "ufo2ft.filters.dottedCircleFilter::DottedCircleFilter(pre=True,dots=10)"
...
$ shape master_ttf/NotoNastaliqUrdu-Regular.ttf '◌ِّ'
[uni25CC=0+727|ShaddaNS=0@-312,-97+0|KasraNS=0@-368,-164+0]
```
![shape](https://user-images.githubusercontent.com/106728/156019354-b6cf6ec4-50bf-4c32-9593-fbd4461d8a79.png)
