### PR TITLE
Build DS5

### DIFF
--- a/Lib/ufo2ft/__init__.py
+++ b/Lib/ufo2ft/__init__.py
@@ -568,7 +568,8 @@ def compileVariableTTFs(designSpaceDoc: DesignSpaceDocument, **kwargs):
     The rest of the arguments works the same as in the other compile functions.
 
     Returns a dictionary that maps each variable font filename to a new variable
-    TTFont object.
+    TTFont object. If no variable fonts are defined in the Designspace, returns
+    an empty dictionary.
 
     .. versionadded:: TODO (Jany) version of addition
     """
@@ -588,7 +589,6 @@ def compileVariableTTFs(designSpaceDoc: DesignSpaceDocument, **kwargs):
     )
 
     if not vfNameToBaseUfo:
-        logger.warning("No variable fonts to build")
         return {}
 
     logger.info("Building variable TTF fonts: %s", ", ".join(vfNameToBaseUfo))

--- a/Lib/ufo2ft/__init__.py
+++ b/Lib/ufo2ft/__init__.py
@@ -571,7 +571,7 @@ def compileVariableTTFs(designSpaceDoc: DesignSpaceDocument, **kwargs):
     TTFont object. If no variable fonts are defined in the Designspace, returns
     an empty dictionary.
 
-    .. versionadded:: TODO (Jany) version of addition
+    .. versionadded:: 2.28.0
     """
     kwargs = init_kwargs(kwargs, compileVariableTTFs_args)
     optimizeGvar = kwargs.pop("optimizeGvar")
@@ -684,7 +684,7 @@ def compileVariableCFF2s(designSpaceDoc, **kwargs):
     Returns a dictionary that maps each variable font filename to a new variable
     TTFont object.
 
-    .. versionadded:: TODO (Jany) version of addition
+    .. versionadded:: 2.28.0
     """
     kwargs = init_kwargs(kwargs, compileVariableCFF2s_args)
     excludeVariationTables = kwargs.pop("excludeVariationTables")

--- a/Lib/ufo2ft/__init__.py
+++ b/Lib/ufo2ft/__init__.py
@@ -1,4 +1,3 @@
-import copy
 import logging
 import os
 from enum import IntEnum
@@ -374,7 +373,7 @@ def compileInterpolatableTTFsFromDS(designSpaceDoc, **kwargs):
     if kwargs["inplace"]:
         result = designSpaceDoc
     else:
-        result = copy.deepcopy(designSpaceDoc)
+        result = designSpaceDoc.deepcopyExceptFonts()
     for source, ttf in zip(result.sources, ttfs):
         source.font = ttf
     return result
@@ -453,7 +452,7 @@ def compileInterpolatableOTFsFromDS(designSpaceDoc, **kwargs):
     if kwargs["inplace"]:
         result = designSpaceDoc
     else:
-        result = copy.deepcopy(designSpaceDoc)
+        result = designSpaceDoc.deepcopyExceptFonts()
 
     for source, otf in zip(result.sources, otfs):
         source.font = otf
@@ -585,7 +584,7 @@ def compileVariableTTFs(designSpaceDoc: DesignSpaceDocument, **kwargs):
     # don't need to worry
     inplace = kwargs.pop("inplace")
     if not inplace:
-        designSpaceDoc = copy.deepcopy(designSpaceDoc)
+        designSpaceDoc = designSpaceDoc.deepcopyExceptFonts()
 
     vfNameToBaseUfo = _compileNeededSources(
         kwargs, designSpaceDoc, variableFontNames, compileInterpolatableTTFsFromDS
@@ -699,7 +698,7 @@ def compileVariableCFF2s(designSpaceDoc, **kwargs):
     # don't need to worry
     inplace = kwargs.pop("inplace")
     if not inplace:
-        designSpaceDoc = copy.deepcopy(designSpaceDoc)
+        designSpaceDoc = designSpaceDoc.deepcopyExceptFonts()
 
     vfNameToBaseUfo = _compileNeededSources(
         kwargs, designSpaceDoc, variableFontNames, compileInterpolatableOTFsFromDS

--- a/Lib/ufo2ft/__init__.py
+++ b/Lib/ufo2ft/__init__.py
@@ -638,9 +638,6 @@ def compileVariableCFF2(designSpaceDoc, **kwargs):
     The rest of the arguments works the same as in the other compile functions.
 
     Returns a new variable TTFont object.
-
-    .. deprecated:: TODO (Jany) version of deprecation
-        use :func:`compileVariableCFF2s` instead (since DesignSpace version 5.0)
     """
     kwargs = init_kwargs(kwargs, compileVariableCFF2_args)
     fonts = compileVariableCFF2s(designSpaceDoc, **kwargs)

--- a/Lib/ufo2ft/__init__.py
+++ b/Lib/ufo2ft/__init__.py
@@ -532,9 +532,6 @@ def compileVariableTTF(designSpaceDoc, **kwargs):
     The rest of the arguments works the same as in the other compile functions.
 
     Returns a new variable TTFont object.
-
-    .. deprecated:: TODO (Jany) version of deprecation
-        use :func:`compileVariableTTFs` instead (since DesignSpace version 5.0)
     """
     kwargs = init_kwargs(kwargs, compileVariableTTF_args)
     fonts = compileVariableTTFs(designSpaceDoc, **kwargs)

--- a/Lib/ufo2ft/__init__.py
+++ b/Lib/ufo2ft/__init__.py
@@ -24,7 +24,6 @@ from ufo2ft.preProcessor import (
 from ufo2ft.util import (
     _getDefaultNotdefGlyph,
     ensure_all_sources_have_names,
-    getDefaultMasterFont,
     init_kwargs,
     prune_unknown_kwargs,
 )
@@ -582,7 +581,8 @@ def compileVariableTTFs(designSpaceDoc: DesignSpaceDocument, **kwargs):
     excludeVariationTables = kwargs.pop("excludeVariationTables")
     variableFontNames = kwargs.pop("variableFontNames")
 
-    # Pop inplace because we'll make a copy at this level so deeper functions don't need to worry
+    # Pop inplace because we'll make a copy at this level so deeper functions
+    # don't need to worry
     inplace = kwargs.pop("inplace")
     if not inplace:
         designSpaceDoc = copy.deepcopy(designSpaceDoc)
@@ -695,7 +695,8 @@ def compileVariableCFF2s(designSpaceDoc, **kwargs):
     optimizeCFF = CFFOptimization(kwargs.pop("optimizeCFF"))
     variableFontNames = kwargs.pop("variableFontNames")
 
-    # Pop inplace because we'll make a copy at this level so deeper functions don't need to worry
+    # Pop inplace because we'll make a copy at this level so deeper functions
+    # don't need to worry
     inplace = kwargs.pop("inplace")
     if not inplace:
         designSpaceDoc = copy.deepcopy(designSpaceDoc)

--- a/Lib/ufo2ft/__init__.py
+++ b/Lib/ufo2ft/__init__.py
@@ -1,8 +1,11 @@
+import copy
 import logging
 import os
 from enum import IntEnum
 
 from fontTools import varLib
+from fontTools.designspaceLib import DesignSpaceDocument
+from fontTools.designspaceLib.split import splitInterpolable, splitVariableFonts
 from fontTools.otlLib.optimize.gpos import GPOS_COMPACT_MODE_ENV_KEY
 
 from ufo2ft.constants import SPARSE_OTF_MASTER_TABLES, SPARSE_TTF_MASTER_TABLES
@@ -20,6 +23,7 @@ from ufo2ft.preProcessor import (
 )
 from ufo2ft.util import (
     _getDefaultNotdefGlyph,
+    ensure_all_sources_have_names,
     getDefaultMasterFont,
     init_kwargs,
     prune_unknown_kwargs,
@@ -371,8 +375,7 @@ def compileInterpolatableTTFsFromDS(designSpaceDoc, **kwargs):
     if kwargs["inplace"]:
         result = designSpaceDoc
     else:
-        # TODO try a more efficient copy method that doesn't involve (de)serializing
-        result = designSpaceDoc.__class__.fromstring(designSpaceDoc.tostring())
+        result = copy.deepcopy(designSpaceDoc)
     for source, ttf in zip(result.sources, ttfs):
         source.font = ttf
     return result
@@ -451,8 +454,7 @@ def compileInterpolatableOTFsFromDS(designSpaceDoc, **kwargs):
     if kwargs["inplace"]:
         result = designSpaceDoc
     else:
-        # TODO try a more efficient copy method that doesn't involve (de)serializing
-        result = designSpaceDoc.__class__.fromstring(designSpaceDoc.tostring())
+        result = copy.deepcopy(designSpaceDoc)
 
     for source, otf in zip(result.sources, otfs):
         source.font = otf
@@ -466,7 +468,7 @@ def compileFeatures(
     glyphSet=None,
     featureCompilerClass=None,
     debugFeatureFile=None,
-    **kwargs
+    **kwargs,
 ):
     """Compile OpenType Layout features from `ufo` into FontTools OTL tables.
     If `ttFont` is None, a new TTFont object is created containing the new
@@ -532,42 +534,82 @@ def compileVariableTTF(designSpaceDoc, **kwargs):
     The rest of the arguments works the same as in the other compile functions.
 
     Returns a new variable TTFont object.
+
+    .. deprecated:: TODO (Jany) version of deprecation
+        use :func:`compileVariableTTFs` instead (since DesignSpace version 5.0)
     """
     kwargs = init_kwargs(kwargs, compileVariableTTF_args)
-    baseUfo = getDefaultMasterFont(designSpaceDoc)
-
-    excludeVariationTables = kwargs.pop("excludeVariationTables")
-    optimizeGvar = kwargs.pop("optimizeGvar")
-
-    # FIXME: Hack until we get a fontTools config module. Disable GPOS
-    # compaction while building masters because the compaction will be undone
-    # anyway by varLib merge and then done again on the VF
-    gpos_compact_value = os.environ.pop(GPOS_COMPACT_MODE_ENV_KEY, None)
-    try:
-        ttfDesignSpace = compileInterpolatableTTFsFromDS(
-            designSpaceDoc,
-            **{
-                **kwargs,
-                **dict(
-                    useProductionNames=False,  # will rename glyphs after varfont is built
-                    # No need to post-process intermediate fonts.
-                    postProcessorClass=None,
-                ),
-            },
+    fonts = compileVariableTTFs(designSpaceDoc, **kwargs)
+    if len(fonts) != 1:
+        raise ValueError(
+            "Tried to build a DesignSpace version 5 with multiple variable "
+            "fonts using the old ufo2ft API `compileVariableTTF`. "
+            "Use the new API instead `compileVariableTTFs`"
         )
-    finally:
-        if gpos_compact_value is not None:
-            os.environ[GPOS_COMPACT_MODE_ENV_KEY] = gpos_compact_value
+    return next(iter(fonts.values()))
 
-    logger.info("Building variable TTF font")
 
-    varfont = varLib.build(
-        ttfDesignSpace,
+compileVariableTTFs_args = {
+    **compileVariableTTF_args,
+    **dict(variableFontNames=None),
+}
+
+
+def compileVariableTTFs(designSpaceDoc: DesignSpaceDocument, **kwargs):
+    """Create FontTools TrueType variable fonts for each variable font defined
+    in the given DesignSpaceDocument, using their UFO sources
+    with interpolatable outlines, using fontTools.varLib.build.
+
+    *optimizeGvar*, if set to False, will not perform IUP optimization on the
+      generated 'gvar' table.
+
+    *excludeVariationTables* is a list of sfnt table tags (str) that is passed on
+      to fontTools.varLib.build, to skip building some variation tables.
+
+    *variableFontNames* is an optional list of names of variable fonts
+      to build. If not provided, all variable fonts listed in the given
+      designspace will by built.
+
+    The rest of the arguments works the same as in the other compile functions.
+
+    Returns a dictionary that maps each variable font filename to a new variable
+    TTFont object.
+
+    .. versionadded:: TODO (Jany) version of addition
+    """
+    kwargs = init_kwargs(kwargs, compileVariableTTFs_args)
+    optimizeGvar = kwargs.pop("optimizeGvar")
+    excludeVariationTables = kwargs.pop("excludeVariationTables")
+    variableFontNames = kwargs.pop("variableFontNames")
+
+    # Pop inplace because we'll make a copy at this level so deeper functions don't need to worry
+    inplace = kwargs.pop("inplace")
+    if not inplace:
+        designSpaceDoc = copy.deepcopy(designSpaceDoc)
+
+    vfNameToBaseUfo = _compileNeededSources(
+        kwargs, designSpaceDoc, variableFontNames, compileInterpolatableTTFsFromDS
+    )
+
+    if not vfNameToBaseUfo:
+        logger.warning("No variable fonts to build")
+        return {}
+
+    logger.info("Building variable TTF fonts: %s", ", ".join(vfNameToBaseUfo))
+
+    vfNameToTTFont = varLib.build_many(
+        designSpaceDoc,
         exclude=excludeVariationTables,
         optimize=optimizeGvar,
-    )[0]
+        skip_vf=lambda vf_name: variableFontNames and vf_name not in variableFontNames,
+    )
 
-    return call_postprocessor(varfont, baseUfo, glyphSet=None, **kwargs)
+    for vfName, varfont in list(vfNameToTTFont.items()):
+        vfNameToTTFont[vfName] = call_postprocessor(
+            varfont, vfNameToBaseUfo[vfName], glyphSet=None, **kwargs
+        )
+
+    return vfNameToTTFont
 
 
 compileVariableCFF2_args = {
@@ -600,48 +642,154 @@ def compileVariableCFF2(designSpaceDoc, **kwargs):
     The rest of the arguments works the same as in the other compile functions.
 
     Returns a new variable TTFont object.
+
+    .. deprecated:: TODO (Jany) version of deprecation
+        use :func:`compileVariableCFF2s` instead (since DesignSpace version 5.0)
     """
     kwargs = init_kwargs(kwargs, compileVariableCFF2_args)
-    baseUfo = getDefaultMasterFont(designSpaceDoc)
-
-    excludeVariationTables = kwargs.pop("excludeVariationTables")
-
-    # FIXME: Hack until we get a fontTools config module. Disable GPOS
-    # compaction while building masters because the compaction will be undone
-    # anyway by varLib merge and then done again on the VF
-    gpos_compact_value = os.environ.pop(GPOS_COMPACT_MODE_ENV_KEY, None)
-    try:
-        otfDesignSpace = compileInterpolatableOTFsFromDS(
-            designSpaceDoc,
-            **{
-                **kwargs,
-                **dict(
-                    useProductionNames=False,  # will rename glyphs after varfont is built
-                    # No need to post-process intermediate fonts.
-                    postProcessorClass=None,
-                ),
-            },
+    fonts = compileVariableCFF2s(designSpaceDoc, **kwargs)
+    if len(fonts) != 1:
+        raise ValueError(
+            "Tried to build a DesignSpace version 5 with multiple variable "
+            "fonts using the old ufo2ft API `compileVariableCFF2`. "
+            "Use the new API instead `compileVariableCFF2s`"
         )
-    finally:
-        if gpos_compact_value is not None:
-            os.environ[GPOS_COMPACT_MODE_ENV_KEY] = gpos_compact_value
+    return next(iter(fonts.values()))
 
-    logger.info("Building variable CFF2 font")
 
+compileVariableCFF2s_args = {
+    **compileVariableCFF2_args,
+    **dict(variableFontNames=None),
+}
+
+
+def compileVariableCFF2s(designSpaceDoc, **kwargs):
+    """Create FontTools CFF2 variable fonts for each variable font defined
+    in the given DesignSpaceDocument, using their UFO sources
+    with interpolatable outlines, using fontTools.varLib.build.
+
+    *excludeVariationTables* is a list of sfnt table tags (str) that is passed on
+      to fontTools.varLib.build, to skip building some variation tables.
+
+    *optimizeCFF* (int) defines whether the CFF charstrings should be
+      specialized and subroutinized. 1 (default) only enables the specialization;
+      2 (default) does both specialization and subroutinization. The value 0 is supposed
+      to disable both optimizations, however it's currently unused, because fontTools
+      has some issues generating a VF with non-specialized CFF2 charstrings:
+      fonttools/fonttools#1979.
+      NOTE: Subroutinization of variable CFF2 requires the "cffsubr" extra requirement.
+
+    *variableFontNames* is an optional list of filenames of variable fonts
+      to build. If not provided, all variable fonts listed in the given
+      designspace will by built.
+
+    The rest of the arguments works the same as in the other compile functions.
+
+    Returns a dictionary that maps each variable font filename to a new variable
+    TTFont object.
+
+    .. versionadded:: TODO (Jany) version of addition
+    """
+    kwargs = init_kwargs(kwargs, compileVariableCFF2s_args)
+    excludeVariationTables = kwargs.pop("excludeVariationTables")
     optimizeCFF = CFFOptimization(kwargs.pop("optimizeCFF"))
+    variableFontNames = kwargs.pop("variableFontNames")
 
-    varfont = varLib.build(
-        otfDesignSpace,
+    # Pop inplace because we'll make a copy at this level so deeper functions don't need to worry
+    inplace = kwargs.pop("inplace")
+    if not inplace:
+        designSpaceDoc = copy.deepcopy(designSpaceDoc)
+
+    vfNameToBaseUfo = _compileNeededSources(
+        kwargs, designSpaceDoc, variableFontNames, compileInterpolatableOTFsFromDS
+    )
+
+    if not vfNameToBaseUfo:
+        logger.warning("No variable fonts to build")
+        return {}
+
+    logger.info(f"Building variable CFF2 fonts: {', '.join(vfNameToBaseUfo)}")
+
+    vfNameToTTFont = varLib.build_many(
+        designSpaceDoc,
         exclude=excludeVariationTables,
         # NOTE optimize=False won't change anything until this PR is merged
         # https://github.com/fonttools/fonttools/pull/1979
         optimize=optimizeCFF >= CFFOptimization.SPECIALIZE,
-    )[0]
-
-    return call_postprocessor(
-        varfont,
-        baseUfo,
-        glyphSet=None,
-        **kwargs,
-        optimizeCFF=optimizeCFF >= CFFOptimization.SUBROUTINIZE,
+        skip_vf=lambda vf_name: variableFontNames and vf_name not in variableFontNames,
     )
+
+    for vfName, varfont in list(vfNameToTTFont.items()):
+        vfNameToTTFont[vfName] = call_postprocessor(
+            varfont,
+            vfNameToBaseUfo[vfName],
+            glyphSet=None,
+            **kwargs,
+            optimizeCFF=optimizeCFF >= CFFOptimization.SUBROUTINIZE,
+        )
+
+    return vfNameToTTFont
+
+
+def _compileNeededSources(
+    kwargs, designSpaceDoc, variableFontNames, compileInterpolatableFunc
+):
+    # We'll need to map <source> elements to TTFonts, to do so make sure that
+    # each <source> has a name.
+    ensure_all_sources_have_names(designSpaceDoc)
+
+    # Go through VFs to build and gather list of needed sources to compile
+    interpolableSubDocs = [
+        subDoc for _location, subDoc in splitInterpolable(designSpaceDoc)
+    ]
+    vfNameToBaseUfo = {}
+    sourcesToCompile = set()
+    for subDoc in interpolableSubDocs:
+        for vfName, vfDoc in splitVariableFonts(subDoc):
+            if variableFontNames is not None and vfName not in variableFontNames:
+                # This VF is not needed so we don't need to compile its sources
+                continue
+            vfNameToBaseUfo[vfName] = vfDoc.findDefault().font
+            for source in vfDoc.sources:
+                sourcesToCompile.add(source.name)
+
+    # Match sources to compile to their Descriptor in the original designspace
+    sourcesByName = {}
+    for source in designSpaceDoc.sources:
+        if source.name in sourcesToCompile:
+            sourcesByName[source.name] = source
+
+    # Compile all needed sources in each interpolable subspace to make sure
+    # they're all compatible; that also ensures that sub-vfs within the same
+    # interpolable sub-space are compatible too.
+    for subDoc in interpolableSubDocs:
+        # Only keep the sources that we've identified earlier as need-to-compile
+        subDoc.sources = [s for s in subDoc.sources if s.name in sourcesToCompile]
+        if not subDoc.sources:
+            continue
+
+        # FIXME: Hack until we get a fontTools config module. Disable GPOS
+        # compaction while building masters because the compaction will be undone
+        # anyway by varLib merge and then done again on the VF
+        gpos_compact_value = os.environ.pop(GPOS_COMPACT_MODE_ENV_KEY, None)
+        try:
+            ttfDesignSpace = compileInterpolatableFunc(
+                subDoc,
+                **{
+                    **kwargs,
+                    **dict(
+                        useProductionNames=False,  # will rename glyphs after varfont is built
+                        # No need to post-process intermediate fonts.
+                        postProcessorClass=None,
+                    ),
+                },
+            )
+        finally:
+            if gpos_compact_value is not None:
+                os.environ[GPOS_COMPACT_MODE_ENV_KEY] = gpos_compact_value
+
+        # Stick TTFs back into original big DS
+        for ttfSource in ttfDesignSpace.sources:
+            sourcesByName[ttfSource.name].font = ttfSource.font
+
+    return vfNameToBaseUfo

--- a/Lib/ufo2ft/__init__.py
+++ b/Lib/ufo2ft/__init__.py
@@ -8,6 +8,7 @@ from fontTools.designspaceLib.split import splitInterpolable, splitVariableFonts
 from fontTools.otlLib.optimize.gpos import GPOS_COMPACT_MODE_ENV_KEY
 
 from ufo2ft.constants import SPARSE_OTF_MASTER_TABLES, SPARSE_TTF_MASTER_TABLES
+from ufo2ft.errors import InvalidDesignSpaceData
 from ufo2ft.featureCompiler import (
     MTI_FEATURES_PREFIX,
     FeatureCompiler,
@@ -743,7 +744,10 @@ def _compileNeededSources(
             if variableFontNames is not None and vfName not in variableFontNames:
                 # This VF is not needed so we don't need to compile its sources
                 continue
-            vfNameToBaseUfo[vfName] = vfDoc.findDefault().font
+            default_source = vfDoc.findDefault()
+            if default_source is None:
+                raise InvalidDesignSpaceData("No default source.")
+            vfNameToBaseUfo[vfName] = default_source.font
             for source in vfDoc.sources:
                 sourcesToCompile.add(source.name)
 

--- a/Lib/ufo2ft/util.py
+++ b/Lib/ufo2ft/util.py
@@ -535,14 +535,14 @@ def prune_unknown_kwargs(kwargs, *callables):
 def ensure_all_sources_have_names(doc: DesignSpaceDocument) -> None:
     """Change in-place the given document to make sure that all <source> elements
     have a unique name assigned.
+
+    This may rename sources with a "temp_master.N" name, designspaceLib's default
+    stand-in.
     """
     used_names: Set[str] = set()
-    counter = 1
+    counter = 0
     for source in doc.sources:
-        while (
-            source.name is None
-            or "temp_master" in source.name  # Legacy quirk in designspaceLib
-            or source.name in used_names
-        ):
-            source.name = f"source.{counter}"
+        while source.name is None or source.name in used_names:
+            source.name = f"temp_master.{counter}"
             counter += 1
+        used_names.add(source.name)

--- a/Lib/ufo2ft/util.py
+++ b/Lib/ufo2ft/util.py
@@ -3,8 +3,10 @@ import logging
 import re
 from copy import deepcopy
 from inspect import currentframe, getfullargspec
+from typing import Set
 
 from fontTools import subset, ttLib, unicodedata
+from fontTools.designspaceLib import DesignSpaceDocument
 from fontTools.feaLib.builder import addOpenTypeFeatures
 from fontTools.misc.fixedTools import otRound
 from fontTools.misc.transform import Identity, Transform
@@ -528,3 +530,19 @@ def prune_unknown_kwargs(kwargs, *callables):
     for func in callables:
         known_args.update(getfullargspec(func).args)
     return {k: v for k, v in kwargs.items() if k in known_args}
+
+
+def ensure_all_sources_have_names(doc: DesignSpaceDocument) -> None:
+    """Change in-place the given document to make sure that all <source> elements
+    have a unique name assigned.
+    """
+    used_names: Set[str] = set()
+    counter = 1
+    for source in doc.sources:
+        while (
+            source.name is None
+            or "temp_master" in source.name  # Legacy quirk in designspaceLib
+            or source.name in used_names
+        ):
+            source.name = f"source.{counter}"
+            counter += 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fonttools[lxml,ufo]==4.29.1
+fonttools[lxml,ufo]==4.33.2
 defcon==0.10.0
 cu2qu==1.6.7.post1
 compreffor==0.5.1.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fonttools[lxml,ufo]==4.33.2
+fonttools[lxml,ufo]==4.33.3
 defcon==0.10.0
 cu2qu==1.6.7.post1
 compreffor==0.5.1.post1

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     setup_requires=pytest_runner + wheel + ["setuptools_scm"],
     tests_require=["pytest>=2.8"],
     install_requires=[
-        "fonttools[ufo]>=4.33.2",
+        "fonttools[ufo]>=4.33.3",
         "cu2qu>=1.6.7",
         "cffsubr>=0.2.8",
         "booleanOperations>=0.9.0",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     setup_requires=pytest_runner + wheel + ["setuptools_scm"],
     tests_require=["pytest>=2.8"],
     install_requires=[
-        "fonttools[ufo]>=4.28.5",
+        "fonttools[ufo]>=4.33.2",
         "cu2qu>=1.6.7",
         "cffsubr>=0.2.8",
         "booleanOperations>=0.9.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,3 +91,36 @@ def designspace(layertestrgufo, layertestbdufo):
     ds.addSource(s3)
 
     return ds
+
+
+@pytest.fixture
+def designspace_v5(FontClass):
+    ds5 = designspaceLib.DesignSpaceDocument.fromfile(
+        "tests/data/DSv5/test_v5_MutatorSans_and_Serif.designspace"
+    )
+
+    sources = {}
+    # Create base UFOs
+    for source in ds5.sources:
+        if source.layerName is not None:
+            continue
+        font = FontClass()
+        for name in ("I", "S", "I.narrow", "S.closed", "a"):
+            font.newGlyph(name)
+        font.lib["public.glyphOrder"] = sorted(font.keys())
+        sources[source.filename] = font
+
+    # Fill in sparse UFOs
+    for source in ds5.sources:
+        if source.layerName is None:
+            continue
+        font = sources[source.filename]
+        layer = font.newLayer(source.layerName)
+        for name in ("I", "S", "I.narrow", "S.closed"):
+            layer.newGlyph(name)
+
+    # Assign UFOs to their attribute
+    for source in ds5.sources:
+        source.font = sources[source.filename]
+
+    return ds5

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,29 +95,48 @@ def designspace(layertestrgufo, layertestbdufo):
 
 @pytest.fixture
 def designspace_v5(FontClass):
+    def draw_rectangle(pen, x_offset, y_offset):
+        pen.moveTo((0 + x_offset, 0 + y_offset))
+        pen.lineTo((10 + x_offset, 0 + y_offset))
+        pen.lineTo((10 + x_offset, 10 + y_offset))
+        pen.lineTo((0 + x_offset, 10 + y_offset))
+        pen.closePath()
+
+    def draw_something(glyph, number, is_sans):
+        # Ensure Sans and Serif sources are incompatible to make sure that the
+        # DS5 code treats them separately when using e.g. cu2qu. Use some number
+        # to offset the drawings so we get some variation.
+        if is_sans:
+            draw_rectangle(glyph.getPen(), 10 * number, 0)
+        else:
+            draw_rectangle(glyph.getPen(), -10 * number, -20)
+            draw_rectangle(glyph.getPen(), 10 * number, 20)
+
     ds5 = designspaceLib.DesignSpaceDocument.fromfile(
         "tests/data/DSv5/test_v5_MutatorSans_and_Serif.designspace"
     )
 
     sources = {}
     # Create base UFOs
-    for source in ds5.sources:
+    for index, source in enumerate(ds5.sources):
         if source.layerName is not None:
             continue
         font = FontClass()
         for name in ("I", "S", "I.narrow", "S.closed", "a"):
-            font.newGlyph(name)
+            glyph = font.newGlyph(name)
+            draw_something(glyph, index, "Serif" not in source.filename)
         font.lib["public.glyphOrder"] = sorted(font.keys())
         sources[source.filename] = font
 
     # Fill in sparse UFOs
-    for source in ds5.sources:
+    for index, source in enumerate(ds5.sources):
         if source.layerName is None:
             continue
         font = sources[source.filename]
         layer = font.newLayer(source.layerName)
         for name in ("I", "S", "I.narrow", "S.closed"):
-            layer.newGlyph(name)
+            glyph = layer.newGlyph(name)
+            draw_something(glyph, index, "Serif" not in source.filename)
 
     # Assign UFOs to their attribute
     for source in ds5.sources:

--- a/tests/data/DSv5/MutatorSansVariable_Weight-CFF2.ttx
+++ b/tests/data/DSv5/MutatorSansVariable_Weight-CFF2.ttx
@@ -21,7 +21,7 @@
     <unitsPerEm value="1000"/>
     <created value="Fri Feb 17 17:17:17 2017"/>
     <modified value="Sun Feb 18 18:18:18 2018"/>
-    <xMin value="50"/>
+    <xMin value="0"/>
     <yMin value="-200"/>
     <xMax value="450"/>
     <yMax value="800"/>
@@ -38,8 +38,8 @@
     <descent value="-200"/>
     <lineGap value="0"/>
     <advanceWidthMax value="500"/>
-    <minLeftSideBearing value="50"/>
-    <minRightSideBearing value="50"/>
+    <minLeftSideBearing value="0"/>
+    <minRightSideBearing value="-10"/>
     <xMaxExtent value="450"/>
     <caretSlopeRise value="1"/>
     <caretSlopeRun value="0"/>
@@ -288,21 +288,37 @@
           900 300 -900 -300 vlineto
         </CharString>
         <CharString name="I">
+          0 40 10 1 blend
+          hmoveto
+          10 10 -10 hlineto
         </CharString>
         <CharString name="I.narrow">
+          0 40 10 1 blend
+          hmoveto
+          10 10 -10 hlineto
         </CharString>
         <CharString name="S">
+          0 40 10 1 blend
+          hmoveto
+          10 10 -10 hlineto
         </CharString>
         <CharString name="S.closed">
+          0 40 10 1 blend
+          hmoveto
+          10 10 -10 hlineto
         </CharString>
         <CharString name="a">
+          1 vsindex
+          0 10 1 blend
+          hmoveto
+          10 10 -10 hlineto
         </CharString>
       </CharStrings>
       <VarStore Format="1">
         <Format value="1"/>
         <VarRegionList>
           <!-- RegionAxisCount=1 -->
-          <!-- RegionCount=2 -->
+          <!-- RegionCount=3 -->
           <Region index="0">
             <VarRegionAxis index="0">
               <StartCoord value="0.0"/>
@@ -317,14 +333,27 @@
               <EndCoord value="1.0"/>
             </VarRegionAxis>
           </Region>
+          <Region index="2">
+            <VarRegionAxis index="0">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
+            </VarRegionAxis>
+          </Region>
         </VarRegionList>
-        <!-- VarDataCount=1 -->
+        <!-- VarDataCount=2 -->
         <VarData index="0">
           <!-- ItemCount=0 -->
           <NumShorts value="0"/>
           <!-- VarRegionCount=2 -->
           <VarRegionIndex index="0" value="0"/>
           <VarRegionIndex index="1" value="1"/>
+        </VarData>
+        <VarData index="1">
+          <!-- ItemCount=0 -->
+          <NumShorts value="0"/>
+          <!-- VarRegionCount=1 -->
+          <VarRegionIndex index="0" value="2"/>
         </VarData>
       </VarStore>
     </CFFFont>

--- a/tests/data/DSv5/MutatorSansVariable_Weight-CFF2.ttx
+++ b/tests/data/DSv5/MutatorSansVariable_Weight-CFF2.ttx
@@ -1,0 +1,568 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="OTTO" ttLibVersion="4.33">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="I"/>
+    <GlyphID id="2" name="I.narrow"/>
+    <GlyphID id="3" name="S"/>
+    <GlyphID id="4" name="S.closed"/>
+    <GlyphID id="5" name="a"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="0.0"/>
+    <checkSumAdjustment value="0x12345678"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Fri Feb 17 17:17:17 2017"/>
+    <modified value="Sun Feb 18 18:18:18 2018"/>
+    <xMin value="50"/>
+    <yMin value="-200"/>
+    <xMax value="450"/>
+    <yMax value="800"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="6"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1000"/>
+    <descent value="-200"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="500"/>
+    <minLeftSideBearing value="50"/>
+    <minRightSideBearing value="50"/>
+    <xMaxExtent value="450"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="2"/>
+  </hhea>
+
+  <maxp>
+    <tableVersion value="0x5000"/>
+    <numGlyphs value="6"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="500"/>
+    <usWeightClass value="300"/>
+    <usWidthClass value="5"/>
+    <fsType value="00000000 00000100"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="300"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="0"/>
+      <bSerifStyle value="0"/>
+      <bWeight value="0"/>
+      <bProportion value="0"/>
+      <bContrast value="0"/>
+      <bStrokeVariation value="0"/>
+      <bArmStyle value="0"/>
+      <bLetterForm value="0"/>
+      <bMidline value="0"/>
+      <bXHeight value="0"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="NONE"/>
+    <fsSelection value="00000000 01000000"/>
+    <usFirstCharIndex value="65535"/>
+    <usLastCharIndex value="65535"/>
+    <sTypoAscender value="800"/>
+    <sTypoDescender value="-200"/>
+    <sTypoLineGap value="200"/>
+    <usWinAscent value="1000"/>
+    <usWinDescent value="200"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="500"/>
+    <sCapHeight value="700"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="0"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="500" lsb="50"/>
+    <mtx name="I" width="0" lsb="0"/>
+    <mtx name="I.narrow" width="0" lsb="0"/>
+    <mtx name="S" width="0" lsb="0"/>
+    <mtx name="S.closed" width="0" lsb="0"/>
+    <mtx name="a" width="0" lsb="0"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+    </cmap_format_4>
+  </cmap>
+
+  <name>
+    <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Weight
+    </namerecord>
+    <namerecord nameID="257" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Sans Light Condensed
+    </namerecord>
+    <namerecord nameID="258" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      MutatorMathTest-SansLightCondensed
+    </namerecord>
+    <namerecord nameID="259" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Sans Bold Condensed
+    </namerecord>
+    <namerecord nameID="260" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      MutatorMathTest-SansBoldCondensed
+    </namerecord>
+    <namerecord nameID="261" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      MutatorMathTest-SansLightCondensed
+    </namerecord>
+    <namerecord nameID="262" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Regular
+    </namerecord>
+    <namerecord nameID="263" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      serif
+    </namerecord>
+    <namerecord nameID="264" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Sans
+    </namerecord>
+    <namerecord nameID="265" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      weight
+    </namerecord>
+    <namerecord nameID="266" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Light
+    </namerecord>
+    <namerecord nameID="267" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Medium
+    </namerecord>
+    <namerecord nameID="268" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Bold
+    </namerecord>
+    <namerecord nameID="269" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      width
+    </namerecord>
+    <namerecord nameID="270" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Condensed
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      New Font
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      0.000;NONE;NewFont-Regular
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      New Font Regular
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 0.000
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      NewFont-Regular
+    </namerecord>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
+      Weight
+    </namerecord>
+    <namerecord nameID="257" platformID="3" platEncID="1" langID="0x409">
+      Sans Light Condensed
+    </namerecord>
+    <namerecord nameID="258" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-SansLightCondensed
+    </namerecord>
+    <namerecord nameID="259" platformID="3" platEncID="1" langID="0x409">
+      Sans Bold Condensed
+    </namerecord>
+    <namerecord nameID="260" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-SansBoldCondensed
+    </namerecord>
+    <namerecord nameID="261" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-SansLightCondensed
+    </namerecord>
+    <namerecord nameID="262" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="263" platformID="3" platEncID="1" langID="0x409">
+      serif
+    </namerecord>
+    <namerecord nameID="264" platformID="3" platEncID="1" langID="0x409">
+      Sans
+    </namerecord>
+    <namerecord nameID="265" platformID="3" platEncID="1" langID="0x409">
+      weight
+    </namerecord>
+    <namerecord nameID="266" platformID="3" platEncID="1" langID="0x409">
+      Light
+    </namerecord>
+    <namerecord nameID="267" platformID="3" platEncID="1" langID="0x409">
+      Medium
+    </namerecord>
+    <namerecord nameID="268" platformID="3" platEncID="1" langID="0x409">
+      Bold
+    </namerecord>
+    <namerecord nameID="269" platformID="3" platEncID="1" langID="0x409">
+      width
+    </namerecord>
+    <namerecord nameID="270" platformID="3" platEncID="1" langID="0x409">
+      Condensed
+    </namerecord>
+  </name>
+
+  <post>
+    <formatType value="2.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-75"/>
+    <underlineThickness value="50"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+    <psNames>
+      <!-- This file uses unique glyph names based on the information
+           found in the 'post' table. Since these names might not be unique,
+           we have to invent artificial names in case of clashes. In order to
+           be able to retain the original information, we need a name to
+           ps name mapping for those cases where they differ. That's what
+           you see below.
+            -->
+    </psNames>
+    <extraNames>
+      <!-- following are the name that are not taken from the standard Mac glyph order -->
+      <psName name="I.narrow"/>
+      <psName name="S.closed"/>
+    </extraNames>
+  </post>
+
+  <CFF2>
+    <major value="2"/>
+    <minor value="0"/>
+    <CFFFont name="CFF2Font">
+      <FontMatrix value="0.001 0 0 0.001 0 0"/>
+      <FDArray>
+        <FontDict index="0">
+          <Private>
+            <BlueScale value="0.039625"/>
+            <BlueShift value="7"/>
+            <BlueFuzz value="1"/>
+            <LanguageGroup value="0"/>
+            <ExpansionFactor value="0.06"/>
+          </Private>
+        </FontDict>
+      </FDArray>
+      <CharStrings>
+        <CharString name=".notdef">
+          50 -200 rmoveto
+          400 1000 -400 -1000 hlineto
+          50 50 rmoveto
+          900 300 -900 -300 vlineto
+        </CharString>
+        <CharString name="I">
+        </CharString>
+        <CharString name="I.narrow">
+        </CharString>
+        <CharString name="S">
+        </CharString>
+        <CharString name="S.closed">
+        </CharString>
+        <CharString name="a">
+        </CharString>
+      </CharStrings>
+      <VarStore Format="1">
+        <Format value="1"/>
+        <VarRegionList>
+          <!-- RegionAxisCount=1 -->
+          <!-- RegionCount=2 -->
+          <Region index="0">
+            <VarRegionAxis index="0">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.7"/>
+              <EndCoord value="1.0"/>
+            </VarRegionAxis>
+          </Region>
+          <Region index="1">
+            <VarRegionAxis index="0">
+              <StartCoord value="0.7"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
+            </VarRegionAxis>
+          </Region>
+        </VarRegionList>
+        <!-- VarDataCount=1 -->
+        <VarData index="0">
+          <!-- ItemCount=0 -->
+          <NumShorts value="0"/>
+          <!-- VarRegionCount=2 -->
+          <VarRegionIndex index="0" value="0"/>
+          <VarRegionIndex index="1" value="1"/>
+        </VarData>
+      </VarStore>
+    </CFFFont>
+
+    <GlobalSubrs>
+      <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+    </GlobalSubrs>
+  </CFF2>
+
+  <GSUB>
+    <Version value="0x00010001"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="rvrn"/>
+        <Feature>
+          <!-- LookupCount=0 -->
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=2 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="I" out="I.narrow"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="S" out="S.closed"/>
+        </SingleSubst>
+      </Lookup>
+    </LookupList>
+    <FeatureVariations>
+      <Version value="0x00010000"/>
+      <!-- FeatureVariationCount=2 -->
+      <FeatureVariationRecord index="0">
+        <ConditionSet>
+          <!-- ConditionCount=1 -->
+          <ConditionTable index="0" Format="1">
+            <AxisIndex value="0"/>
+            <FilterRangeMinValue value="0.0"/>
+            <FilterRangeMaxValue value="0.5"/>
+          </ConditionTable>
+        </ConditionSet>
+        <FeatureTableSubstitution>
+          <Version value="0x00010000"/>
+          <!-- SubstitutionCount=1 -->
+          <SubstitutionRecord index="0">
+            <FeatureIndex value="0"/>
+            <Feature>
+              <!-- LookupCount=2 -->
+              <LookupListIndex index="0" value="0"/>
+              <LookupListIndex index="1" value="1"/>
+            </Feature>
+          </SubstitutionRecord>
+        </FeatureTableSubstitution>
+      </FeatureVariationRecord>
+      <FeatureVariationRecord index="1">
+        <ConditionSet>
+          <!-- ConditionCount=0 -->
+        </ConditionSet>
+        <FeatureTableSubstitution>
+          <Version value="0x00010000"/>
+          <!-- SubstitutionCount=1 -->
+          <SubstitutionRecord index="0">
+            <FeatureIndex value="0"/>
+            <Feature>
+              <!-- LookupCount=1 -->
+              <LookupListIndex index="0" value="0"/>
+            </Feature>
+          </SubstitutionRecord>
+        </FeatureTableSubstitution>
+      </FeatureVariationRecord>
+    </FeatureVariations>
+  </GSUB>
+
+  <HVAR>
+    <Version value="0x00010000"/>
+    <VarStore Format="1">
+      <Format value="1"/>
+      <VarRegionList>
+        <!-- RegionAxisCount=1 -->
+        <!-- RegionCount=3 -->
+        <Region index="0">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.7"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="1">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.7"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="2">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+      </VarRegionList>
+      <!-- VarDataCount=1 -->
+      <VarData index="0">
+        <!-- ItemCount=1 -->
+        <NumShorts value="0"/>
+        <!-- VarRegionCount=0 -->
+        <Item index="0" value="[]"/>
+      </VarData>
+    </VarStore>
+    <AdvWidthMap>
+      <Map glyph=".notdef" outer="0" inner="0"/>
+      <Map glyph="I" outer="0" inner="0"/>
+      <Map glyph="I.narrow" outer="0" inner="0"/>
+      <Map glyph="S" outer="0" inner="0"/>
+      <Map glyph="S.closed" outer="0" inner="0"/>
+      <Map glyph="a" outer="0" inner="0"/>
+    </AdvWidthMap>
+  </HVAR>
+
+  <STAT>
+    <Version value="0x00010001"/>
+    <DesignAxisRecordSize value="8"/>
+    <!-- DesignAxisCount=3 -->
+    <DesignAxisRecord>
+      <Axis index="0">
+        <AxisTag value="SRIF"/>
+        <AxisNameID value="263"/>  <!-- serif -->
+        <AxisOrdering value="0"/>
+      </Axis>
+      <Axis index="1">
+        <AxisTag value="wght"/>
+        <AxisNameID value="265"/>  <!-- weight -->
+        <AxisOrdering value="1"/>
+      </Axis>
+      <Axis index="2">
+        <AxisTag value="wdth"/>
+        <AxisNameID value="269"/>  <!-- width -->
+        <AxisOrdering value="2"/>
+      </Axis>
+    </DesignAxisRecord>
+    <!-- AxisValueCount=5 -->
+    <AxisValueArray>
+      <AxisValue index="0" Format="1">
+        <AxisIndex value="0"/>
+        <Flags value="0"/>
+        <ValueNameID value="264"/>  <!-- Sans -->
+        <Value value="0.0"/>
+      </AxisValue>
+      <AxisValue index="1" Format="2">
+        <AxisIndex value="1"/>
+        <Flags value="0"/>
+        <ValueNameID value="266"/>  <!-- Light -->
+        <NominalValue value="300.0"/>
+        <RangeMinValue value="300.0"/>
+        <RangeMaxValue value="400.0"/>
+      </AxisValue>
+      <AxisValue index="2" Format="2">
+        <AxisIndex value="1"/>
+        <Flags value="0"/>
+        <ValueNameID value="267"/>  <!-- Medium -->
+        <NominalValue value="500.0"/>
+        <RangeMinValue value="400.0"/>
+        <RangeMaxValue value="600.0"/>
+      </AxisValue>
+      <AxisValue index="3" Format="2">
+        <AxisIndex value="1"/>
+        <Flags value="0"/>
+        <ValueNameID value="268"/>  <!-- Bold -->
+        <NominalValue value="700.0"/>
+        <RangeMinValue value="600.0"/>
+        <RangeMaxValue value="700.0"/>
+      </AxisValue>
+      <AxisValue index="4" Format="2">
+        <AxisIndex value="2"/>
+        <Flags value="0"/>
+        <ValueNameID value="270"/>  <!-- Condensed -->
+        <NominalValue value="50.0"/>
+        <RangeMinValue value="50.0"/>
+        <RangeMaxValue value="75.0"/>
+      </AxisValue>
+    </AxisValueArray>
+    <ElidedFallbackNameID value="262"/>  <!-- Regular -->
+  </STAT>
+
+  <fvar>
+
+    <!-- Weight -->
+    <Axis>
+      <AxisTag>wght</AxisTag>
+      <Flags>0x0</Flags>
+      <MinValue>300.0</MinValue>
+      <DefaultValue>300.0</DefaultValue>
+      <MaxValue>700.0</MaxValue>
+      <AxisNameID>256</AxisNameID>
+    </Axis>
+
+    <!-- Sans Light Condensed -->
+    <!-- PostScript: MutatorMathTest-SansLightCondensed -->
+    <NamedInstance flags="0x0" postscriptNameID="258" subfamilyNameID="257">
+      <coord axis="wght" value="300.0"/>
+    </NamedInstance>
+
+    <!-- Sans Bold Condensed -->
+    <!-- PostScript: MutatorMathTest-SansBoldCondensed -->
+    <NamedInstance flags="0x0" postscriptNameID="260" subfamilyNameID="259">
+      <coord axis="wght" value="700.0"/>
+    </NamedInstance>
+
+    <!-- Sans Light Condensed -->
+    <!-- PostScript: MutatorMathTest-SansLightCondensed -->
+    <NamedInstance flags="0x0" postscriptNameID="261" subfamilyNameID="257">
+      <coord axis="wght" value="300.0"/>
+    </NamedInstance>
+  </fvar>
+
+</ttFont>

--- a/tests/data/DSv5/MutatorSansVariable_Weight-TTF.ttx
+++ b/tests/data/DSv5/MutatorSansVariable_Weight-TTF.ttx
@@ -1,0 +1,554 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.33">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="I"/>
+    <GlyphID id="2" name="I.narrow"/>
+    <GlyphID id="3" name="S"/>
+    <GlyphID id="4" name="S.closed"/>
+    <GlyphID id="5" name="a"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="0.0"/>
+    <checkSumAdjustment value="0x12345678"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Fri Feb 17 17:17:17 2017"/>
+    <modified value="Sun Feb 18 18:18:18 2018"/>
+    <xMin value="50"/>
+    <yMin value="-200"/>
+    <xMax value="450"/>
+    <yMax value="800"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="6"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1000"/>
+    <descent value="-200"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="500"/>
+    <minLeftSideBearing value="50"/>
+    <minRightSideBearing value="50"/>
+    <xMaxExtent value="450"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="2"/>
+  </hhea>
+
+  <maxp>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="0x10000"/>
+    <numGlyphs value="6"/>
+    <maxPoints value="8"/>
+    <maxContours value="2"/>
+    <maxCompositePoints value="0"/>
+    <maxCompositeContours value="0"/>
+    <maxZones value="1"/>
+    <maxTwilightPoints value="0"/>
+    <maxStorage value="0"/>
+    <maxFunctionDefs value="0"/>
+    <maxInstructionDefs value="0"/>
+    <maxStackElements value="0"/>
+    <maxSizeOfInstructions value="0"/>
+    <maxComponentElements value="0"/>
+    <maxComponentDepth value="0"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="500"/>
+    <usWeightClass value="300"/>
+    <usWidthClass value="5"/>
+    <fsType value="00000000 00000100"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="300"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="0"/>
+      <bSerifStyle value="0"/>
+      <bWeight value="0"/>
+      <bProportion value="0"/>
+      <bContrast value="0"/>
+      <bStrokeVariation value="0"/>
+      <bArmStyle value="0"/>
+      <bLetterForm value="0"/>
+      <bMidline value="0"/>
+      <bXHeight value="0"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="NONE"/>
+    <fsSelection value="00000000 01000000"/>
+    <usFirstCharIndex value="65535"/>
+    <usLastCharIndex value="65535"/>
+    <sTypoAscender value="800"/>
+    <sTypoDescender value="-200"/>
+    <sTypoLineGap value="200"/>
+    <usWinAscent value="1000"/>
+    <usWinDescent value="200"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="500"/>
+    <sCapHeight value="700"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="0"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="500" lsb="50"/>
+    <mtx name="I" width="0" lsb="0"/>
+    <mtx name="I.narrow" width="0" lsb="0"/>
+    <mtx name="S" width="0" lsb="0"/>
+    <mtx name="S.closed" width="0" lsb="0"/>
+    <mtx name="a" width="0" lsb="0"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+    </cmap_format_4>
+  </cmap>
+
+  <loca>
+    <!-- The 'loca' table will be calculated by the compiler -->
+  </loca>
+
+  <glyf>
+
+    <!-- The xMin, yMin, xMax and yMax values
+         will be recalculated by the compiler. -->
+
+    <TTGlyph name=".notdef" xMin="50" yMin="-200" xMax="450" yMax="800">
+      <contour>
+        <pt x="50" y="-200" on="1"/>
+        <pt x="50" y="800" on="1"/>
+        <pt x="450" y="800" on="1"/>
+        <pt x="450" y="-200" on="1"/>
+      </contour>
+      <contour>
+        <pt x="100" y="-150" on="1"/>
+        <pt x="400" y="-150" on="1"/>
+        <pt x="400" y="750" on="1"/>
+        <pt x="100" y="750" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="I"/><!-- contains no outline data -->
+
+    <TTGlyph name="I.narrow"/><!-- contains no outline data -->
+
+    <TTGlyph name="S"/><!-- contains no outline data -->
+
+    <TTGlyph name="S.closed"/><!-- contains no outline data -->
+
+    <TTGlyph name="a"/><!-- contains no outline data -->
+
+  </glyf>
+
+  <name>
+    <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Weight
+    </namerecord>
+    <namerecord nameID="257" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Sans Light Condensed
+    </namerecord>
+    <namerecord nameID="258" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      MutatorMathTest-SansLightCondensed
+    </namerecord>
+    <namerecord nameID="259" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Sans Bold Condensed
+    </namerecord>
+    <namerecord nameID="260" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      MutatorMathTest-SansBoldCondensed
+    </namerecord>
+    <namerecord nameID="261" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      MutatorMathTest-SansLightCondensed
+    </namerecord>
+    <namerecord nameID="262" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Regular
+    </namerecord>
+    <namerecord nameID="263" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      serif
+    </namerecord>
+    <namerecord nameID="264" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Sans
+    </namerecord>
+    <namerecord nameID="265" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      weight
+    </namerecord>
+    <namerecord nameID="266" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Light
+    </namerecord>
+    <namerecord nameID="267" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Medium
+    </namerecord>
+    <namerecord nameID="268" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Bold
+    </namerecord>
+    <namerecord nameID="269" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      width
+    </namerecord>
+    <namerecord nameID="270" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Condensed
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      New Font
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      0.000;NONE;NewFont-Regular
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      New Font Regular
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 0.000
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      NewFont-Regular
+    </namerecord>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
+      Weight
+    </namerecord>
+    <namerecord nameID="257" platformID="3" platEncID="1" langID="0x409">
+      Sans Light Condensed
+    </namerecord>
+    <namerecord nameID="258" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-SansLightCondensed
+    </namerecord>
+    <namerecord nameID="259" platformID="3" platEncID="1" langID="0x409">
+      Sans Bold Condensed
+    </namerecord>
+    <namerecord nameID="260" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-SansBoldCondensed
+    </namerecord>
+    <namerecord nameID="261" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-SansLightCondensed
+    </namerecord>
+    <namerecord nameID="262" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="263" platformID="3" platEncID="1" langID="0x409">
+      serif
+    </namerecord>
+    <namerecord nameID="264" platformID="3" platEncID="1" langID="0x409">
+      Sans
+    </namerecord>
+    <namerecord nameID="265" platformID="3" platEncID="1" langID="0x409">
+      weight
+    </namerecord>
+    <namerecord nameID="266" platformID="3" platEncID="1" langID="0x409">
+      Light
+    </namerecord>
+    <namerecord nameID="267" platformID="3" platEncID="1" langID="0x409">
+      Medium
+    </namerecord>
+    <namerecord nameID="268" platformID="3" platEncID="1" langID="0x409">
+      Bold
+    </namerecord>
+    <namerecord nameID="269" platformID="3" platEncID="1" langID="0x409">
+      width
+    </namerecord>
+    <namerecord nameID="270" platformID="3" platEncID="1" langID="0x409">
+      Condensed
+    </namerecord>
+  </name>
+
+  <post>
+    <formatType value="2.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-75"/>
+    <underlineThickness value="50"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+    <psNames>
+      <!-- This file uses unique glyph names based on the information
+           found in the 'post' table. Since these names might not be unique,
+           we have to invent artificial names in case of clashes. In order to
+           be able to retain the original information, we need a name to
+           ps name mapping for those cases where they differ. That's what
+           you see below.
+            -->
+    </psNames>
+    <extraNames>
+      <!-- following are the name that are not taken from the standard Mac glyph order -->
+      <psName name="I.narrow"/>
+      <psName name="S.closed"/>
+    </extraNames>
+  </post>
+
+  <GSUB>
+    <Version value="0x00010001"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="rvrn"/>
+        <Feature>
+          <!-- LookupCount=0 -->
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=2 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="I" out="I.narrow"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="S" out="S.closed"/>
+        </SingleSubst>
+      </Lookup>
+    </LookupList>
+    <FeatureVariations>
+      <Version value="0x00010000"/>
+      <!-- FeatureVariationCount=2 -->
+      <FeatureVariationRecord index="0">
+        <ConditionSet>
+          <!-- ConditionCount=1 -->
+          <ConditionTable index="0" Format="1">
+            <AxisIndex value="0"/>
+            <FilterRangeMinValue value="0.0"/>
+            <FilterRangeMaxValue value="0.5"/>
+          </ConditionTable>
+        </ConditionSet>
+        <FeatureTableSubstitution>
+          <Version value="0x00010000"/>
+          <!-- SubstitutionCount=1 -->
+          <SubstitutionRecord index="0">
+            <FeatureIndex value="0"/>
+            <Feature>
+              <!-- LookupCount=2 -->
+              <LookupListIndex index="0" value="0"/>
+              <LookupListIndex index="1" value="1"/>
+            </Feature>
+          </SubstitutionRecord>
+        </FeatureTableSubstitution>
+      </FeatureVariationRecord>
+      <FeatureVariationRecord index="1">
+        <ConditionSet>
+          <!-- ConditionCount=0 -->
+        </ConditionSet>
+        <FeatureTableSubstitution>
+          <Version value="0x00010000"/>
+          <!-- SubstitutionCount=1 -->
+          <SubstitutionRecord index="0">
+            <FeatureIndex value="0"/>
+            <Feature>
+              <!-- LookupCount=1 -->
+              <LookupListIndex index="0" value="0"/>
+            </Feature>
+          </SubstitutionRecord>
+        </FeatureTableSubstitution>
+      </FeatureVariationRecord>
+    </FeatureVariations>
+  </GSUB>
+
+  <HVAR>
+    <Version value="0x00010000"/>
+    <VarStore Format="1">
+      <Format value="1"/>
+      <VarRegionList>
+        <!-- RegionAxisCount=1 -->
+        <!-- RegionCount=3 -->
+        <Region index="0">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.7"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="1">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.7"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="2">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+      </VarRegionList>
+      <!-- VarDataCount=1 -->
+      <VarData index="0">
+        <!-- ItemCount=1 -->
+        <NumShorts value="0"/>
+        <!-- VarRegionCount=0 -->
+        <Item index="0" value="[]"/>
+      </VarData>
+    </VarStore>
+    <AdvWidthMap>
+      <Map glyph=".notdef" outer="0" inner="0"/>
+      <Map glyph="I" outer="0" inner="0"/>
+      <Map glyph="I.narrow" outer="0" inner="0"/>
+      <Map glyph="S" outer="0" inner="0"/>
+      <Map glyph="S.closed" outer="0" inner="0"/>
+      <Map glyph="a" outer="0" inner="0"/>
+    </AdvWidthMap>
+  </HVAR>
+
+  <STAT>
+    <Version value="0x00010001"/>
+    <DesignAxisRecordSize value="8"/>
+    <!-- DesignAxisCount=3 -->
+    <DesignAxisRecord>
+      <Axis index="0">
+        <AxisTag value="SRIF"/>
+        <AxisNameID value="263"/>  <!-- serif -->
+        <AxisOrdering value="0"/>
+      </Axis>
+      <Axis index="1">
+        <AxisTag value="wght"/>
+        <AxisNameID value="265"/>  <!-- weight -->
+        <AxisOrdering value="1"/>
+      </Axis>
+      <Axis index="2">
+        <AxisTag value="wdth"/>
+        <AxisNameID value="269"/>  <!-- width -->
+        <AxisOrdering value="2"/>
+      </Axis>
+    </DesignAxisRecord>
+    <!-- AxisValueCount=5 -->
+    <AxisValueArray>
+      <AxisValue index="0" Format="1">
+        <AxisIndex value="0"/>
+        <Flags value="0"/>
+        <ValueNameID value="264"/>  <!-- Sans -->
+        <Value value="0.0"/>
+      </AxisValue>
+      <AxisValue index="1" Format="2">
+        <AxisIndex value="1"/>
+        <Flags value="0"/>
+        <ValueNameID value="266"/>  <!-- Light -->
+        <NominalValue value="300.0"/>
+        <RangeMinValue value="300.0"/>
+        <RangeMaxValue value="400.0"/>
+      </AxisValue>
+      <AxisValue index="2" Format="2">
+        <AxisIndex value="1"/>
+        <Flags value="0"/>
+        <ValueNameID value="267"/>  <!-- Medium -->
+        <NominalValue value="500.0"/>
+        <RangeMinValue value="400.0"/>
+        <RangeMaxValue value="600.0"/>
+      </AxisValue>
+      <AxisValue index="3" Format="2">
+        <AxisIndex value="1"/>
+        <Flags value="0"/>
+        <ValueNameID value="268"/>  <!-- Bold -->
+        <NominalValue value="700.0"/>
+        <RangeMinValue value="600.0"/>
+        <RangeMaxValue value="700.0"/>
+      </AxisValue>
+      <AxisValue index="4" Format="2">
+        <AxisIndex value="2"/>
+        <Flags value="0"/>
+        <ValueNameID value="270"/>  <!-- Condensed -->
+        <NominalValue value="50.0"/>
+        <RangeMinValue value="50.0"/>
+        <RangeMaxValue value="75.0"/>
+      </AxisValue>
+    </AxisValueArray>
+    <ElidedFallbackNameID value="262"/>  <!-- Regular -->
+  </STAT>
+
+  <fvar>
+
+    <!-- Weight -->
+    <Axis>
+      <AxisTag>wght</AxisTag>
+      <Flags>0x0</Flags>
+      <MinValue>300.0</MinValue>
+      <DefaultValue>300.0</DefaultValue>
+      <MaxValue>700.0</MaxValue>
+      <AxisNameID>256</AxisNameID>
+    </Axis>
+
+    <!-- Sans Light Condensed -->
+    <!-- PostScript: MutatorMathTest-SansLightCondensed -->
+    <NamedInstance flags="0x0" postscriptNameID="258" subfamilyNameID="257">
+      <coord axis="wght" value="300.0"/>
+    </NamedInstance>
+
+    <!-- Sans Bold Condensed -->
+    <!-- PostScript: MutatorMathTest-SansBoldCondensed -->
+    <NamedInstance flags="0x0" postscriptNameID="260" subfamilyNameID="259">
+      <coord axis="wght" value="700.0"/>
+    </NamedInstance>
+
+    <!-- Sans Light Condensed -->
+    <!-- PostScript: MutatorMathTest-SansLightCondensed -->
+    <NamedInstance flags="0x0" postscriptNameID="261" subfamilyNameID="257">
+      <coord axis="wght" value="300.0"/>
+    </NamedInstance>
+  </fvar>
+
+  <gvar>
+    <version value="1"/>
+    <reserved value="0"/>
+  </gvar>
+
+</ttFont>

--- a/tests/data/DSv5/MutatorSansVariable_Weight-TTF.ttx
+++ b/tests/data/DSv5/MutatorSansVariable_Weight-TTF.ttx
@@ -21,7 +21,7 @@
     <unitsPerEm value="1000"/>
     <created value="Fri Feb 17 17:17:17 2017"/>
     <modified value="Sun Feb 18 18:18:18 2018"/>
-    <xMin value="50"/>
+    <xMin value="0"/>
     <yMin value="-200"/>
     <xMax value="450"/>
     <yMax value="800"/>
@@ -38,8 +38,8 @@
     <descent value="-200"/>
     <lineGap value="0"/>
     <advanceWidthMax value="500"/>
-    <minLeftSideBearing value="50"/>
-    <minRightSideBearing value="50"/>
+    <minLeftSideBearing value="0"/>
+    <minRightSideBearing value="-10"/>
     <xMaxExtent value="450"/>
     <caretSlopeRise value="1"/>
     <caretSlopeRun value="0"/>
@@ -166,15 +166,55 @@
       <instructions/>
     </TTGlyph>
 
-    <TTGlyph name="I"/><!-- contains no outline data -->
+    <TTGlyph name="I" xMin="0" yMin="0" xMax="10" yMax="10">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="10" on="1"/>
+        <pt x="10" y="10" on="1"/>
+        <pt x="10" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
-    <TTGlyph name="I.narrow"/><!-- contains no outline data -->
+    <TTGlyph name="I.narrow" xMin="0" yMin="0" xMax="10" yMax="10">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="10" on="1"/>
+        <pt x="10" y="10" on="1"/>
+        <pt x="10" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
-    <TTGlyph name="S"/><!-- contains no outline data -->
+    <TTGlyph name="S" xMin="0" yMin="0" xMax="10" yMax="10">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="10" on="1"/>
+        <pt x="10" y="10" on="1"/>
+        <pt x="10" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
-    <TTGlyph name="S.closed"/><!-- contains no outline data -->
+    <TTGlyph name="S.closed" xMin="0" yMin="0" xMax="10" yMax="10">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="10" on="1"/>
+        <pt x="10" y="10" on="1"/>
+        <pt x="10" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
-    <TTGlyph name="a"/><!-- contains no outline data -->
+    <TTGlyph name="a" xMin="0" yMin="0" xMax="10" yMax="10">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="10" on="1"/>
+        <pt x="10" y="10" on="1"/>
+        <pt x="10" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
   </glyf>
 
@@ -549,6 +589,52 @@
   <gvar>
     <version value="1"/>
     <reserved value="0"/>
+    <glyphVariations glyph="I">
+      <tuple>
+        <coord axis="wght" min="0.0" value="0.7" max="1.0"/>
+        <delta pt="0" x="40" y="0"/>
+      </tuple>
+      <tuple>
+        <coord axis="wght" min="0.7" value="1.0" max="1.0"/>
+        <delta pt="0" x="10" y="0"/>
+      </tuple>
+    </glyphVariations>
+    <glyphVariations glyph="I.narrow">
+      <tuple>
+        <coord axis="wght" min="0.0" value="0.7" max="1.0"/>
+        <delta pt="0" x="40" y="0"/>
+      </tuple>
+      <tuple>
+        <coord axis="wght" min="0.7" value="1.0" max="1.0"/>
+        <delta pt="0" x="10" y="0"/>
+      </tuple>
+    </glyphVariations>
+    <glyphVariations glyph="S">
+      <tuple>
+        <coord axis="wght" min="0.0" value="0.7" max="1.0"/>
+        <delta pt="0" x="40" y="0"/>
+      </tuple>
+      <tuple>
+        <coord axis="wght" min="0.7" value="1.0" max="1.0"/>
+        <delta pt="0" x="10" y="0"/>
+      </tuple>
+    </glyphVariations>
+    <glyphVariations glyph="S.closed">
+      <tuple>
+        <coord axis="wght" min="0.0" value="0.7" max="1.0"/>
+        <delta pt="0" x="40" y="0"/>
+      </tuple>
+      <tuple>
+        <coord axis="wght" min="0.7" value="1.0" max="1.0"/>
+        <delta pt="0" x="10" y="0"/>
+      </tuple>
+    </glyphVariations>
+    <glyphVariations glyph="a">
+      <tuple>
+        <coord axis="wght" value="1.0"/>
+        <delta pt="0" x="10" y="0"/>
+      </tuple>
+    </glyphVariations>
   </gvar>
 
 </ttFont>

--- a/tests/data/DSv5/MutatorSansVariable_Weight_Width-CFF2.ttx
+++ b/tests/data/DSv5/MutatorSansVariable_Weight_Width-CFF2.ttx
@@ -21,7 +21,7 @@
     <unitsPerEm value="1000"/>
     <created value="Fri Feb 17 17:17:17 2017"/>
     <modified value="Sun Feb 18 18:18:18 2018"/>
-    <xMin value="50"/>
+    <xMin value="0"/>
     <yMin value="-200"/>
     <xMax value="450"/>
     <yMax value="800"/>
@@ -38,8 +38,8 @@
     <descent value="-200"/>
     <lineGap value="0"/>
     <advanceWidthMax value="500"/>
-    <minLeftSideBearing value="50"/>
-    <minRightSideBearing value="50"/>
+    <minLeftSideBearing value="0"/>
+    <minRightSideBearing value="-10"/>
     <xMaxExtent value="450"/>
     <caretSlopeRise value="1"/>
     <caretSlopeRun value="0"/>
@@ -384,21 +384,37 @@
           900 300 -900 -300 vlineto
         </CharString>
         <CharString name="I">
+          0 40 10 20 -10 0 14 1 blend
+          hmoveto
+          10 10 -10 hlineto
         </CharString>
         <CharString name="I.narrow">
+          0 40 10 20 -10 0 14 1 blend
+          hmoveto
+          10 10 -10 hlineto
         </CharString>
         <CharString name="S">
+          0 40 10 20 -10 0 14 1 blend
+          hmoveto
+          10 10 -10 hlineto
         </CharString>
         <CharString name="S.closed">
+          0 40 10 20 -10 0 14 1 blend
+          hmoveto
+          10 10 -10 hlineto
         </CharString>
         <CharString name="a">
+          1 vsindex
+          0 10 20 0 1 blend
+          hmoveto
+          10 10 -10 hlineto
         </CharString>
       </CharStrings>
       <VarStore Format="1">
         <Format value="1"/>
         <VarRegionList>
           <!-- RegionAxisCount=2 -->
-          <!-- RegionCount=6 -->
+          <!-- RegionCount=8 -->
           <Region index="0">
             <VarRegionAxis index="0">
               <StartCoord value="0.0"/>
@@ -471,8 +487,32 @@
               <EndCoord value="1.0"/>
             </VarRegionAxis>
           </Region>
+          <Region index="6">
+            <VarRegionAxis index="0">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="1">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+          </Region>
+          <Region index="7">
+            <VarRegionAxis index="0">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="1">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
+            </VarRegionAxis>
+          </Region>
         </VarRegionList>
-        <!-- VarDataCount=1 -->
+        <!-- VarDataCount=2 -->
         <VarData index="0">
           <!-- ItemCount=0 -->
           <NumShorts value="0"/>
@@ -483,6 +523,14 @@
           <VarRegionIndex index="3" value="3"/>
           <VarRegionIndex index="4" value="4"/>
           <VarRegionIndex index="5" value="5"/>
+        </VarData>
+        <VarData index="1">
+          <!-- ItemCount=0 -->
+          <NumShorts value="0"/>
+          <!-- VarRegionCount=3 -->
+          <VarRegionIndex index="0" value="6"/>
+          <VarRegionIndex index="1" value="2"/>
+          <VarRegionIndex index="2" value="7"/>
         </VarData>
       </VarStore>
     </CFFFont>

--- a/tests/data/DSv5/MutatorSansVariable_Weight_Width-CFF2.ttx
+++ b/tests/data/DSv5/MutatorSansVariable_Weight_Width-CFF2.ttx
@@ -1,0 +1,951 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="OTTO" ttLibVersion="4.33">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="I"/>
+    <GlyphID id="2" name="I.narrow"/>
+    <GlyphID id="3" name="S"/>
+    <GlyphID id="4" name="S.closed"/>
+    <GlyphID id="5" name="a"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="0.0"/>
+    <checkSumAdjustment value="0x12345678"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Fri Feb 17 17:17:17 2017"/>
+    <modified value="Sun Feb 18 18:18:18 2018"/>
+    <xMin value="50"/>
+    <yMin value="-200"/>
+    <xMax value="450"/>
+    <yMax value="800"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="6"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1000"/>
+    <descent value="-200"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="500"/>
+    <minLeftSideBearing value="50"/>
+    <minRightSideBearing value="50"/>
+    <xMaxExtent value="450"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="2"/>
+  </hhea>
+
+  <maxp>
+    <tableVersion value="0x5000"/>
+    <numGlyphs value="6"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="500"/>
+    <usWeightClass value="300"/>
+    <usWidthClass value="1"/>
+    <fsType value="00000000 00000100"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="300"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="0"/>
+      <bSerifStyle value="0"/>
+      <bWeight value="0"/>
+      <bProportion value="0"/>
+      <bContrast value="0"/>
+      <bStrokeVariation value="0"/>
+      <bArmStyle value="0"/>
+      <bLetterForm value="0"/>
+      <bMidline value="0"/>
+      <bXHeight value="0"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="NONE"/>
+    <fsSelection value="00000000 01000000"/>
+    <usFirstCharIndex value="65535"/>
+    <usLastCharIndex value="65535"/>
+    <sTypoAscender value="800"/>
+    <sTypoDescender value="-200"/>
+    <sTypoLineGap value="200"/>
+    <usWinAscent value="1000"/>
+    <usWinDescent value="200"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="500"/>
+    <sCapHeight value="700"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="0"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="500" lsb="50"/>
+    <mtx name="I" width="0" lsb="0"/>
+    <mtx name="I.narrow" width="0" lsb="0"/>
+    <mtx name="S" width="0" lsb="0"/>
+    <mtx name="S.closed" width="0" lsb="0"/>
+    <mtx name="a" width="0" lsb="0"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+    </cmap_format_4>
+  </cmap>
+
+  <name>
+    <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Weight
+    </namerecord>
+    <namerecord nameID="257" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Width
+    </namerecord>
+    <namerecord nameID="258" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Sans Light Condensed
+    </namerecord>
+    <namerecord nameID="259" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      MutatorMathTest-SansLightCondensed
+    </namerecord>
+    <namerecord nameID="260" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Sans Bold Condensed
+    </namerecord>
+    <namerecord nameID="261" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      MutatorMathTest-SansBoldCondensed
+    </namerecord>
+    <namerecord nameID="262" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Sans Light Extended
+    </namerecord>
+    <namerecord nameID="263" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      MutatorMathTest-SansLightExtended
+    </namerecord>
+    <namerecord nameID="264" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Sans Bold Extended
+    </namerecord>
+    <namerecord nameID="265" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      MutatorMathTest-SansBoldExtended
+    </namerecord>
+    <namerecord nameID="266" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Sans Medium
+    </namerecord>
+    <namerecord nameID="267" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      MutatorMathTest-SansMedium
+    </namerecord>
+    <namerecord nameID="268" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      MutatorMathTest-SansMedium
+    </namerecord>
+    <namerecord nameID="269" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Sans Bold
+    </namerecord>
+    <namerecord nameID="270" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      MutatorMathTest-SansBold
+    </namerecord>
+    <namerecord nameID="271" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Sans Medium Extended
+    </namerecord>
+    <namerecord nameID="272" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      MutatorMathTest-SansMediumExtended
+    </namerecord>
+    <namerecord nameID="273" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      MutatorMathTest-SansLightCondensed
+    </namerecord>
+    <namerecord nameID="274" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Regular
+    </namerecord>
+    <namerecord nameID="275" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      serif
+    </namerecord>
+    <namerecord nameID="276" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Sans
+    </namerecord>
+    <namerecord nameID="277" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      weight
+    </namerecord>
+    <namerecord nameID="278" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Light
+    </namerecord>
+    <namerecord nameID="279" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Medium
+    </namerecord>
+    <namerecord nameID="280" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Bold
+    </namerecord>
+    <namerecord nameID="281" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      width
+    </namerecord>
+    <namerecord nameID="282" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Condensed
+    </namerecord>
+    <namerecord nameID="283" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Normal
+    </namerecord>
+    <namerecord nameID="284" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Extended
+    </namerecord>
+    <namerecord nameID="285" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      S1
+    </namerecord>
+    <namerecord nameID="286" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      S2
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      New Font
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      0.000;NONE;NewFont-Regular
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      New Font Regular
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 0.000
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      NewFont-Regular
+    </namerecord>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
+      Weight
+    </namerecord>
+    <namerecord nameID="257" platformID="3" platEncID="1" langID="0x409">
+      Width
+    </namerecord>
+    <namerecord nameID="258" platformID="3" platEncID="1" langID="0x409">
+      Sans Light Condensed
+    </namerecord>
+    <namerecord nameID="259" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-SansLightCondensed
+    </namerecord>
+    <namerecord nameID="260" platformID="3" platEncID="1" langID="0x409">
+      Sans Bold Condensed
+    </namerecord>
+    <namerecord nameID="261" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-SansBoldCondensed
+    </namerecord>
+    <namerecord nameID="262" platformID="3" platEncID="1" langID="0x409">
+      Sans Light Extended
+    </namerecord>
+    <namerecord nameID="263" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-SansLightExtended
+    </namerecord>
+    <namerecord nameID="264" platformID="3" platEncID="1" langID="0x409">
+      Sans Bold Extended
+    </namerecord>
+    <namerecord nameID="265" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-SansBoldExtended
+    </namerecord>
+    <namerecord nameID="266" platformID="3" platEncID="1" langID="0x409">
+      Sans Medium
+    </namerecord>
+    <namerecord nameID="267" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-SansMedium
+    </namerecord>
+    <namerecord nameID="268" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-SansMedium
+    </namerecord>
+    <namerecord nameID="269" platformID="3" platEncID="1" langID="0x409">
+      Sans Bold
+    </namerecord>
+    <namerecord nameID="270" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-SansBold
+    </namerecord>
+    <namerecord nameID="271" platformID="3" platEncID="1" langID="0x409">
+      Sans Medium Extended
+    </namerecord>
+    <namerecord nameID="272" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-SansMediumExtended
+    </namerecord>
+    <namerecord nameID="273" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-SansLightCondensed
+    </namerecord>
+    <namerecord nameID="274" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="275" platformID="3" platEncID="1" langID="0x409">
+      serif
+    </namerecord>
+    <namerecord nameID="276" platformID="3" platEncID="1" langID="0x409">
+      Sans
+    </namerecord>
+    <namerecord nameID="277" platformID="3" platEncID="1" langID="0x409">
+      weight
+    </namerecord>
+    <namerecord nameID="278" platformID="3" platEncID="1" langID="0x409">
+      Light
+    </namerecord>
+    <namerecord nameID="279" platformID="3" platEncID="1" langID="0x409">
+      Medium
+    </namerecord>
+    <namerecord nameID="280" platformID="3" platEncID="1" langID="0x409">
+      Bold
+    </namerecord>
+    <namerecord nameID="281" platformID="3" platEncID="1" langID="0x409">
+      width
+    </namerecord>
+    <namerecord nameID="282" platformID="3" platEncID="1" langID="0x409">
+      Condensed
+    </namerecord>
+    <namerecord nameID="283" platformID="3" platEncID="1" langID="0x409">
+      Normal
+    </namerecord>
+    <namerecord nameID="284" platformID="3" platEncID="1" langID="0x409">
+      Extended
+    </namerecord>
+    <namerecord nameID="285" platformID="3" platEncID="1" langID="0x409">
+      S1
+    </namerecord>
+    <namerecord nameID="286" platformID="3" platEncID="1" langID="0x409">
+      S2
+    </namerecord>
+  </name>
+
+  <post>
+    <formatType value="2.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-75"/>
+    <underlineThickness value="50"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+    <psNames>
+      <!-- This file uses unique glyph names based on the information
+           found in the 'post' table. Since these names might not be unique,
+           we have to invent artificial names in case of clashes. In order to
+           be able to retain the original information, we need a name to
+           ps name mapping for those cases where they differ. That's what
+           you see below.
+            -->
+    </psNames>
+    <extraNames>
+      <!-- following are the name that are not taken from the standard Mac glyph order -->
+      <psName name="I.narrow"/>
+      <psName name="S.closed"/>
+    </extraNames>
+  </post>
+
+  <CFF2>
+    <major value="2"/>
+    <minor value="0"/>
+    <CFFFont name="CFF2Font">
+      <FontMatrix value="0.001 0 0 0.001 0 0"/>
+      <FDArray>
+        <FontDict index="0">
+          <Private>
+            <BlueScale value="0.039625"/>
+            <BlueShift value="7"/>
+            <BlueFuzz value="1"/>
+            <LanguageGroup value="0"/>
+            <ExpansionFactor value="0.06"/>
+          </Private>
+        </FontDict>
+      </FDArray>
+      <CharStrings>
+        <CharString name=".notdef">
+          50 -200 rmoveto
+          400 1000 -400 -1000 hlineto
+          50 50 rmoveto
+          900 300 -900 -300 vlineto
+        </CharString>
+        <CharString name="I">
+        </CharString>
+        <CharString name="I.narrow">
+        </CharString>
+        <CharString name="S">
+        </CharString>
+        <CharString name="S.closed">
+        </CharString>
+        <CharString name="a">
+        </CharString>
+      </CharStrings>
+      <VarStore Format="1">
+        <Format value="1"/>
+        <VarRegionList>
+          <!-- RegionAxisCount=2 -->
+          <!-- RegionCount=6 -->
+          <Region index="0">
+            <VarRegionAxis index="0">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.7"/>
+              <EndCoord value="1.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="1">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+          </Region>
+          <Region index="1">
+            <VarRegionAxis index="0">
+              <StartCoord value="0.7"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="1">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+          </Region>
+          <Region index="2">
+            <VarRegionAxis index="0">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="1">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
+            </VarRegionAxis>
+          </Region>
+          <Region index="3">
+            <VarRegionAxis index="0">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.7"/>
+              <EndCoord value="1.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="1">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
+            </VarRegionAxis>
+          </Region>
+          <Region index="4">
+            <VarRegionAxis index="0">
+              <StartCoord value="0.7"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="1">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
+            </VarRegionAxis>
+          </Region>
+          <Region index="5">
+            <VarRegionAxis index="0">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.7"/>
+              <EndCoord value="1.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="1">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.5691"/>
+              <EndCoord value="1.0"/>
+            </VarRegionAxis>
+          </Region>
+        </VarRegionList>
+        <!-- VarDataCount=1 -->
+        <VarData index="0">
+          <!-- ItemCount=0 -->
+          <NumShorts value="0"/>
+          <!-- VarRegionCount=6 -->
+          <VarRegionIndex index="0" value="0"/>
+          <VarRegionIndex index="1" value="1"/>
+          <VarRegionIndex index="2" value="2"/>
+          <VarRegionIndex index="3" value="3"/>
+          <VarRegionIndex index="4" value="4"/>
+          <VarRegionIndex index="5" value="5"/>
+        </VarData>
+      </VarStore>
+    </CFFFont>
+
+    <GlobalSubrs>
+      <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+    </GlobalSubrs>
+  </CFF2>
+
+  <GSUB>
+    <Version value="0x00010001"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="rvrn"/>
+        <Feature>
+          <!-- LookupCount=0 -->
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=2 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="I" out="I.narrow"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="S" out="S.closed"/>
+        </SingleSubst>
+      </Lookup>
+    </LookupList>
+    <FeatureVariations>
+      <Version value="0x00010000"/>
+      <!-- FeatureVariationCount=3 -->
+      <FeatureVariationRecord index="0">
+        <ConditionSet>
+          <!-- ConditionCount=2 -->
+          <ConditionTable index="0" Format="1">
+            <AxisIndex value="1"/>
+            <FilterRangeMinValue value="0.0"/>
+            <FilterRangeMaxValue value="0.328"/>
+          </ConditionTable>
+          <ConditionTable index="1" Format="1">
+            <AxisIndex value="0"/>
+            <FilterRangeMinValue value="0.0"/>
+            <FilterRangeMaxValue value="0.5"/>
+          </ConditionTable>
+        </ConditionSet>
+        <FeatureTableSubstitution>
+          <Version value="0x00010000"/>
+          <!-- SubstitutionCount=1 -->
+          <SubstitutionRecord index="0">
+            <FeatureIndex value="0"/>
+            <Feature>
+              <!-- LookupCount=2 -->
+              <LookupListIndex index="0" value="0"/>
+              <LookupListIndex index="1" value="1"/>
+            </Feature>
+          </SubstitutionRecord>
+        </FeatureTableSubstitution>
+      </FeatureVariationRecord>
+      <FeatureVariationRecord index="1">
+        <ConditionSet>
+          <!-- ConditionCount=1 -->
+          <ConditionTable index="0" Format="1">
+            <AxisIndex value="0"/>
+            <FilterRangeMinValue value="0.0"/>
+            <FilterRangeMaxValue value="0.5"/>
+          </ConditionTable>
+        </ConditionSet>
+        <FeatureTableSubstitution>
+          <Version value="0x00010000"/>
+          <!-- SubstitutionCount=1 -->
+          <SubstitutionRecord index="0">
+            <FeatureIndex value="0"/>
+            <Feature>
+              <!-- LookupCount=1 -->
+              <LookupListIndex index="0" value="1"/>
+            </Feature>
+          </SubstitutionRecord>
+        </FeatureTableSubstitution>
+      </FeatureVariationRecord>
+      <FeatureVariationRecord index="2">
+        <ConditionSet>
+          <!-- ConditionCount=1 -->
+          <ConditionTable index="0" Format="1">
+            <AxisIndex value="1"/>
+            <FilterRangeMinValue value="0.0"/>
+            <FilterRangeMaxValue value="0.328"/>
+          </ConditionTable>
+        </ConditionSet>
+        <FeatureTableSubstitution>
+          <Version value="0x00010000"/>
+          <!-- SubstitutionCount=1 -->
+          <SubstitutionRecord index="0">
+            <FeatureIndex value="0"/>
+            <Feature>
+              <!-- LookupCount=1 -->
+              <LookupListIndex index="0" value="0"/>
+            </Feature>
+          </SubstitutionRecord>
+        </FeatureTableSubstitution>
+      </FeatureVariationRecord>
+    </FeatureVariations>
+  </GSUB>
+
+  <HVAR>
+    <Version value="0x00010000"/>
+    <VarStore Format="1">
+      <Format value="1"/>
+      <VarRegionList>
+        <!-- RegionAxisCount=2 -->
+        <!-- RegionCount=8 -->
+        <Region index="0">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.7"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+          <VarRegionAxis index="1">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.0"/>
+            <EndCoord value="0.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="1">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.7"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+          <VarRegionAxis index="1">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.0"/>
+            <EndCoord value="0.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="2">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.0"/>
+            <EndCoord value="0.0"/>
+          </VarRegionAxis>
+          <VarRegionAxis index="1">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="3">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.7"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+          <VarRegionAxis index="1">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="4">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.7"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+          <VarRegionAxis index="1">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="5">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.7"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+          <VarRegionAxis index="1">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.5691"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="6">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+          <VarRegionAxis index="1">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.0"/>
+            <EndCoord value="0.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="7">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+          <VarRegionAxis index="1">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+      </VarRegionList>
+      <!-- VarDataCount=1 -->
+      <VarData index="0">
+        <!-- ItemCount=1 -->
+        <NumShorts value="0"/>
+        <!-- VarRegionCount=0 -->
+        <Item index="0" value="[]"/>
+      </VarData>
+    </VarStore>
+    <AdvWidthMap>
+      <Map glyph=".notdef" outer="0" inner="0"/>
+      <Map glyph="I" outer="0" inner="0"/>
+      <Map glyph="I.narrow" outer="0" inner="0"/>
+      <Map glyph="S" outer="0" inner="0"/>
+      <Map glyph="S.closed" outer="0" inner="0"/>
+      <Map glyph="a" outer="0" inner="0"/>
+    </AdvWidthMap>
+  </HVAR>
+
+  <STAT>
+    <Version value="0x00010002"/>
+    <DesignAxisRecordSize value="8"/>
+    <!-- DesignAxisCount=3 -->
+    <DesignAxisRecord>
+      <Axis index="0">
+        <AxisTag value="SRIF"/>
+        <AxisNameID value="275"/>  <!-- serif -->
+        <AxisOrdering value="0"/>
+      </Axis>
+      <Axis index="1">
+        <AxisTag value="wght"/>
+        <AxisNameID value="277"/>  <!-- weight -->
+        <AxisOrdering value="1"/>
+      </Axis>
+      <Axis index="2">
+        <AxisTag value="wdth"/>
+        <AxisNameID value="281"/>  <!-- width -->
+        <AxisOrdering value="2"/>
+      </Axis>
+    </DesignAxisRecord>
+    <!-- AxisValueCount=9 -->
+    <AxisValueArray>
+      <AxisValue index="0" Format="4">
+        <!-- AxisCount=3 -->
+        <Flags value="0"/>
+        <ValueNameID value="285"/>  <!-- S1 -->
+        <AxisValueRecord index="0">
+          <AxisIndex value="0"/>
+          <Value value="0.0"/>
+        </AxisValueRecord>
+        <AxisValueRecord index="1">
+          <AxisIndex value="1"/>
+          <Value value="610.2436"/>
+        </AxisValueRecord>
+        <AxisValueRecord index="2">
+          <AxisIndex value="2"/>
+          <Value value="158.9044"/>
+        </AxisValueRecord>
+      </AxisValue>
+      <AxisValue index="1" Format="4">
+        <!-- AxisCount=3 -->
+        <Flags value="0"/>
+        <ValueNameID value="286"/>  <!-- S2 -->
+        <AxisValueRecord index="0">
+          <AxisIndex value="0"/>
+          <Value value="0.0"/>
+        </AxisValueRecord>
+        <AxisValueRecord index="1">
+          <AxisIndex value="1"/>
+          <Value value="642.2196"/>
+        </AxisValueRecord>
+        <AxisValueRecord index="2">
+          <AxisIndex value="2"/>
+          <Value value="159.1956"/>
+        </AxisValueRecord>
+      </AxisValue>
+      <AxisValue index="2" Format="1">
+        <AxisIndex value="0"/>
+        <Flags value="0"/>
+        <ValueNameID value="276"/>  <!-- Sans -->
+        <Value value="0.0"/>
+      </AxisValue>
+      <AxisValue index="3" Format="2">
+        <AxisIndex value="1"/>
+        <Flags value="0"/>
+        <ValueNameID value="278"/>  <!-- Light -->
+        <NominalValue value="300.0"/>
+        <RangeMinValue value="300.0"/>
+        <RangeMaxValue value="400.0"/>
+      </AxisValue>
+      <AxisValue index="4" Format="2">
+        <AxisIndex value="1"/>
+        <Flags value="0"/>
+        <ValueNameID value="279"/>  <!-- Medium -->
+        <NominalValue value="500.0"/>
+        <RangeMinValue value="400.0"/>
+        <RangeMaxValue value="600.0"/>
+      </AxisValue>
+      <AxisValue index="5" Format="2">
+        <AxisIndex value="1"/>
+        <Flags value="0"/>
+        <ValueNameID value="280"/>  <!-- Bold -->
+        <NominalValue value="700.0"/>
+        <RangeMinValue value="600.0"/>
+        <RangeMaxValue value="700.0"/>
+      </AxisValue>
+      <AxisValue index="6" Format="2">
+        <AxisIndex value="2"/>
+        <Flags value="0"/>
+        <ValueNameID value="282"/>  <!-- Condensed -->
+        <NominalValue value="50.0"/>
+        <RangeMinValue value="50.0"/>
+        <RangeMaxValue value="75.0"/>
+      </AxisValue>
+      <AxisValue index="7" Format="2">
+        <AxisIndex value="2"/>
+        <Flags value="2"/>  <!-- ElidableAxisValueName -->
+        <ValueNameID value="283"/>  <!-- Normal -->
+        <NominalValue value="100.0"/>
+        <RangeMinValue value="75.0"/>
+        <RangeMaxValue value="125.0"/>
+      </AxisValue>
+      <AxisValue index="8" Format="2">
+        <AxisIndex value="2"/>
+        <Flags value="0"/>
+        <ValueNameID value="284"/>  <!-- Extended -->
+        <NominalValue value="200.0"/>
+        <RangeMinValue value="125.0"/>
+        <RangeMaxValue value="200.0"/>
+      </AxisValue>
+    </AxisValueArray>
+    <ElidedFallbackNameID value="274"/>  <!-- Regular -->
+  </STAT>
+
+  <avar>
+    <segment axis="wght">
+      <mapping from="-1.0" to="-1.0"/>
+      <mapping from="0.0" to="0.0"/>
+      <mapping from="1.0" to="1.0"/>
+    </segment>
+    <segment axis="wdth">
+      <mapping from="-1.0" to="-1.0"/>
+      <mapping from="0.0" to="0.0"/>
+      <mapping from="0.3333" to="0.5"/>
+      <mapping from="1.0" to="1.0"/>
+    </segment>
+  </avar>
+
+  <fvar>
+
+    <!-- Weight -->
+    <Axis>
+      <AxisTag>wght</AxisTag>
+      <Flags>0x0</Flags>
+      <MinValue>300.0</MinValue>
+      <DefaultValue>300.0</DefaultValue>
+      <MaxValue>700.0</MaxValue>
+      <AxisNameID>256</AxisNameID>
+    </Axis>
+
+    <!-- Width -->
+    <Axis>
+      <AxisTag>wdth</AxisTag>
+      <Flags>0x0</Flags>
+      <MinValue>50.0</MinValue>
+      <DefaultValue>50.0</DefaultValue>
+      <MaxValue>200.0</MaxValue>
+      <AxisNameID>257</AxisNameID>
+    </Axis>
+
+    <!-- Sans Light Condensed -->
+    <!-- PostScript: MutatorMathTest-SansLightCondensed -->
+    <NamedInstance flags="0x0" postscriptNameID="259" subfamilyNameID="258">
+      <coord axis="wght" value="300.0"/>
+      <coord axis="wdth" value="50.0"/>
+    </NamedInstance>
+
+    <!-- Sans Bold Condensed -->
+    <!-- PostScript: MutatorMathTest-SansBoldCondensed -->
+    <NamedInstance flags="0x0" postscriptNameID="261" subfamilyNameID="260">
+      <coord axis="wght" value="700.0"/>
+      <coord axis="wdth" value="50.0"/>
+    </NamedInstance>
+
+    <!-- Sans Light Extended -->
+    <!-- PostScript: MutatorMathTest-SansLightExtended -->
+    <NamedInstance flags="0x0" postscriptNameID="263" subfamilyNameID="262">
+      <coord axis="wght" value="300.0"/>
+      <coord axis="wdth" value="200.0"/>
+    </NamedInstance>
+
+    <!-- Sans Bold Extended -->
+    <!-- PostScript: MutatorMathTest-SansBoldExtended -->
+    <NamedInstance flags="0x0" postscriptNameID="265" subfamilyNameID="264">
+      <coord axis="wght" value="700.0"/>
+      <coord axis="wdth" value="200.0"/>
+    </NamedInstance>
+
+    <!-- Sans Medium -->
+    <!-- PostScript: MutatorMathTest-SansMedium -->
+    <NamedInstance flags="0x0" postscriptNameID="267" subfamilyNameID="266">
+      <coord axis="wght" value="500.0"/>
+      <coord axis="wdth" value="82.7"/>
+    </NamedInstance>
+
+    <!-- Sans Medium -->
+    <!-- PostScript: MutatorMathTest-SansMedium -->
+    <NamedInstance flags="0x0" postscriptNameID="268" subfamilyNameID="266">
+      <coord axis="wght" value="500.0"/>
+      <coord axis="wdth" value="82.7"/>
+    </NamedInstance>
+
+    <!-- Sans Bold -->
+    <!-- PostScript: MutatorMathTest-SansBold -->
+    <NamedInstance flags="0x0" postscriptNameID="270" subfamilyNameID="269">
+      <coord axis="wght" value="700.0"/>
+      <coord axis="wdth" value="113.8156"/>
+    </NamedInstance>
+
+    <!-- Sans Medium Extended -->
+    <!-- PostScript: MutatorMathTest-SansMediumExtended -->
+    <NamedInstance flags="0x0" postscriptNameID="272" subfamilyNameID="271">
+      <coord axis="wght" value="500.0"/>
+      <coord axis="wdth" value="200.0"/>
+    </NamedInstance>
+
+    <!-- Sans Light Condensed -->
+    <!-- PostScript: MutatorMathTest-SansLightCondensed -->
+    <NamedInstance flags="0x0" postscriptNameID="273" subfamilyNameID="258">
+      <coord axis="wght" value="300.0"/>
+      <coord axis="wdth" value="50.0"/>
+    </NamedInstance>
+  </fvar>
+
+</ttFont>

--- a/tests/data/DSv5/MutatorSansVariable_Weight_Width-TTF.ttx
+++ b/tests/data/DSv5/MutatorSansVariable_Weight_Width-TTF.ttx
@@ -1,0 +1,875 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.33">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="I"/>
+    <GlyphID id="2" name="I.narrow"/>
+    <GlyphID id="3" name="S"/>
+    <GlyphID id="4" name="S.closed"/>
+    <GlyphID id="5" name="a"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="0.0"/>
+    <checkSumAdjustment value="0x12345678"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Fri Feb 17 17:17:17 2017"/>
+    <modified value="Sun Feb 18 18:18:18 2018"/>
+    <xMin value="50"/>
+    <yMin value="-200"/>
+    <xMax value="450"/>
+    <yMax value="800"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="6"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1000"/>
+    <descent value="-200"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="500"/>
+    <minLeftSideBearing value="50"/>
+    <minRightSideBearing value="50"/>
+    <xMaxExtent value="450"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="2"/>
+  </hhea>
+
+  <maxp>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="0x10000"/>
+    <numGlyphs value="6"/>
+    <maxPoints value="8"/>
+    <maxContours value="2"/>
+    <maxCompositePoints value="0"/>
+    <maxCompositeContours value="0"/>
+    <maxZones value="1"/>
+    <maxTwilightPoints value="0"/>
+    <maxStorage value="0"/>
+    <maxFunctionDefs value="0"/>
+    <maxInstructionDefs value="0"/>
+    <maxStackElements value="0"/>
+    <maxSizeOfInstructions value="0"/>
+    <maxComponentElements value="0"/>
+    <maxComponentDepth value="0"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="500"/>
+    <usWeightClass value="300"/>
+    <usWidthClass value="1"/>
+    <fsType value="00000000 00000100"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="300"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="0"/>
+      <bSerifStyle value="0"/>
+      <bWeight value="0"/>
+      <bProportion value="0"/>
+      <bContrast value="0"/>
+      <bStrokeVariation value="0"/>
+      <bArmStyle value="0"/>
+      <bLetterForm value="0"/>
+      <bMidline value="0"/>
+      <bXHeight value="0"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="NONE"/>
+    <fsSelection value="00000000 01000000"/>
+    <usFirstCharIndex value="65535"/>
+    <usLastCharIndex value="65535"/>
+    <sTypoAscender value="800"/>
+    <sTypoDescender value="-200"/>
+    <sTypoLineGap value="200"/>
+    <usWinAscent value="1000"/>
+    <usWinDescent value="200"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="500"/>
+    <sCapHeight value="700"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="0"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="500" lsb="50"/>
+    <mtx name="I" width="0" lsb="0"/>
+    <mtx name="I.narrow" width="0" lsb="0"/>
+    <mtx name="S" width="0" lsb="0"/>
+    <mtx name="S.closed" width="0" lsb="0"/>
+    <mtx name="a" width="0" lsb="0"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+    </cmap_format_4>
+  </cmap>
+
+  <loca>
+    <!-- The 'loca' table will be calculated by the compiler -->
+  </loca>
+
+  <glyf>
+
+    <!-- The xMin, yMin, xMax and yMax values
+         will be recalculated by the compiler. -->
+
+    <TTGlyph name=".notdef" xMin="50" yMin="-200" xMax="450" yMax="800">
+      <contour>
+        <pt x="50" y="-200" on="1"/>
+        <pt x="50" y="800" on="1"/>
+        <pt x="450" y="800" on="1"/>
+        <pt x="450" y="-200" on="1"/>
+      </contour>
+      <contour>
+        <pt x="100" y="-150" on="1"/>
+        <pt x="400" y="-150" on="1"/>
+        <pt x="400" y="750" on="1"/>
+        <pt x="100" y="750" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="I"/><!-- contains no outline data -->
+
+    <TTGlyph name="I.narrow"/><!-- contains no outline data -->
+
+    <TTGlyph name="S"/><!-- contains no outline data -->
+
+    <TTGlyph name="S.closed"/><!-- contains no outline data -->
+
+    <TTGlyph name="a"/><!-- contains no outline data -->
+
+  </glyf>
+
+  <name>
+    <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Weight
+    </namerecord>
+    <namerecord nameID="257" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Width
+    </namerecord>
+    <namerecord nameID="258" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Sans Light Condensed
+    </namerecord>
+    <namerecord nameID="259" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      MutatorMathTest-SansLightCondensed
+    </namerecord>
+    <namerecord nameID="260" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Sans Bold Condensed
+    </namerecord>
+    <namerecord nameID="261" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      MutatorMathTest-SansBoldCondensed
+    </namerecord>
+    <namerecord nameID="262" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Sans Light Extended
+    </namerecord>
+    <namerecord nameID="263" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      MutatorMathTest-SansLightExtended
+    </namerecord>
+    <namerecord nameID="264" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Sans Bold Extended
+    </namerecord>
+    <namerecord nameID="265" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      MutatorMathTest-SansBoldExtended
+    </namerecord>
+    <namerecord nameID="266" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Sans Medium
+    </namerecord>
+    <namerecord nameID="267" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      MutatorMathTest-SansMedium
+    </namerecord>
+    <namerecord nameID="268" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      MutatorMathTest-SansMedium
+    </namerecord>
+    <namerecord nameID="269" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Sans Bold
+    </namerecord>
+    <namerecord nameID="270" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      MutatorMathTest-SansBold
+    </namerecord>
+    <namerecord nameID="271" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Sans Medium Extended
+    </namerecord>
+    <namerecord nameID="272" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      MutatorMathTest-SansMediumExtended
+    </namerecord>
+    <namerecord nameID="273" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      MutatorMathTest-SansLightCondensed
+    </namerecord>
+    <namerecord nameID="274" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Regular
+    </namerecord>
+    <namerecord nameID="275" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      serif
+    </namerecord>
+    <namerecord nameID="276" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Sans
+    </namerecord>
+    <namerecord nameID="277" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      weight
+    </namerecord>
+    <namerecord nameID="278" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Light
+    </namerecord>
+    <namerecord nameID="279" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Medium
+    </namerecord>
+    <namerecord nameID="280" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Bold
+    </namerecord>
+    <namerecord nameID="281" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      width
+    </namerecord>
+    <namerecord nameID="282" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Condensed
+    </namerecord>
+    <namerecord nameID="283" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Normal
+    </namerecord>
+    <namerecord nameID="284" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Extended
+    </namerecord>
+    <namerecord nameID="285" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      S1
+    </namerecord>
+    <namerecord nameID="286" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      S2
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      New Font
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      0.000;NONE;NewFont-Regular
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      New Font Regular
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 0.000
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      NewFont-Regular
+    </namerecord>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
+      Weight
+    </namerecord>
+    <namerecord nameID="257" platformID="3" platEncID="1" langID="0x409">
+      Width
+    </namerecord>
+    <namerecord nameID="258" platformID="3" platEncID="1" langID="0x409">
+      Sans Light Condensed
+    </namerecord>
+    <namerecord nameID="259" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-SansLightCondensed
+    </namerecord>
+    <namerecord nameID="260" platformID="3" platEncID="1" langID="0x409">
+      Sans Bold Condensed
+    </namerecord>
+    <namerecord nameID="261" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-SansBoldCondensed
+    </namerecord>
+    <namerecord nameID="262" platformID="3" platEncID="1" langID="0x409">
+      Sans Light Extended
+    </namerecord>
+    <namerecord nameID="263" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-SansLightExtended
+    </namerecord>
+    <namerecord nameID="264" platformID="3" platEncID="1" langID="0x409">
+      Sans Bold Extended
+    </namerecord>
+    <namerecord nameID="265" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-SansBoldExtended
+    </namerecord>
+    <namerecord nameID="266" platformID="3" platEncID="1" langID="0x409">
+      Sans Medium
+    </namerecord>
+    <namerecord nameID="267" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-SansMedium
+    </namerecord>
+    <namerecord nameID="268" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-SansMedium
+    </namerecord>
+    <namerecord nameID="269" platformID="3" platEncID="1" langID="0x409">
+      Sans Bold
+    </namerecord>
+    <namerecord nameID="270" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-SansBold
+    </namerecord>
+    <namerecord nameID="271" platformID="3" platEncID="1" langID="0x409">
+      Sans Medium Extended
+    </namerecord>
+    <namerecord nameID="272" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-SansMediumExtended
+    </namerecord>
+    <namerecord nameID="273" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-SansLightCondensed
+    </namerecord>
+    <namerecord nameID="274" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="275" platformID="3" platEncID="1" langID="0x409">
+      serif
+    </namerecord>
+    <namerecord nameID="276" platformID="3" platEncID="1" langID="0x409">
+      Sans
+    </namerecord>
+    <namerecord nameID="277" platformID="3" platEncID="1" langID="0x409">
+      weight
+    </namerecord>
+    <namerecord nameID="278" platformID="3" platEncID="1" langID="0x409">
+      Light
+    </namerecord>
+    <namerecord nameID="279" platformID="3" platEncID="1" langID="0x409">
+      Medium
+    </namerecord>
+    <namerecord nameID="280" platformID="3" platEncID="1" langID="0x409">
+      Bold
+    </namerecord>
+    <namerecord nameID="281" platformID="3" platEncID="1" langID="0x409">
+      width
+    </namerecord>
+    <namerecord nameID="282" platformID="3" platEncID="1" langID="0x409">
+      Condensed
+    </namerecord>
+    <namerecord nameID="283" platformID="3" platEncID="1" langID="0x409">
+      Normal
+    </namerecord>
+    <namerecord nameID="284" platformID="3" platEncID="1" langID="0x409">
+      Extended
+    </namerecord>
+    <namerecord nameID="285" platformID="3" platEncID="1" langID="0x409">
+      S1
+    </namerecord>
+    <namerecord nameID="286" platformID="3" platEncID="1" langID="0x409">
+      S2
+    </namerecord>
+  </name>
+
+  <post>
+    <formatType value="2.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-75"/>
+    <underlineThickness value="50"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+    <psNames>
+      <!-- This file uses unique glyph names based on the information
+           found in the 'post' table. Since these names might not be unique,
+           we have to invent artificial names in case of clashes. In order to
+           be able to retain the original information, we need a name to
+           ps name mapping for those cases where they differ. That's what
+           you see below.
+            -->
+    </psNames>
+    <extraNames>
+      <!-- following are the name that are not taken from the standard Mac glyph order -->
+      <psName name="I.narrow"/>
+      <psName name="S.closed"/>
+    </extraNames>
+  </post>
+
+  <GSUB>
+    <Version value="0x00010001"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="rvrn"/>
+        <Feature>
+          <!-- LookupCount=0 -->
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=2 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="I" out="I.narrow"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="S" out="S.closed"/>
+        </SingleSubst>
+      </Lookup>
+    </LookupList>
+    <FeatureVariations>
+      <Version value="0x00010000"/>
+      <!-- FeatureVariationCount=3 -->
+      <FeatureVariationRecord index="0">
+        <ConditionSet>
+          <!-- ConditionCount=2 -->
+          <ConditionTable index="0" Format="1">
+            <AxisIndex value="1"/>
+            <FilterRangeMinValue value="0.0"/>
+            <FilterRangeMaxValue value="0.328"/>
+          </ConditionTable>
+          <ConditionTable index="1" Format="1">
+            <AxisIndex value="0"/>
+            <FilterRangeMinValue value="0.0"/>
+            <FilterRangeMaxValue value="0.5"/>
+          </ConditionTable>
+        </ConditionSet>
+        <FeatureTableSubstitution>
+          <Version value="0x00010000"/>
+          <!-- SubstitutionCount=1 -->
+          <SubstitutionRecord index="0">
+            <FeatureIndex value="0"/>
+            <Feature>
+              <!-- LookupCount=2 -->
+              <LookupListIndex index="0" value="0"/>
+              <LookupListIndex index="1" value="1"/>
+            </Feature>
+          </SubstitutionRecord>
+        </FeatureTableSubstitution>
+      </FeatureVariationRecord>
+      <FeatureVariationRecord index="1">
+        <ConditionSet>
+          <!-- ConditionCount=1 -->
+          <ConditionTable index="0" Format="1">
+            <AxisIndex value="0"/>
+            <FilterRangeMinValue value="0.0"/>
+            <FilterRangeMaxValue value="0.5"/>
+          </ConditionTable>
+        </ConditionSet>
+        <FeatureTableSubstitution>
+          <Version value="0x00010000"/>
+          <!-- SubstitutionCount=1 -->
+          <SubstitutionRecord index="0">
+            <FeatureIndex value="0"/>
+            <Feature>
+              <!-- LookupCount=1 -->
+              <LookupListIndex index="0" value="1"/>
+            </Feature>
+          </SubstitutionRecord>
+        </FeatureTableSubstitution>
+      </FeatureVariationRecord>
+      <FeatureVariationRecord index="2">
+        <ConditionSet>
+          <!-- ConditionCount=1 -->
+          <ConditionTable index="0" Format="1">
+            <AxisIndex value="1"/>
+            <FilterRangeMinValue value="0.0"/>
+            <FilterRangeMaxValue value="0.328"/>
+          </ConditionTable>
+        </ConditionSet>
+        <FeatureTableSubstitution>
+          <Version value="0x00010000"/>
+          <!-- SubstitutionCount=1 -->
+          <SubstitutionRecord index="0">
+            <FeatureIndex value="0"/>
+            <Feature>
+              <!-- LookupCount=1 -->
+              <LookupListIndex index="0" value="0"/>
+            </Feature>
+          </SubstitutionRecord>
+        </FeatureTableSubstitution>
+      </FeatureVariationRecord>
+    </FeatureVariations>
+  </GSUB>
+
+  <HVAR>
+    <Version value="0x00010000"/>
+    <VarStore Format="1">
+      <Format value="1"/>
+      <VarRegionList>
+        <!-- RegionAxisCount=2 -->
+        <!-- RegionCount=8 -->
+        <Region index="0">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.7"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+          <VarRegionAxis index="1">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.0"/>
+            <EndCoord value="0.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="1">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.7"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+          <VarRegionAxis index="1">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.0"/>
+            <EndCoord value="0.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="2">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.0"/>
+            <EndCoord value="0.0"/>
+          </VarRegionAxis>
+          <VarRegionAxis index="1">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="3">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.7"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+          <VarRegionAxis index="1">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="4">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.7"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+          <VarRegionAxis index="1">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="5">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.7"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+          <VarRegionAxis index="1">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.5691"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="6">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+          <VarRegionAxis index="1">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.0"/>
+            <EndCoord value="0.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="7">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+          <VarRegionAxis index="1">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+      </VarRegionList>
+      <!-- VarDataCount=1 -->
+      <VarData index="0">
+        <!-- ItemCount=1 -->
+        <NumShorts value="0"/>
+        <!-- VarRegionCount=0 -->
+        <Item index="0" value="[]"/>
+      </VarData>
+    </VarStore>
+    <AdvWidthMap>
+      <Map glyph=".notdef" outer="0" inner="0"/>
+      <Map glyph="I" outer="0" inner="0"/>
+      <Map glyph="I.narrow" outer="0" inner="0"/>
+      <Map glyph="S" outer="0" inner="0"/>
+      <Map glyph="S.closed" outer="0" inner="0"/>
+      <Map glyph="a" outer="0" inner="0"/>
+    </AdvWidthMap>
+  </HVAR>
+
+  <STAT>
+    <Version value="0x00010002"/>
+    <DesignAxisRecordSize value="8"/>
+    <!-- DesignAxisCount=3 -->
+    <DesignAxisRecord>
+      <Axis index="0">
+        <AxisTag value="SRIF"/>
+        <AxisNameID value="275"/>  <!-- serif -->
+        <AxisOrdering value="0"/>
+      </Axis>
+      <Axis index="1">
+        <AxisTag value="wght"/>
+        <AxisNameID value="277"/>  <!-- weight -->
+        <AxisOrdering value="1"/>
+      </Axis>
+      <Axis index="2">
+        <AxisTag value="wdth"/>
+        <AxisNameID value="281"/>  <!-- width -->
+        <AxisOrdering value="2"/>
+      </Axis>
+    </DesignAxisRecord>
+    <!-- AxisValueCount=9 -->
+    <AxisValueArray>
+      <AxisValue index="0" Format="4">
+        <!-- AxisCount=3 -->
+        <Flags value="0"/>
+        <ValueNameID value="285"/>  <!-- S1 -->
+        <AxisValueRecord index="0">
+          <AxisIndex value="0"/>
+          <Value value="0.0"/>
+        </AxisValueRecord>
+        <AxisValueRecord index="1">
+          <AxisIndex value="1"/>
+          <Value value="610.2436"/>
+        </AxisValueRecord>
+        <AxisValueRecord index="2">
+          <AxisIndex value="2"/>
+          <Value value="158.9044"/>
+        </AxisValueRecord>
+      </AxisValue>
+      <AxisValue index="1" Format="4">
+        <!-- AxisCount=3 -->
+        <Flags value="0"/>
+        <ValueNameID value="286"/>  <!-- S2 -->
+        <AxisValueRecord index="0">
+          <AxisIndex value="0"/>
+          <Value value="0.0"/>
+        </AxisValueRecord>
+        <AxisValueRecord index="1">
+          <AxisIndex value="1"/>
+          <Value value="642.2196"/>
+        </AxisValueRecord>
+        <AxisValueRecord index="2">
+          <AxisIndex value="2"/>
+          <Value value="159.1956"/>
+        </AxisValueRecord>
+      </AxisValue>
+      <AxisValue index="2" Format="1">
+        <AxisIndex value="0"/>
+        <Flags value="0"/>
+        <ValueNameID value="276"/>  <!-- Sans -->
+        <Value value="0.0"/>
+      </AxisValue>
+      <AxisValue index="3" Format="2">
+        <AxisIndex value="1"/>
+        <Flags value="0"/>
+        <ValueNameID value="278"/>  <!-- Light -->
+        <NominalValue value="300.0"/>
+        <RangeMinValue value="300.0"/>
+        <RangeMaxValue value="400.0"/>
+      </AxisValue>
+      <AxisValue index="4" Format="2">
+        <AxisIndex value="1"/>
+        <Flags value="0"/>
+        <ValueNameID value="279"/>  <!-- Medium -->
+        <NominalValue value="500.0"/>
+        <RangeMinValue value="400.0"/>
+        <RangeMaxValue value="600.0"/>
+      </AxisValue>
+      <AxisValue index="5" Format="2">
+        <AxisIndex value="1"/>
+        <Flags value="0"/>
+        <ValueNameID value="280"/>  <!-- Bold -->
+        <NominalValue value="700.0"/>
+        <RangeMinValue value="600.0"/>
+        <RangeMaxValue value="700.0"/>
+      </AxisValue>
+      <AxisValue index="6" Format="2">
+        <AxisIndex value="2"/>
+        <Flags value="0"/>
+        <ValueNameID value="282"/>  <!-- Condensed -->
+        <NominalValue value="50.0"/>
+        <RangeMinValue value="50.0"/>
+        <RangeMaxValue value="75.0"/>
+      </AxisValue>
+      <AxisValue index="7" Format="2">
+        <AxisIndex value="2"/>
+        <Flags value="2"/>  <!-- ElidableAxisValueName -->
+        <ValueNameID value="283"/>  <!-- Normal -->
+        <NominalValue value="100.0"/>
+        <RangeMinValue value="75.0"/>
+        <RangeMaxValue value="125.0"/>
+      </AxisValue>
+      <AxisValue index="8" Format="2">
+        <AxisIndex value="2"/>
+        <Flags value="0"/>
+        <ValueNameID value="284"/>  <!-- Extended -->
+        <NominalValue value="200.0"/>
+        <RangeMinValue value="125.0"/>
+        <RangeMaxValue value="200.0"/>
+      </AxisValue>
+    </AxisValueArray>
+    <ElidedFallbackNameID value="274"/>  <!-- Regular -->
+  </STAT>
+
+  <avar>
+    <segment axis="wght">
+      <mapping from="-1.0" to="-1.0"/>
+      <mapping from="0.0" to="0.0"/>
+      <mapping from="1.0" to="1.0"/>
+    </segment>
+    <segment axis="wdth">
+      <mapping from="-1.0" to="-1.0"/>
+      <mapping from="0.0" to="0.0"/>
+      <mapping from="0.3333" to="0.5"/>
+      <mapping from="1.0" to="1.0"/>
+    </segment>
+  </avar>
+
+  <fvar>
+
+    <!-- Weight -->
+    <Axis>
+      <AxisTag>wght</AxisTag>
+      <Flags>0x0</Flags>
+      <MinValue>300.0</MinValue>
+      <DefaultValue>300.0</DefaultValue>
+      <MaxValue>700.0</MaxValue>
+      <AxisNameID>256</AxisNameID>
+    </Axis>
+
+    <!-- Width -->
+    <Axis>
+      <AxisTag>wdth</AxisTag>
+      <Flags>0x0</Flags>
+      <MinValue>50.0</MinValue>
+      <DefaultValue>50.0</DefaultValue>
+      <MaxValue>200.0</MaxValue>
+      <AxisNameID>257</AxisNameID>
+    </Axis>
+
+    <!-- Sans Light Condensed -->
+    <!-- PostScript: MutatorMathTest-SansLightCondensed -->
+    <NamedInstance flags="0x0" postscriptNameID="259" subfamilyNameID="258">
+      <coord axis="wght" value="300.0"/>
+      <coord axis="wdth" value="50.0"/>
+    </NamedInstance>
+
+    <!-- Sans Bold Condensed -->
+    <!-- PostScript: MutatorMathTest-SansBoldCondensed -->
+    <NamedInstance flags="0x0" postscriptNameID="261" subfamilyNameID="260">
+      <coord axis="wght" value="700.0"/>
+      <coord axis="wdth" value="50.0"/>
+    </NamedInstance>
+
+    <!-- Sans Light Extended -->
+    <!-- PostScript: MutatorMathTest-SansLightExtended -->
+    <NamedInstance flags="0x0" postscriptNameID="263" subfamilyNameID="262">
+      <coord axis="wght" value="300.0"/>
+      <coord axis="wdth" value="200.0"/>
+    </NamedInstance>
+
+    <!-- Sans Bold Extended -->
+    <!-- PostScript: MutatorMathTest-SansBoldExtended -->
+    <NamedInstance flags="0x0" postscriptNameID="265" subfamilyNameID="264">
+      <coord axis="wght" value="700.0"/>
+      <coord axis="wdth" value="200.0"/>
+    </NamedInstance>
+
+    <!-- Sans Medium -->
+    <!-- PostScript: MutatorMathTest-SansMedium -->
+    <NamedInstance flags="0x0" postscriptNameID="267" subfamilyNameID="266">
+      <coord axis="wght" value="500.0"/>
+      <coord axis="wdth" value="82.7"/>
+    </NamedInstance>
+
+    <!-- Sans Medium -->
+    <!-- PostScript: MutatorMathTest-SansMedium -->
+    <NamedInstance flags="0x0" postscriptNameID="268" subfamilyNameID="266">
+      <coord axis="wght" value="500.0"/>
+      <coord axis="wdth" value="82.7"/>
+    </NamedInstance>
+
+    <!-- Sans Bold -->
+    <!-- PostScript: MutatorMathTest-SansBold -->
+    <NamedInstance flags="0x0" postscriptNameID="270" subfamilyNameID="269">
+      <coord axis="wght" value="700.0"/>
+      <coord axis="wdth" value="113.8156"/>
+    </NamedInstance>
+
+    <!-- Sans Medium Extended -->
+    <!-- PostScript: MutatorMathTest-SansMediumExtended -->
+    <NamedInstance flags="0x0" postscriptNameID="272" subfamilyNameID="271">
+      <coord axis="wght" value="500.0"/>
+      <coord axis="wdth" value="200.0"/>
+    </NamedInstance>
+
+    <!-- Sans Light Condensed -->
+    <!-- PostScript: MutatorMathTest-SansLightCondensed -->
+    <NamedInstance flags="0x0" postscriptNameID="273" subfamilyNameID="258">
+      <coord axis="wght" value="300.0"/>
+      <coord axis="wdth" value="50.0"/>
+    </NamedInstance>
+  </fvar>
+
+  <gvar>
+    <version value="1"/>
+    <reserved value="0"/>
+  </gvar>
+
+</ttFont>

--- a/tests/data/DSv5/MutatorSansVariable_Weight_Width-TTF.ttx
+++ b/tests/data/DSv5/MutatorSansVariable_Weight_Width-TTF.ttx
@@ -21,7 +21,7 @@
     <unitsPerEm value="1000"/>
     <created value="Fri Feb 17 17:17:17 2017"/>
     <modified value="Sun Feb 18 18:18:18 2018"/>
-    <xMin value="50"/>
+    <xMin value="0"/>
     <yMin value="-200"/>
     <xMax value="450"/>
     <yMax value="800"/>
@@ -38,8 +38,8 @@
     <descent value="-200"/>
     <lineGap value="0"/>
     <advanceWidthMax value="500"/>
-    <minLeftSideBearing value="50"/>
-    <minRightSideBearing value="50"/>
+    <minLeftSideBearing value="0"/>
+    <minRightSideBearing value="-10"/>
     <xMaxExtent value="450"/>
     <caretSlopeRise value="1"/>
     <caretSlopeRun value="0"/>
@@ -166,15 +166,55 @@
       <instructions/>
     </TTGlyph>
 
-    <TTGlyph name="I"/><!-- contains no outline data -->
+    <TTGlyph name="I" xMin="0" yMin="0" xMax="10" yMax="10">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="10" on="1"/>
+        <pt x="10" y="10" on="1"/>
+        <pt x="10" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
-    <TTGlyph name="I.narrow"/><!-- contains no outline data -->
+    <TTGlyph name="I.narrow" xMin="0" yMin="0" xMax="10" yMax="10">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="10" on="1"/>
+        <pt x="10" y="10" on="1"/>
+        <pt x="10" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
-    <TTGlyph name="S"/><!-- contains no outline data -->
+    <TTGlyph name="S" xMin="0" yMin="0" xMax="10" yMax="10">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="10" on="1"/>
+        <pt x="10" y="10" on="1"/>
+        <pt x="10" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
-    <TTGlyph name="S.closed"/><!-- contains no outline data -->
+    <TTGlyph name="S.closed" xMin="0" yMin="0" xMax="10" yMax="10">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="10" on="1"/>
+        <pt x="10" y="10" on="1"/>
+        <pt x="10" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
-    <TTGlyph name="a"/><!-- contains no outline data -->
+    <TTGlyph name="a" xMin="0" yMin="0" xMax="10" yMax="10">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="10" on="1"/>
+        <pt x="10" y="10" on="1"/>
+        <pt x="10" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
   </glyf>
 
@@ -870,6 +910,112 @@
   <gvar>
     <version value="1"/>
     <reserved value="0"/>
+    <glyphVariations glyph="I">
+      <tuple>
+        <coord axis="wght" min="0.0" value="0.7" max="1.0"/>
+        <delta pt="0" x="40" y="0"/>
+      </tuple>
+      <tuple>
+        <coord axis="wght" min="0.7" value="1.0" max="1.0"/>
+        <delta pt="0" x="10" y="0"/>
+      </tuple>
+      <tuple>
+        <coord axis="wdth" value="1.0"/>
+        <delta pt="0" x="20" y="0"/>
+      </tuple>
+      <tuple>
+        <coord axis="wght" min="0.0" value="0.7" max="1.0"/>
+        <coord axis="wdth" value="1.0"/>
+        <delta pt="0" x="-10" y="0"/>
+      </tuple>
+      <tuple>
+        <coord axis="wght" min="0.0" value="0.7" max="1.0"/>
+        <coord axis="wdth" min="0.0" value="0.5691" max="1.0"/>
+        <delta pt="0" x="14" y="0"/>
+      </tuple>
+    </glyphVariations>
+    <glyphVariations glyph="I.narrow">
+      <tuple>
+        <coord axis="wght" min="0.0" value="0.7" max="1.0"/>
+        <delta pt="0" x="40" y="0"/>
+      </tuple>
+      <tuple>
+        <coord axis="wght" min="0.7" value="1.0" max="1.0"/>
+        <delta pt="0" x="10" y="0"/>
+      </tuple>
+      <tuple>
+        <coord axis="wdth" value="1.0"/>
+        <delta pt="0" x="20" y="0"/>
+      </tuple>
+      <tuple>
+        <coord axis="wght" min="0.0" value="0.7" max="1.0"/>
+        <coord axis="wdth" value="1.0"/>
+        <delta pt="0" x="-10" y="0"/>
+      </tuple>
+      <tuple>
+        <coord axis="wght" min="0.0" value="0.7" max="1.0"/>
+        <coord axis="wdth" min="0.0" value="0.5691" max="1.0"/>
+        <delta pt="0" x="14" y="0"/>
+      </tuple>
+    </glyphVariations>
+    <glyphVariations glyph="S">
+      <tuple>
+        <coord axis="wght" min="0.0" value="0.7" max="1.0"/>
+        <delta pt="0" x="40" y="0"/>
+      </tuple>
+      <tuple>
+        <coord axis="wght" min="0.7" value="1.0" max="1.0"/>
+        <delta pt="0" x="10" y="0"/>
+      </tuple>
+      <tuple>
+        <coord axis="wdth" value="1.0"/>
+        <delta pt="0" x="20" y="0"/>
+      </tuple>
+      <tuple>
+        <coord axis="wght" min="0.0" value="0.7" max="1.0"/>
+        <coord axis="wdth" value="1.0"/>
+        <delta pt="0" x="-10" y="0"/>
+      </tuple>
+      <tuple>
+        <coord axis="wght" min="0.0" value="0.7" max="1.0"/>
+        <coord axis="wdth" min="0.0" value="0.5691" max="1.0"/>
+        <delta pt="0" x="14" y="0"/>
+      </tuple>
+    </glyphVariations>
+    <glyphVariations glyph="S.closed">
+      <tuple>
+        <coord axis="wght" min="0.0" value="0.7" max="1.0"/>
+        <delta pt="0" x="40" y="0"/>
+      </tuple>
+      <tuple>
+        <coord axis="wght" min="0.7" value="1.0" max="1.0"/>
+        <delta pt="0" x="10" y="0"/>
+      </tuple>
+      <tuple>
+        <coord axis="wdth" value="1.0"/>
+        <delta pt="0" x="20" y="0"/>
+      </tuple>
+      <tuple>
+        <coord axis="wght" min="0.0" value="0.7" max="1.0"/>
+        <coord axis="wdth" value="1.0"/>
+        <delta pt="0" x="-10" y="0"/>
+      </tuple>
+      <tuple>
+        <coord axis="wght" min="0.0" value="0.7" max="1.0"/>
+        <coord axis="wdth" min="0.0" value="0.5691" max="1.0"/>
+        <delta pt="0" x="14" y="0"/>
+      </tuple>
+    </glyphVariations>
+    <glyphVariations glyph="a">
+      <tuple>
+        <coord axis="wght" value="1.0"/>
+        <delta pt="0" x="10" y="0"/>
+      </tuple>
+      <tuple>
+        <coord axis="wdth" value="1.0"/>
+        <delta pt="0" x="20" y="0"/>
+      </tuple>
+    </glyphVariations>
   </gvar>
 
 </ttFont>

--- a/tests/data/DSv5/MutatorSansVariable_Width-CFF2.ttx
+++ b/tests/data/DSv5/MutatorSansVariable_Width-CFF2.ttx
@@ -1,0 +1,552 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="OTTO" ttLibVersion="4.33">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="I"/>
+    <GlyphID id="2" name="I.narrow"/>
+    <GlyphID id="3" name="S"/>
+    <GlyphID id="4" name="S.closed"/>
+    <GlyphID id="5" name="a"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="0.0"/>
+    <checkSumAdjustment value="0x12345678"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Fri Feb 17 17:17:17 2017"/>
+    <modified value="Sun Feb 18 18:18:18 2018"/>
+    <xMin value="50"/>
+    <yMin value="-200"/>
+    <xMax value="450"/>
+    <yMax value="800"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="6"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1000"/>
+    <descent value="-200"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="500"/>
+    <minLeftSideBearing value="50"/>
+    <minRightSideBearing value="50"/>
+    <xMaxExtent value="450"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="2"/>
+  </hhea>
+
+  <maxp>
+    <tableVersion value="0x5000"/>
+    <numGlyphs value="6"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="500"/>
+    <usWeightClass value="400"/>
+    <usWidthClass value="1"/>
+    <fsType value="00000000 00000100"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="300"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="0"/>
+      <bSerifStyle value="0"/>
+      <bWeight value="0"/>
+      <bProportion value="0"/>
+      <bContrast value="0"/>
+      <bStrokeVariation value="0"/>
+      <bArmStyle value="0"/>
+      <bLetterForm value="0"/>
+      <bMidline value="0"/>
+      <bXHeight value="0"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="NONE"/>
+    <fsSelection value="00000000 01000000"/>
+    <usFirstCharIndex value="65535"/>
+    <usLastCharIndex value="65535"/>
+    <sTypoAscender value="800"/>
+    <sTypoDescender value="-200"/>
+    <sTypoLineGap value="200"/>
+    <usWinAscent value="1000"/>
+    <usWinDescent value="200"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="500"/>
+    <sCapHeight value="700"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="0"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="500" lsb="50"/>
+    <mtx name="I" width="0" lsb="0"/>
+    <mtx name="I.narrow" width="0" lsb="0"/>
+    <mtx name="S" width="0" lsb="0"/>
+    <mtx name="S.closed" width="0" lsb="0"/>
+    <mtx name="a" width="0" lsb="0"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+    </cmap_format_4>
+  </cmap>
+
+  <name>
+    <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Width
+    </namerecord>
+    <namerecord nameID="257" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Sans Light Condensed
+    </namerecord>
+    <namerecord nameID="258" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      MutatorMathTest-SansLightCondensed
+    </namerecord>
+    <namerecord nameID="259" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Sans Light Extended
+    </namerecord>
+    <namerecord nameID="260" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      MutatorMathTest-SansLightExtended
+    </namerecord>
+    <namerecord nameID="261" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      MutatorMathTest-SansLightCondensed
+    </namerecord>
+    <namerecord nameID="262" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Regular
+    </namerecord>
+    <namerecord nameID="263" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      serif
+    </namerecord>
+    <namerecord nameID="264" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Sans
+    </namerecord>
+    <namerecord nameID="265" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      weight
+    </namerecord>
+    <namerecord nameID="266" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Light
+    </namerecord>
+    <namerecord nameID="267" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      width
+    </namerecord>
+    <namerecord nameID="268" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Condensed
+    </namerecord>
+    <namerecord nameID="269" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Normal
+    </namerecord>
+    <namerecord nameID="270" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Extended
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      New Font
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      0.000;NONE;NewFont-Regular
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      New Font Regular
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 0.000
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      NewFont-Regular
+    </namerecord>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
+      Width
+    </namerecord>
+    <namerecord nameID="257" platformID="3" platEncID="1" langID="0x409">
+      Sans Light Condensed
+    </namerecord>
+    <namerecord nameID="258" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-SansLightCondensed
+    </namerecord>
+    <namerecord nameID="259" platformID="3" platEncID="1" langID="0x409">
+      Sans Light Extended
+    </namerecord>
+    <namerecord nameID="260" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-SansLightExtended
+    </namerecord>
+    <namerecord nameID="261" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-SansLightCondensed
+    </namerecord>
+    <namerecord nameID="262" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="263" platformID="3" platEncID="1" langID="0x409">
+      serif
+    </namerecord>
+    <namerecord nameID="264" platformID="3" platEncID="1" langID="0x409">
+      Sans
+    </namerecord>
+    <namerecord nameID="265" platformID="3" platEncID="1" langID="0x409">
+      weight
+    </namerecord>
+    <namerecord nameID="266" platformID="3" platEncID="1" langID="0x409">
+      Light
+    </namerecord>
+    <namerecord nameID="267" platformID="3" platEncID="1" langID="0x409">
+      width
+    </namerecord>
+    <namerecord nameID="268" platformID="3" platEncID="1" langID="0x409">
+      Condensed
+    </namerecord>
+    <namerecord nameID="269" platformID="3" platEncID="1" langID="0x409">
+      Normal
+    </namerecord>
+    <namerecord nameID="270" platformID="3" platEncID="1" langID="0x409">
+      Extended
+    </namerecord>
+  </name>
+
+  <post>
+    <formatType value="2.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-75"/>
+    <underlineThickness value="50"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+    <psNames>
+      <!-- This file uses unique glyph names based on the information
+           found in the 'post' table. Since these names might not be unique,
+           we have to invent artificial names in case of clashes. In order to
+           be able to retain the original information, we need a name to
+           ps name mapping for those cases where they differ. That's what
+           you see below.
+            -->
+    </psNames>
+    <extraNames>
+      <!-- following are the name that are not taken from the standard Mac glyph order -->
+      <psName name="I.narrow"/>
+      <psName name="S.closed"/>
+    </extraNames>
+  </post>
+
+  <CFF2>
+    <major value="2"/>
+    <minor value="0"/>
+    <CFFFont name="CFF2Font">
+      <FontMatrix value="0.001 0 0 0.001 0 0"/>
+      <FDArray>
+        <FontDict index="0">
+          <Private>
+            <BlueScale value="0.039625"/>
+            <BlueShift value="7"/>
+            <BlueFuzz value="1"/>
+            <LanguageGroup value="0"/>
+            <ExpansionFactor value="0.06"/>
+          </Private>
+        </FontDict>
+      </FDArray>
+      <CharStrings>
+        <CharString name=".notdef">
+          50 -200 rmoveto
+          400 1000 -400 -1000 hlineto
+          50 50 rmoveto
+          900 300 -900 -300 vlineto
+        </CharString>
+        <CharString name="I">
+        </CharString>
+        <CharString name="I.narrow">
+        </CharString>
+        <CharString name="S">
+        </CharString>
+        <CharString name="S.closed">
+        </CharString>
+        <CharString name="a">
+        </CharString>
+      </CharStrings>
+      <VarStore Format="1">
+        <Format value="1"/>
+        <VarRegionList>
+          <!-- RegionAxisCount=1 -->
+          <!-- RegionCount=1 -->
+          <Region index="0">
+            <VarRegionAxis index="0">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
+            </VarRegionAxis>
+          </Region>
+        </VarRegionList>
+        <!-- VarDataCount=1 -->
+        <VarData index="0">
+          <!-- ItemCount=0 -->
+          <NumShorts value="0"/>
+          <!-- VarRegionCount=1 -->
+          <VarRegionIndex index="0" value="0"/>
+        </VarData>
+      </VarStore>
+    </CFFFont>
+
+    <GlobalSubrs>
+      <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+    </GlobalSubrs>
+  </CFF2>
+
+  <GSUB>
+    <Version value="0x00010001"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="rvrn"/>
+        <Feature>
+          <!-- LookupCount=0 -->
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=2 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="I" out="I.narrow"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="S" out="S.closed"/>
+        </SingleSubst>
+      </Lookup>
+    </LookupList>
+    <FeatureVariations>
+      <Version value="0x00010000"/>
+      <!-- FeatureVariationCount=2 -->
+      <FeatureVariationRecord index="0">
+        <ConditionSet>
+          <!-- ConditionCount=1 -->
+          <ConditionTable index="0" Format="1">
+            <AxisIndex value="0"/>
+            <FilterRangeMinValue value="0.0"/>
+            <FilterRangeMaxValue value="0.328"/>
+          </ConditionTable>
+        </ConditionSet>
+        <FeatureTableSubstitution>
+          <Version value="0x00010000"/>
+          <!-- SubstitutionCount=1 -->
+          <SubstitutionRecord index="0">
+            <FeatureIndex value="0"/>
+            <Feature>
+              <!-- LookupCount=2 -->
+              <LookupListIndex index="0" value="0"/>
+              <LookupListIndex index="1" value="1"/>
+            </Feature>
+          </SubstitutionRecord>
+        </FeatureTableSubstitution>
+      </FeatureVariationRecord>
+      <FeatureVariationRecord index="1">
+        <ConditionSet>
+          <!-- ConditionCount=0 -->
+        </ConditionSet>
+        <FeatureTableSubstitution>
+          <Version value="0x00010000"/>
+          <!-- SubstitutionCount=1 -->
+          <SubstitutionRecord index="0">
+            <FeatureIndex value="0"/>
+            <Feature>
+              <!-- LookupCount=1 -->
+              <LookupListIndex index="0" value="1"/>
+            </Feature>
+          </SubstitutionRecord>
+        </FeatureTableSubstitution>
+      </FeatureVariationRecord>
+    </FeatureVariations>
+  </GSUB>
+
+  <HVAR>
+    <Version value="0x00010000"/>
+    <VarStore Format="1">
+      <Format value="1"/>
+      <VarRegionList>
+        <!-- RegionAxisCount=1 -->
+        <!-- RegionCount=1 -->
+        <Region index="0">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+      </VarRegionList>
+      <!-- VarDataCount=1 -->
+      <VarData index="0">
+        <!-- ItemCount=6 -->
+        <NumShorts value="0"/>
+        <!-- VarRegionCount=0 -->
+        <Item index="0" value="[]"/>
+        <Item index="1" value="[]"/>
+        <Item index="2" value="[]"/>
+        <Item index="3" value="[]"/>
+        <Item index="4" value="[]"/>
+        <Item index="5" value="[]"/>
+      </VarData>
+    </VarStore>
+  </HVAR>
+
+  <STAT>
+    <Version value="0x00010001"/>
+    <DesignAxisRecordSize value="8"/>
+    <!-- DesignAxisCount=3 -->
+    <DesignAxisRecord>
+      <Axis index="0">
+        <AxisTag value="SRIF"/>
+        <AxisNameID value="263"/>  <!-- serif -->
+        <AxisOrdering value="0"/>
+      </Axis>
+      <Axis index="1">
+        <AxisTag value="wght"/>
+        <AxisNameID value="265"/>  <!-- weight -->
+        <AxisOrdering value="1"/>
+      </Axis>
+      <Axis index="2">
+        <AxisTag value="wdth"/>
+        <AxisNameID value="267"/>  <!-- width -->
+        <AxisOrdering value="2"/>
+      </Axis>
+    </DesignAxisRecord>
+    <!-- AxisValueCount=5 -->
+    <AxisValueArray>
+      <AxisValue index="0" Format="1">
+        <AxisIndex value="0"/>
+        <Flags value="0"/>
+        <ValueNameID value="264"/>  <!-- Sans -->
+        <Value value="0.0"/>
+      </AxisValue>
+      <AxisValue index="1" Format="2">
+        <AxisIndex value="1"/>
+        <Flags value="0"/>
+        <ValueNameID value="266"/>  <!-- Light -->
+        <NominalValue value="300.0"/>
+        <RangeMinValue value="300.0"/>
+        <RangeMaxValue value="400.0"/>
+      </AxisValue>
+      <AxisValue index="2" Format="2">
+        <AxisIndex value="2"/>
+        <Flags value="0"/>
+        <ValueNameID value="268"/>  <!-- Condensed -->
+        <NominalValue value="50.0"/>
+        <RangeMinValue value="50.0"/>
+        <RangeMaxValue value="75.0"/>
+      </AxisValue>
+      <AxisValue index="3" Format="2">
+        <AxisIndex value="2"/>
+        <Flags value="2"/>  <!-- ElidableAxisValueName -->
+        <ValueNameID value="269"/>  <!-- Normal -->
+        <NominalValue value="100.0"/>
+        <RangeMinValue value="75.0"/>
+        <RangeMaxValue value="125.0"/>
+      </AxisValue>
+      <AxisValue index="4" Format="2">
+        <AxisIndex value="2"/>
+        <Flags value="0"/>
+        <ValueNameID value="270"/>  <!-- Extended -->
+        <NominalValue value="200.0"/>
+        <RangeMinValue value="125.0"/>
+        <RangeMaxValue value="200.0"/>
+      </AxisValue>
+    </AxisValueArray>
+    <ElidedFallbackNameID value="262"/>  <!-- Regular -->
+  </STAT>
+
+  <avar>
+    <segment axis="wdth">
+      <mapping from="-1.0" to="-1.0"/>
+      <mapping from="0.0" to="0.0"/>
+      <mapping from="0.3333" to="0.5"/>
+      <mapping from="1.0" to="1.0"/>
+    </segment>
+  </avar>
+
+  <fvar>
+
+    <!-- Width -->
+    <Axis>
+      <AxisTag>wdth</AxisTag>
+      <Flags>0x0</Flags>
+      <MinValue>50.0</MinValue>
+      <DefaultValue>50.0</DefaultValue>
+      <MaxValue>200.0</MaxValue>
+      <AxisNameID>256</AxisNameID>
+    </Axis>
+
+    <!-- Sans Light Condensed -->
+    <!-- PostScript: MutatorMathTest-SansLightCondensed -->
+    <NamedInstance flags="0x0" postscriptNameID="258" subfamilyNameID="257">
+      <coord axis="wdth" value="50.0"/>
+    </NamedInstance>
+
+    <!-- Sans Light Extended -->
+    <!-- PostScript: MutatorMathTest-SansLightExtended -->
+    <NamedInstance flags="0x0" postscriptNameID="260" subfamilyNameID="259">
+      <coord axis="wdth" value="200.0"/>
+    </NamedInstance>
+
+    <!-- Sans Light Condensed -->
+    <!-- PostScript: MutatorMathTest-SansLightCondensed -->
+    <NamedInstance flags="0x0" postscriptNameID="261" subfamilyNameID="257">
+      <coord axis="wdth" value="50.0"/>
+    </NamedInstance>
+  </fvar>
+
+</ttFont>

--- a/tests/data/DSv5/MutatorSansVariable_Width-CFF2.ttx
+++ b/tests/data/DSv5/MutatorSansVariable_Width-CFF2.ttx
@@ -21,7 +21,7 @@
     <unitsPerEm value="1000"/>
     <created value="Fri Feb 17 17:17:17 2017"/>
     <modified value="Sun Feb 18 18:18:18 2018"/>
-    <xMin value="50"/>
+    <xMin value="0"/>
     <yMin value="-200"/>
     <xMax value="450"/>
     <yMax value="800"/>
@@ -38,8 +38,8 @@
     <descent value="-200"/>
     <lineGap value="0"/>
     <advanceWidthMax value="500"/>
-    <minLeftSideBearing value="50"/>
-    <minRightSideBearing value="50"/>
+    <minLeftSideBearing value="0"/>
+    <minRightSideBearing value="-10"/>
     <xMaxExtent value="450"/>
     <caretSlopeRise value="1"/>
     <caretSlopeRun value="0"/>
@@ -288,14 +288,29 @@
           900 300 -900 -300 vlineto
         </CharString>
         <CharString name="I">
+          0 20 1 blend
+          hmoveto
+          10 10 -10 hlineto
         </CharString>
         <CharString name="I.narrow">
+          0 20 1 blend
+          hmoveto
+          10 10 -10 hlineto
         </CharString>
         <CharString name="S">
+          0 20 1 blend
+          hmoveto
+          10 10 -10 hlineto
         </CharString>
         <CharString name="S.closed">
+          0 20 1 blend
+          hmoveto
+          10 10 -10 hlineto
         </CharString>
         <CharString name="a">
+          0 20 1 blend
+          hmoveto
+          10 10 -10 hlineto
         </CharString>
       </CharStrings>
       <VarStore Format="1">

--- a/tests/data/DSv5/MutatorSansVariable_Width-TTF.ttx
+++ b/tests/data/DSv5/MutatorSansVariable_Width-TTF.ttx
@@ -21,7 +21,7 @@
     <unitsPerEm value="1000"/>
     <created value="Fri Feb 17 17:17:17 2017"/>
     <modified value="Sun Feb 18 18:18:18 2018"/>
-    <xMin value="50"/>
+    <xMin value="0"/>
     <yMin value="-200"/>
     <xMax value="450"/>
     <yMax value="800"/>
@@ -38,8 +38,8 @@
     <descent value="-200"/>
     <lineGap value="0"/>
     <advanceWidthMax value="500"/>
-    <minLeftSideBearing value="50"/>
-    <minRightSideBearing value="50"/>
+    <minLeftSideBearing value="0"/>
+    <minRightSideBearing value="-10"/>
     <xMaxExtent value="450"/>
     <caretSlopeRise value="1"/>
     <caretSlopeRun value="0"/>
@@ -166,15 +166,55 @@
       <instructions/>
     </TTGlyph>
 
-    <TTGlyph name="I"/><!-- contains no outline data -->
+    <TTGlyph name="I" xMin="0" yMin="0" xMax="10" yMax="10">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="10" on="1"/>
+        <pt x="10" y="10" on="1"/>
+        <pt x="10" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
-    <TTGlyph name="I.narrow"/><!-- contains no outline data -->
+    <TTGlyph name="I.narrow" xMin="0" yMin="0" xMax="10" yMax="10">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="10" on="1"/>
+        <pt x="10" y="10" on="1"/>
+        <pt x="10" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
-    <TTGlyph name="S"/><!-- contains no outline data -->
+    <TTGlyph name="S" xMin="0" yMin="0" xMax="10" yMax="10">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="10" on="1"/>
+        <pt x="10" y="10" on="1"/>
+        <pt x="10" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
-    <TTGlyph name="S.closed"/><!-- contains no outline data -->
+    <TTGlyph name="S.closed" xMin="0" yMin="0" xMax="10" yMax="10">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="10" on="1"/>
+        <pt x="10" y="10" on="1"/>
+        <pt x="10" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
-    <TTGlyph name="a"/><!-- contains no outline data -->
+    <TTGlyph name="a" xMin="0" yMin="0" xMax="10" yMax="10">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="10" on="1"/>
+        <pt x="10" y="10" on="1"/>
+        <pt x="10" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
   </glyf>
 
@@ -541,6 +581,36 @@
   <gvar>
     <version value="1"/>
     <reserved value="0"/>
+    <glyphVariations glyph="I">
+      <tuple>
+        <coord axis="wdth" value="1.0"/>
+        <delta pt="0" x="20" y="0"/>
+      </tuple>
+    </glyphVariations>
+    <glyphVariations glyph="I.narrow">
+      <tuple>
+        <coord axis="wdth" value="1.0"/>
+        <delta pt="0" x="20" y="0"/>
+      </tuple>
+    </glyphVariations>
+    <glyphVariations glyph="S">
+      <tuple>
+        <coord axis="wdth" value="1.0"/>
+        <delta pt="0" x="20" y="0"/>
+      </tuple>
+    </glyphVariations>
+    <glyphVariations glyph="S.closed">
+      <tuple>
+        <coord axis="wdth" value="1.0"/>
+        <delta pt="0" x="20" y="0"/>
+      </tuple>
+    </glyphVariations>
+    <glyphVariations glyph="a">
+      <tuple>
+        <coord axis="wdth" value="1.0"/>
+        <delta pt="0" x="20" y="0"/>
+      </tuple>
+    </glyphVariations>
   </gvar>
 
 </ttFont>

--- a/tests/data/DSv5/MutatorSansVariable_Width-TTF.ttx
+++ b/tests/data/DSv5/MutatorSansVariable_Width-TTF.ttx
@@ -1,0 +1,546 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.33">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="I"/>
+    <GlyphID id="2" name="I.narrow"/>
+    <GlyphID id="3" name="S"/>
+    <GlyphID id="4" name="S.closed"/>
+    <GlyphID id="5" name="a"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="0.0"/>
+    <checkSumAdjustment value="0x12345678"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Fri Feb 17 17:17:17 2017"/>
+    <modified value="Sun Feb 18 18:18:18 2018"/>
+    <xMin value="50"/>
+    <yMin value="-200"/>
+    <xMax value="450"/>
+    <yMax value="800"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="6"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1000"/>
+    <descent value="-200"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="500"/>
+    <minLeftSideBearing value="50"/>
+    <minRightSideBearing value="50"/>
+    <xMaxExtent value="450"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="2"/>
+  </hhea>
+
+  <maxp>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="0x10000"/>
+    <numGlyphs value="6"/>
+    <maxPoints value="8"/>
+    <maxContours value="2"/>
+    <maxCompositePoints value="0"/>
+    <maxCompositeContours value="0"/>
+    <maxZones value="1"/>
+    <maxTwilightPoints value="0"/>
+    <maxStorage value="0"/>
+    <maxFunctionDefs value="0"/>
+    <maxInstructionDefs value="0"/>
+    <maxStackElements value="0"/>
+    <maxSizeOfInstructions value="0"/>
+    <maxComponentElements value="0"/>
+    <maxComponentDepth value="0"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="500"/>
+    <usWeightClass value="400"/>
+    <usWidthClass value="1"/>
+    <fsType value="00000000 00000100"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="300"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="0"/>
+      <bSerifStyle value="0"/>
+      <bWeight value="0"/>
+      <bProportion value="0"/>
+      <bContrast value="0"/>
+      <bStrokeVariation value="0"/>
+      <bArmStyle value="0"/>
+      <bLetterForm value="0"/>
+      <bMidline value="0"/>
+      <bXHeight value="0"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="NONE"/>
+    <fsSelection value="00000000 01000000"/>
+    <usFirstCharIndex value="65535"/>
+    <usLastCharIndex value="65535"/>
+    <sTypoAscender value="800"/>
+    <sTypoDescender value="-200"/>
+    <sTypoLineGap value="200"/>
+    <usWinAscent value="1000"/>
+    <usWinDescent value="200"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="500"/>
+    <sCapHeight value="700"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="0"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="500" lsb="50"/>
+    <mtx name="I" width="0" lsb="0"/>
+    <mtx name="I.narrow" width="0" lsb="0"/>
+    <mtx name="S" width="0" lsb="0"/>
+    <mtx name="S.closed" width="0" lsb="0"/>
+    <mtx name="a" width="0" lsb="0"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+    </cmap_format_4>
+  </cmap>
+
+  <loca>
+    <!-- The 'loca' table will be calculated by the compiler -->
+  </loca>
+
+  <glyf>
+
+    <!-- The xMin, yMin, xMax and yMax values
+         will be recalculated by the compiler. -->
+
+    <TTGlyph name=".notdef" xMin="50" yMin="-200" xMax="450" yMax="800">
+      <contour>
+        <pt x="50" y="-200" on="1"/>
+        <pt x="50" y="800" on="1"/>
+        <pt x="450" y="800" on="1"/>
+        <pt x="450" y="-200" on="1"/>
+      </contour>
+      <contour>
+        <pt x="100" y="-150" on="1"/>
+        <pt x="400" y="-150" on="1"/>
+        <pt x="400" y="750" on="1"/>
+        <pt x="100" y="750" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="I"/><!-- contains no outline data -->
+
+    <TTGlyph name="I.narrow"/><!-- contains no outline data -->
+
+    <TTGlyph name="S"/><!-- contains no outline data -->
+
+    <TTGlyph name="S.closed"/><!-- contains no outline data -->
+
+    <TTGlyph name="a"/><!-- contains no outline data -->
+
+  </glyf>
+
+  <name>
+    <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Width
+    </namerecord>
+    <namerecord nameID="257" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Sans Light Condensed
+    </namerecord>
+    <namerecord nameID="258" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      MutatorMathTest-SansLightCondensed
+    </namerecord>
+    <namerecord nameID="259" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Sans Light Extended
+    </namerecord>
+    <namerecord nameID="260" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      MutatorMathTest-SansLightExtended
+    </namerecord>
+    <namerecord nameID="261" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      MutatorMathTest-SansLightCondensed
+    </namerecord>
+    <namerecord nameID="262" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Regular
+    </namerecord>
+    <namerecord nameID="263" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      serif
+    </namerecord>
+    <namerecord nameID="264" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Sans
+    </namerecord>
+    <namerecord nameID="265" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      weight
+    </namerecord>
+    <namerecord nameID="266" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Light
+    </namerecord>
+    <namerecord nameID="267" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      width
+    </namerecord>
+    <namerecord nameID="268" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Condensed
+    </namerecord>
+    <namerecord nameID="269" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Normal
+    </namerecord>
+    <namerecord nameID="270" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Extended
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      New Font
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      0.000;NONE;NewFont-Regular
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      New Font Regular
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 0.000
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      NewFont-Regular
+    </namerecord>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
+      Width
+    </namerecord>
+    <namerecord nameID="257" platformID="3" platEncID="1" langID="0x409">
+      Sans Light Condensed
+    </namerecord>
+    <namerecord nameID="258" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-SansLightCondensed
+    </namerecord>
+    <namerecord nameID="259" platformID="3" platEncID="1" langID="0x409">
+      Sans Light Extended
+    </namerecord>
+    <namerecord nameID="260" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-SansLightExtended
+    </namerecord>
+    <namerecord nameID="261" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-SansLightCondensed
+    </namerecord>
+    <namerecord nameID="262" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="263" platformID="3" platEncID="1" langID="0x409">
+      serif
+    </namerecord>
+    <namerecord nameID="264" platformID="3" platEncID="1" langID="0x409">
+      Sans
+    </namerecord>
+    <namerecord nameID="265" platformID="3" platEncID="1" langID="0x409">
+      weight
+    </namerecord>
+    <namerecord nameID="266" platformID="3" platEncID="1" langID="0x409">
+      Light
+    </namerecord>
+    <namerecord nameID="267" platformID="3" platEncID="1" langID="0x409">
+      width
+    </namerecord>
+    <namerecord nameID="268" platformID="3" platEncID="1" langID="0x409">
+      Condensed
+    </namerecord>
+    <namerecord nameID="269" platformID="3" platEncID="1" langID="0x409">
+      Normal
+    </namerecord>
+    <namerecord nameID="270" platformID="3" platEncID="1" langID="0x409">
+      Extended
+    </namerecord>
+  </name>
+
+  <post>
+    <formatType value="2.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-75"/>
+    <underlineThickness value="50"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+    <psNames>
+      <!-- This file uses unique glyph names based on the information
+           found in the 'post' table. Since these names might not be unique,
+           we have to invent artificial names in case of clashes. In order to
+           be able to retain the original information, we need a name to
+           ps name mapping for those cases where they differ. That's what
+           you see below.
+            -->
+    </psNames>
+    <extraNames>
+      <!-- following are the name that are not taken from the standard Mac glyph order -->
+      <psName name="I.narrow"/>
+      <psName name="S.closed"/>
+    </extraNames>
+  </post>
+
+  <GSUB>
+    <Version value="0x00010001"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="rvrn"/>
+        <Feature>
+          <!-- LookupCount=0 -->
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=2 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="I" out="I.narrow"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="S" out="S.closed"/>
+        </SingleSubst>
+      </Lookup>
+    </LookupList>
+    <FeatureVariations>
+      <Version value="0x00010000"/>
+      <!-- FeatureVariationCount=2 -->
+      <FeatureVariationRecord index="0">
+        <ConditionSet>
+          <!-- ConditionCount=1 -->
+          <ConditionTable index="0" Format="1">
+            <AxisIndex value="0"/>
+            <FilterRangeMinValue value="0.0"/>
+            <FilterRangeMaxValue value="0.328"/>
+          </ConditionTable>
+        </ConditionSet>
+        <FeatureTableSubstitution>
+          <Version value="0x00010000"/>
+          <!-- SubstitutionCount=1 -->
+          <SubstitutionRecord index="0">
+            <FeatureIndex value="0"/>
+            <Feature>
+              <!-- LookupCount=2 -->
+              <LookupListIndex index="0" value="0"/>
+              <LookupListIndex index="1" value="1"/>
+            </Feature>
+          </SubstitutionRecord>
+        </FeatureTableSubstitution>
+      </FeatureVariationRecord>
+      <FeatureVariationRecord index="1">
+        <ConditionSet>
+          <!-- ConditionCount=0 -->
+        </ConditionSet>
+        <FeatureTableSubstitution>
+          <Version value="0x00010000"/>
+          <!-- SubstitutionCount=1 -->
+          <SubstitutionRecord index="0">
+            <FeatureIndex value="0"/>
+            <Feature>
+              <!-- LookupCount=1 -->
+              <LookupListIndex index="0" value="1"/>
+            </Feature>
+          </SubstitutionRecord>
+        </FeatureTableSubstitution>
+      </FeatureVariationRecord>
+    </FeatureVariations>
+  </GSUB>
+
+  <HVAR>
+    <Version value="0x00010000"/>
+    <VarStore Format="1">
+      <Format value="1"/>
+      <VarRegionList>
+        <!-- RegionAxisCount=1 -->
+        <!-- RegionCount=1 -->
+        <Region index="0">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+      </VarRegionList>
+      <!-- VarDataCount=1 -->
+      <VarData index="0">
+        <!-- ItemCount=6 -->
+        <NumShorts value="0"/>
+        <!-- VarRegionCount=0 -->
+        <Item index="0" value="[]"/>
+        <Item index="1" value="[]"/>
+        <Item index="2" value="[]"/>
+        <Item index="3" value="[]"/>
+        <Item index="4" value="[]"/>
+        <Item index="5" value="[]"/>
+      </VarData>
+    </VarStore>
+  </HVAR>
+
+  <STAT>
+    <Version value="0x00010001"/>
+    <DesignAxisRecordSize value="8"/>
+    <!-- DesignAxisCount=3 -->
+    <DesignAxisRecord>
+      <Axis index="0">
+        <AxisTag value="SRIF"/>
+        <AxisNameID value="263"/>  <!-- serif -->
+        <AxisOrdering value="0"/>
+      </Axis>
+      <Axis index="1">
+        <AxisTag value="wght"/>
+        <AxisNameID value="265"/>  <!-- weight -->
+        <AxisOrdering value="1"/>
+      </Axis>
+      <Axis index="2">
+        <AxisTag value="wdth"/>
+        <AxisNameID value="267"/>  <!-- width -->
+        <AxisOrdering value="2"/>
+      </Axis>
+    </DesignAxisRecord>
+    <!-- AxisValueCount=5 -->
+    <AxisValueArray>
+      <AxisValue index="0" Format="1">
+        <AxisIndex value="0"/>
+        <Flags value="0"/>
+        <ValueNameID value="264"/>  <!-- Sans -->
+        <Value value="0.0"/>
+      </AxisValue>
+      <AxisValue index="1" Format="2">
+        <AxisIndex value="1"/>
+        <Flags value="0"/>
+        <ValueNameID value="266"/>  <!-- Light -->
+        <NominalValue value="300.0"/>
+        <RangeMinValue value="300.0"/>
+        <RangeMaxValue value="400.0"/>
+      </AxisValue>
+      <AxisValue index="2" Format="2">
+        <AxisIndex value="2"/>
+        <Flags value="0"/>
+        <ValueNameID value="268"/>  <!-- Condensed -->
+        <NominalValue value="50.0"/>
+        <RangeMinValue value="50.0"/>
+        <RangeMaxValue value="75.0"/>
+      </AxisValue>
+      <AxisValue index="3" Format="2">
+        <AxisIndex value="2"/>
+        <Flags value="2"/>  <!-- ElidableAxisValueName -->
+        <ValueNameID value="269"/>  <!-- Normal -->
+        <NominalValue value="100.0"/>
+        <RangeMinValue value="75.0"/>
+        <RangeMaxValue value="125.0"/>
+      </AxisValue>
+      <AxisValue index="4" Format="2">
+        <AxisIndex value="2"/>
+        <Flags value="0"/>
+        <ValueNameID value="270"/>  <!-- Extended -->
+        <NominalValue value="200.0"/>
+        <RangeMinValue value="125.0"/>
+        <RangeMaxValue value="200.0"/>
+      </AxisValue>
+    </AxisValueArray>
+    <ElidedFallbackNameID value="262"/>  <!-- Regular -->
+  </STAT>
+
+  <avar>
+    <segment axis="wdth">
+      <mapping from="-1.0" to="-1.0"/>
+      <mapping from="0.0" to="0.0"/>
+      <mapping from="0.3333" to="0.5"/>
+      <mapping from="1.0" to="1.0"/>
+    </segment>
+  </avar>
+
+  <fvar>
+
+    <!-- Width -->
+    <Axis>
+      <AxisTag>wdth</AxisTag>
+      <Flags>0x0</Flags>
+      <MinValue>50.0</MinValue>
+      <DefaultValue>50.0</DefaultValue>
+      <MaxValue>200.0</MaxValue>
+      <AxisNameID>256</AxisNameID>
+    </Axis>
+
+    <!-- Sans Light Condensed -->
+    <!-- PostScript: MutatorMathTest-SansLightCondensed -->
+    <NamedInstance flags="0x0" postscriptNameID="258" subfamilyNameID="257">
+      <coord axis="wdth" value="50.0"/>
+    </NamedInstance>
+
+    <!-- Sans Light Extended -->
+    <!-- PostScript: MutatorMathTest-SansLightExtended -->
+    <NamedInstance flags="0x0" postscriptNameID="260" subfamilyNameID="259">
+      <coord axis="wdth" value="200.0"/>
+    </NamedInstance>
+
+    <!-- Sans Light Condensed -->
+    <!-- PostScript: MutatorMathTest-SansLightCondensed -->
+    <NamedInstance flags="0x0" postscriptNameID="261" subfamilyNameID="257">
+      <coord axis="wdth" value="50.0"/>
+    </NamedInstance>
+  </fvar>
+
+  <gvar>
+    <version value="1"/>
+    <reserved value="0"/>
+  </gvar>
+
+</ttFont>

--- a/tests/data/DSv5/MutatorSerifVariable_Width-CFF2.ttx
+++ b/tests/data/DSv5/MutatorSerifVariable_Width-CFF2.ttx
@@ -1,0 +1,434 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="OTTO" ttLibVersion="4.33">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="I"/>
+    <GlyphID id="2" name="I.narrow"/>
+    <GlyphID id="3" name="S"/>
+    <GlyphID id="4" name="S.closed"/>
+    <GlyphID id="5" name="a"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="0.0"/>
+    <checkSumAdjustment value="0x12345678"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Fri Feb 17 17:17:17 2017"/>
+    <modified value="Sun Feb 18 18:18:18 2018"/>
+    <xMin value="50"/>
+    <yMin value="-200"/>
+    <xMax value="450"/>
+    <yMax value="800"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="6"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1000"/>
+    <descent value="-200"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="500"/>
+    <minLeftSideBearing value="50"/>
+    <minRightSideBearing value="50"/>
+    <xMaxExtent value="450"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="2"/>
+  </hhea>
+
+  <maxp>
+    <tableVersion value="0x5000"/>
+    <numGlyphs value="6"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="500"/>
+    <usWeightClass value="400"/>
+    <usWidthClass value="1"/>
+    <fsType value="00000000 00000100"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="300"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="0"/>
+      <bSerifStyle value="0"/>
+      <bWeight value="0"/>
+      <bProportion value="0"/>
+      <bContrast value="0"/>
+      <bStrokeVariation value="0"/>
+      <bArmStyle value="0"/>
+      <bLetterForm value="0"/>
+      <bMidline value="0"/>
+      <bXHeight value="0"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="NONE"/>
+    <fsSelection value="00000000 01000000"/>
+    <usFirstCharIndex value="65535"/>
+    <usLastCharIndex value="65535"/>
+    <sTypoAscender value="800"/>
+    <sTypoDescender value="-200"/>
+    <sTypoLineGap value="200"/>
+    <usWinAscent value="1000"/>
+    <usWinDescent value="200"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="500"/>
+    <sCapHeight value="700"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="0"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="500" lsb="50"/>
+    <mtx name="I" width="0" lsb="0"/>
+    <mtx name="I.narrow" width="0" lsb="0"/>
+    <mtx name="S" width="0" lsb="0"/>
+    <mtx name="S.closed" width="0" lsb="0"/>
+    <mtx name="a" width="0" lsb="0"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+    </cmap_format_4>
+  </cmap>
+
+  <name>
+    <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Width
+    </namerecord>
+    <namerecord nameID="257" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Serif Light Condensed
+    </namerecord>
+    <namerecord nameID="258" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      MutatorMathTest-SerifLightCondensed
+    </namerecord>
+    <namerecord nameID="259" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Regular
+    </namerecord>
+    <namerecord nameID="260" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      serif
+    </namerecord>
+    <namerecord nameID="261" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Serif
+    </namerecord>
+    <namerecord nameID="262" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      weight
+    </namerecord>
+    <namerecord nameID="263" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Light
+    </namerecord>
+    <namerecord nameID="264" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      width
+    </namerecord>
+    <namerecord nameID="265" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Condensed
+    </namerecord>
+    <namerecord nameID="266" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Normal
+    </namerecord>
+    <namerecord nameID="267" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Extended
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      New Font
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      0.000;NONE;NewFont-Regular
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      New Font Regular
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 0.000
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      NewFont-Regular
+    </namerecord>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
+      Width
+    </namerecord>
+    <namerecord nameID="257" platformID="3" platEncID="1" langID="0x409">
+      Serif Light Condensed
+    </namerecord>
+    <namerecord nameID="258" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-SerifLightCondensed
+    </namerecord>
+    <namerecord nameID="259" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="260" platformID="3" platEncID="1" langID="0x409">
+      serif
+    </namerecord>
+    <namerecord nameID="261" platformID="3" platEncID="1" langID="0x409">
+      Serif
+    </namerecord>
+    <namerecord nameID="262" platformID="3" platEncID="1" langID="0x409">
+      weight
+    </namerecord>
+    <namerecord nameID="263" platformID="3" platEncID="1" langID="0x409">
+      Light
+    </namerecord>
+    <namerecord nameID="264" platformID="3" platEncID="1" langID="0x409">
+      width
+    </namerecord>
+    <namerecord nameID="265" platformID="3" platEncID="1" langID="0x409">
+      Condensed
+    </namerecord>
+    <namerecord nameID="266" platformID="3" platEncID="1" langID="0x409">
+      Normal
+    </namerecord>
+    <namerecord nameID="267" platformID="3" platEncID="1" langID="0x409">
+      Extended
+    </namerecord>
+  </name>
+
+  <post>
+    <formatType value="2.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-75"/>
+    <underlineThickness value="50"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+    <psNames>
+      <!-- This file uses unique glyph names based on the information
+           found in the 'post' table. Since these names might not be unique,
+           we have to invent artificial names in case of clashes. In order to
+           be able to retain the original information, we need a name to
+           ps name mapping for those cases where they differ. That's what
+           you see below.
+            -->
+    </psNames>
+    <extraNames>
+      <!-- following are the name that are not taken from the standard Mac glyph order -->
+      <psName name="I.narrow"/>
+      <psName name="S.closed"/>
+    </extraNames>
+  </post>
+
+  <CFF2>
+    <major value="2"/>
+    <minor value="0"/>
+    <CFFFont name="CFF2Font">
+      <FontMatrix value="0.001 0 0 0.001 0 0"/>
+      <FDArray>
+        <FontDict index="0">
+          <Private>
+            <BlueScale value="0.039625"/>
+            <BlueShift value="7"/>
+            <BlueFuzz value="1"/>
+            <LanguageGroup value="0"/>
+            <ExpansionFactor value="0.06"/>
+          </Private>
+        </FontDict>
+      </FDArray>
+      <CharStrings>
+        <CharString name=".notdef">
+          50 -200 rmoveto
+          400 1000 -400 -1000 hlineto
+          50 50 rmoveto
+          900 300 -900 -300 vlineto
+        </CharString>
+        <CharString name="I">
+        </CharString>
+        <CharString name="I.narrow">
+        </CharString>
+        <CharString name="S">
+        </CharString>
+        <CharString name="S.closed">
+        </CharString>
+        <CharString name="a">
+        </CharString>
+      </CharStrings>
+      <VarStore Format="1">
+        <Format value="1"/>
+        <VarRegionList>
+          <!-- RegionAxisCount=1 -->
+          <!-- RegionCount=1 -->
+          <Region index="0">
+            <VarRegionAxis index="0">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
+            </VarRegionAxis>
+          </Region>
+        </VarRegionList>
+        <!-- VarDataCount=1 -->
+        <VarData index="0">
+          <!-- ItemCount=0 -->
+          <NumShorts value="0"/>
+          <!-- VarRegionCount=1 -->
+          <VarRegionIndex index="0" value="0"/>
+        </VarData>
+      </VarStore>
+    </CFFFont>
+
+    <GlobalSubrs>
+      <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+    </GlobalSubrs>
+  </CFF2>
+
+  <HVAR>
+    <Version value="0x00010000"/>
+    <VarStore Format="1">
+      <Format value="1"/>
+      <VarRegionList>
+        <!-- RegionAxisCount=1 -->
+        <!-- RegionCount=1 -->
+        <Region index="0">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+      </VarRegionList>
+      <!-- VarDataCount=1 -->
+      <VarData index="0">
+        <!-- ItemCount=6 -->
+        <NumShorts value="0"/>
+        <!-- VarRegionCount=0 -->
+        <Item index="0" value="[]"/>
+        <Item index="1" value="[]"/>
+        <Item index="2" value="[]"/>
+        <Item index="3" value="[]"/>
+        <Item index="4" value="[]"/>
+        <Item index="5" value="[]"/>
+      </VarData>
+    </VarStore>
+  </HVAR>
+
+  <STAT>
+    <Version value="0x00010001"/>
+    <DesignAxisRecordSize value="8"/>
+    <!-- DesignAxisCount=3 -->
+    <DesignAxisRecord>
+      <Axis index="0">
+        <AxisTag value="SRIF"/>
+        <AxisNameID value="260"/>  <!-- serif -->
+        <AxisOrdering value="0"/>
+      </Axis>
+      <Axis index="1">
+        <AxisTag value="wght"/>
+        <AxisNameID value="262"/>  <!-- weight -->
+        <AxisOrdering value="1"/>
+      </Axis>
+      <Axis index="2">
+        <AxisTag value="wdth"/>
+        <AxisNameID value="264"/>  <!-- width -->
+        <AxisOrdering value="2"/>
+      </Axis>
+    </DesignAxisRecord>
+    <!-- AxisValueCount=5 -->
+    <AxisValueArray>
+      <AxisValue index="0" Format="1">
+        <AxisIndex value="0"/>
+        <Flags value="0"/>
+        <ValueNameID value="261"/>  <!-- Serif -->
+        <Value value="1.0"/>
+      </AxisValue>
+      <AxisValue index="1" Format="2">
+        <AxisIndex value="1"/>
+        <Flags value="0"/>
+        <ValueNameID value="263"/>  <!-- Light -->
+        <NominalValue value="300.0"/>
+        <RangeMinValue value="300.0"/>
+        <RangeMaxValue value="400.0"/>
+      </AxisValue>
+      <AxisValue index="2" Format="2">
+        <AxisIndex value="2"/>
+        <Flags value="0"/>
+        <ValueNameID value="265"/>  <!-- Condensed -->
+        <NominalValue value="50.0"/>
+        <RangeMinValue value="50.0"/>
+        <RangeMaxValue value="75.0"/>
+      </AxisValue>
+      <AxisValue index="3" Format="2">
+        <AxisIndex value="2"/>
+        <Flags value="2"/>  <!-- ElidableAxisValueName -->
+        <ValueNameID value="266"/>  <!-- Normal -->
+        <NominalValue value="100.0"/>
+        <RangeMinValue value="75.0"/>
+        <RangeMaxValue value="125.0"/>
+      </AxisValue>
+      <AxisValue index="4" Format="2">
+        <AxisIndex value="2"/>
+        <Flags value="0"/>
+        <ValueNameID value="267"/>  <!-- Extended -->
+        <NominalValue value="200.0"/>
+        <RangeMinValue value="125.0"/>
+        <RangeMaxValue value="200.0"/>
+      </AxisValue>
+    </AxisValueArray>
+    <ElidedFallbackNameID value="259"/>  <!-- Regular -->
+  </STAT>
+
+  <avar>
+    <segment axis="wdth">
+      <mapping from="-1.0" to="-1.0"/>
+      <mapping from="0.0" to="0.0"/>
+      <mapping from="0.3333" to="0.5"/>
+      <mapping from="1.0" to="1.0"/>
+    </segment>
+  </avar>
+
+  <fvar>
+
+    <!-- Width -->
+    <Axis>
+      <AxisTag>wdth</AxisTag>
+      <Flags>0x0</Flags>
+      <MinValue>50.0</MinValue>
+      <DefaultValue>50.0</DefaultValue>
+      <MaxValue>200.0</MaxValue>
+      <AxisNameID>256</AxisNameID>
+    </Axis>
+
+    <!-- Serif Light Condensed -->
+    <!-- PostScript: MutatorMathTest-SerifLightCondensed -->
+    <NamedInstance flags="0x0" postscriptNameID="258" subfamilyNameID="257">
+      <coord axis="wdth" value="50.0"/>
+    </NamedInstance>
+  </fvar>
+
+</ttFont>

--- a/tests/data/DSv5/MutatorSerifVariable_Width-CFF2.ttx
+++ b/tests/data/DSv5/MutatorSerifVariable_Width-CFF2.ttx
@@ -21,7 +21,7 @@
     <unitsPerEm value="1000"/>
     <created value="Fri Feb 17 17:17:17 2017"/>
     <modified value="Sun Feb 18 18:18:18 2018"/>
-    <xMin value="50"/>
+    <xMin value="-70"/>
     <yMin value="-200"/>
     <xMax value="450"/>
     <yMax value="800"/>
@@ -38,8 +38,8 @@
     <descent value="-200"/>
     <lineGap value="0"/>
     <advanceWidthMax value="500"/>
-    <minLeftSideBearing value="50"/>
-    <minRightSideBearing value="50"/>
+    <minLeftSideBearing value="-70"/>
+    <minRightSideBearing value="-80"/>
     <xMaxExtent value="450"/>
     <caretSlopeRise value="1"/>
     <caretSlopeRun value="0"/>
@@ -112,11 +112,11 @@
 
   <hmtx>
     <mtx name=".notdef" width="500" lsb="50"/>
-    <mtx name="I" width="0" lsb="0"/>
-    <mtx name="I.narrow" width="0" lsb="0"/>
-    <mtx name="S" width="0" lsb="0"/>
-    <mtx name="S.closed" width="0" lsb="0"/>
-    <mtx name="a" width="0" lsb="0"/>
+    <mtx name="I" width="0" lsb="-70"/>
+    <mtx name="I.narrow" width="0" lsb="-70"/>
+    <mtx name="S" width="0" lsb="-70"/>
+    <mtx name="S.closed" width="0" lsb="-70"/>
+    <mtx name="a" width="0" lsb="-70"/>
   </hmtx>
 
   <cmap>
@@ -270,14 +270,44 @@
           900 300 -900 -300 vlineto
         </CharString>
         <CharString name="I">
+          -70 -10 1 blend
+          -20 rmoveto
+          10 10 -10 hlineto
+          140 20 1 blend
+          30 rmoveto
+          10 10 -10 hlineto
         </CharString>
         <CharString name="I.narrow">
+          -70 -10 1 blend
+          -20 rmoveto
+          10 10 -10 hlineto
+          140 20 1 blend
+          30 rmoveto
+          10 10 -10 hlineto
         </CharString>
         <CharString name="S">
+          -70 -10 1 blend
+          -20 rmoveto
+          10 10 -10 hlineto
+          140 20 1 blend
+          30 rmoveto
+          10 10 -10 hlineto
         </CharString>
         <CharString name="S.closed">
+          -70 -10 1 blend
+          -20 rmoveto
+          10 10 -10 hlineto
+          140 20 1 blend
+          30 rmoveto
+          10 10 -10 hlineto
         </CharString>
         <CharString name="a">
+          -70 -10 1 blend
+          -20 rmoveto
+          10 10 -10 hlineto
+          140 20 1 blend
+          30 rmoveto
+          10 10 -10 hlineto
         </CharString>
       </CharStrings>
       <VarStore Format="1">

--- a/tests/data/DSv5/MutatorSerifVariable_Width-TTF.ttx
+++ b/tests/data/DSv5/MutatorSerifVariable_Width-TTF.ttx
@@ -21,7 +21,7 @@
     <unitsPerEm value="1000"/>
     <created value="Fri Feb 17 17:17:17 2017"/>
     <modified value="Sun Feb 18 18:18:18 2018"/>
-    <xMin value="50"/>
+    <xMin value="-70"/>
     <yMin value="-200"/>
     <xMax value="450"/>
     <yMax value="800"/>
@@ -38,8 +38,8 @@
     <descent value="-200"/>
     <lineGap value="0"/>
     <advanceWidthMax value="500"/>
-    <minLeftSideBearing value="50"/>
-    <minRightSideBearing value="50"/>
+    <minLeftSideBearing value="-70"/>
+    <minRightSideBearing value="-80"/>
     <xMaxExtent value="450"/>
     <caretSlopeRise value="1"/>
     <caretSlopeRun value="0"/>
@@ -126,11 +126,11 @@
 
   <hmtx>
     <mtx name=".notdef" width="500" lsb="50"/>
-    <mtx name="I" width="0" lsb="0"/>
-    <mtx name="I.narrow" width="0" lsb="0"/>
-    <mtx name="S" width="0" lsb="0"/>
-    <mtx name="S.closed" width="0" lsb="0"/>
-    <mtx name="a" width="0" lsb="0"/>
+    <mtx name="I" width="0" lsb="-70"/>
+    <mtx name="I.narrow" width="0" lsb="-70"/>
+    <mtx name="S" width="0" lsb="-70"/>
+    <mtx name="S.closed" width="0" lsb="-70"/>
+    <mtx name="a" width="0" lsb="-70"/>
   </hmtx>
 
   <cmap>
@@ -166,15 +166,85 @@
       <instructions/>
     </TTGlyph>
 
-    <TTGlyph name="I"/><!-- contains no outline data -->
+    <TTGlyph name="I" xMin="-70" yMin="-20" xMax="80" yMax="30">
+      <contour>
+        <pt x="-70" y="-20" on="1"/>
+        <pt x="-70" y="-10" on="1"/>
+        <pt x="-60" y="-10" on="1"/>
+        <pt x="-60" y="-20" on="1"/>
+      </contour>
+      <contour>
+        <pt x="70" y="20" on="1"/>
+        <pt x="70" y="30" on="1"/>
+        <pt x="80" y="30" on="1"/>
+        <pt x="80" y="20" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
-    <TTGlyph name="I.narrow"/><!-- contains no outline data -->
+    <TTGlyph name="I.narrow" xMin="-70" yMin="-20" xMax="80" yMax="30">
+      <contour>
+        <pt x="-70" y="-20" on="1"/>
+        <pt x="-70" y="-10" on="1"/>
+        <pt x="-60" y="-10" on="1"/>
+        <pt x="-60" y="-20" on="1"/>
+      </contour>
+      <contour>
+        <pt x="70" y="20" on="1"/>
+        <pt x="70" y="30" on="1"/>
+        <pt x="80" y="30" on="1"/>
+        <pt x="80" y="20" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
-    <TTGlyph name="S"/><!-- contains no outline data -->
+    <TTGlyph name="S" xMin="-70" yMin="-20" xMax="80" yMax="30">
+      <contour>
+        <pt x="-70" y="-20" on="1"/>
+        <pt x="-70" y="-10" on="1"/>
+        <pt x="-60" y="-10" on="1"/>
+        <pt x="-60" y="-20" on="1"/>
+      </contour>
+      <contour>
+        <pt x="70" y="20" on="1"/>
+        <pt x="70" y="30" on="1"/>
+        <pt x="80" y="30" on="1"/>
+        <pt x="80" y="20" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
-    <TTGlyph name="S.closed"/><!-- contains no outline data -->
+    <TTGlyph name="S.closed" xMin="-70" yMin="-20" xMax="80" yMax="30">
+      <contour>
+        <pt x="-70" y="-20" on="1"/>
+        <pt x="-70" y="-10" on="1"/>
+        <pt x="-60" y="-10" on="1"/>
+        <pt x="-60" y="-20" on="1"/>
+      </contour>
+      <contour>
+        <pt x="70" y="20" on="1"/>
+        <pt x="70" y="30" on="1"/>
+        <pt x="80" y="30" on="1"/>
+        <pt x="80" y="20" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
-    <TTGlyph name="a"/><!-- contains no outline data -->
+    <TTGlyph name="a" xMin="-70" yMin="-20" xMax="80" yMax="30">
+      <contour>
+        <pt x="-70" y="-20" on="1"/>
+        <pt x="-70" y="-10" on="1"/>
+        <pt x="-60" y="-10" on="1"/>
+        <pt x="-60" y="-20" on="1"/>
+      </contour>
+      <contour>
+        <pt x="70" y="20" on="1"/>
+        <pt x="70" y="30" on="1"/>
+        <pt x="80" y="30" on="1"/>
+        <pt x="80" y="20" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
 
   </glyf>
 
@@ -423,6 +493,41 @@
   <gvar>
     <version value="1"/>
     <reserved value="0"/>
+    <glyphVariations glyph="I">
+      <tuple>
+        <coord axis="wdth" value="1.0"/>
+        <delta pt="0" x="-10" y="0"/>
+        <delta pt="4" x="10" y="0"/>
+      </tuple>
+    </glyphVariations>
+    <glyphVariations glyph="I.narrow">
+      <tuple>
+        <coord axis="wdth" value="1.0"/>
+        <delta pt="0" x="-10" y="0"/>
+        <delta pt="4" x="10" y="0"/>
+      </tuple>
+    </glyphVariations>
+    <glyphVariations glyph="S">
+      <tuple>
+        <coord axis="wdth" value="1.0"/>
+        <delta pt="0" x="-10" y="0"/>
+        <delta pt="4" x="10" y="0"/>
+      </tuple>
+    </glyphVariations>
+    <glyphVariations glyph="S.closed">
+      <tuple>
+        <coord axis="wdth" value="1.0"/>
+        <delta pt="0" x="-10" y="0"/>
+        <delta pt="4" x="10" y="0"/>
+      </tuple>
+    </glyphVariations>
+    <glyphVariations glyph="a">
+      <tuple>
+        <coord axis="wdth" value="1.0"/>
+        <delta pt="0" x="-10" y="0"/>
+        <delta pt="4" x="10" y="0"/>
+      </tuple>
+    </glyphVariations>
   </gvar>
 
 </ttFont>

--- a/tests/data/DSv5/MutatorSerifVariable_Width-TTF.ttx
+++ b/tests/data/DSv5/MutatorSerifVariable_Width-TTF.ttx
@@ -1,0 +1,428 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.33">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="I"/>
+    <GlyphID id="2" name="I.narrow"/>
+    <GlyphID id="3" name="S"/>
+    <GlyphID id="4" name="S.closed"/>
+    <GlyphID id="5" name="a"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="0.0"/>
+    <checkSumAdjustment value="0x12345678"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Fri Feb 17 17:17:17 2017"/>
+    <modified value="Sun Feb 18 18:18:18 2018"/>
+    <xMin value="50"/>
+    <yMin value="-200"/>
+    <xMax value="450"/>
+    <yMax value="800"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="6"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1000"/>
+    <descent value="-200"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="500"/>
+    <minLeftSideBearing value="50"/>
+    <minRightSideBearing value="50"/>
+    <xMaxExtent value="450"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="2"/>
+  </hhea>
+
+  <maxp>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="0x10000"/>
+    <numGlyphs value="6"/>
+    <maxPoints value="8"/>
+    <maxContours value="2"/>
+    <maxCompositePoints value="0"/>
+    <maxCompositeContours value="0"/>
+    <maxZones value="1"/>
+    <maxTwilightPoints value="0"/>
+    <maxStorage value="0"/>
+    <maxFunctionDefs value="0"/>
+    <maxInstructionDefs value="0"/>
+    <maxStackElements value="0"/>
+    <maxSizeOfInstructions value="0"/>
+    <maxComponentElements value="0"/>
+    <maxComponentDepth value="0"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="500"/>
+    <usWeightClass value="400"/>
+    <usWidthClass value="1"/>
+    <fsType value="00000000 00000100"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="300"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="0"/>
+      <bSerifStyle value="0"/>
+      <bWeight value="0"/>
+      <bProportion value="0"/>
+      <bContrast value="0"/>
+      <bStrokeVariation value="0"/>
+      <bArmStyle value="0"/>
+      <bLetterForm value="0"/>
+      <bMidline value="0"/>
+      <bXHeight value="0"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="NONE"/>
+    <fsSelection value="00000000 01000000"/>
+    <usFirstCharIndex value="65535"/>
+    <usLastCharIndex value="65535"/>
+    <sTypoAscender value="800"/>
+    <sTypoDescender value="-200"/>
+    <sTypoLineGap value="200"/>
+    <usWinAscent value="1000"/>
+    <usWinDescent value="200"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="500"/>
+    <sCapHeight value="700"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="0"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="500" lsb="50"/>
+    <mtx name="I" width="0" lsb="0"/>
+    <mtx name="I.narrow" width="0" lsb="0"/>
+    <mtx name="S" width="0" lsb="0"/>
+    <mtx name="S.closed" width="0" lsb="0"/>
+    <mtx name="a" width="0" lsb="0"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+    </cmap_format_4>
+  </cmap>
+
+  <loca>
+    <!-- The 'loca' table will be calculated by the compiler -->
+  </loca>
+
+  <glyf>
+
+    <!-- The xMin, yMin, xMax and yMax values
+         will be recalculated by the compiler. -->
+
+    <TTGlyph name=".notdef" xMin="50" yMin="-200" xMax="450" yMax="800">
+      <contour>
+        <pt x="50" y="-200" on="1"/>
+        <pt x="50" y="800" on="1"/>
+        <pt x="450" y="800" on="1"/>
+        <pt x="450" y="-200" on="1"/>
+      </contour>
+      <contour>
+        <pt x="100" y="-150" on="1"/>
+        <pt x="400" y="-150" on="1"/>
+        <pt x="400" y="750" on="1"/>
+        <pt x="100" y="750" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="I"/><!-- contains no outline data -->
+
+    <TTGlyph name="I.narrow"/><!-- contains no outline data -->
+
+    <TTGlyph name="S"/><!-- contains no outline data -->
+
+    <TTGlyph name="S.closed"/><!-- contains no outline data -->
+
+    <TTGlyph name="a"/><!-- contains no outline data -->
+
+  </glyf>
+
+  <name>
+    <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Width
+    </namerecord>
+    <namerecord nameID="257" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Serif Light Condensed
+    </namerecord>
+    <namerecord nameID="258" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      MutatorMathTest-SerifLightCondensed
+    </namerecord>
+    <namerecord nameID="259" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Regular
+    </namerecord>
+    <namerecord nameID="260" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      serif
+    </namerecord>
+    <namerecord nameID="261" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Serif
+    </namerecord>
+    <namerecord nameID="262" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      weight
+    </namerecord>
+    <namerecord nameID="263" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Light
+    </namerecord>
+    <namerecord nameID="264" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      width
+    </namerecord>
+    <namerecord nameID="265" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Condensed
+    </namerecord>
+    <namerecord nameID="266" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Normal
+    </namerecord>
+    <namerecord nameID="267" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Extended
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      New Font
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      0.000;NONE;NewFont-Regular
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      New Font Regular
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 0.000
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      NewFont-Regular
+    </namerecord>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
+      Width
+    </namerecord>
+    <namerecord nameID="257" platformID="3" platEncID="1" langID="0x409">
+      Serif Light Condensed
+    </namerecord>
+    <namerecord nameID="258" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-SerifLightCondensed
+    </namerecord>
+    <namerecord nameID="259" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="260" platformID="3" platEncID="1" langID="0x409">
+      serif
+    </namerecord>
+    <namerecord nameID="261" platformID="3" platEncID="1" langID="0x409">
+      Serif
+    </namerecord>
+    <namerecord nameID="262" platformID="3" platEncID="1" langID="0x409">
+      weight
+    </namerecord>
+    <namerecord nameID="263" platformID="3" platEncID="1" langID="0x409">
+      Light
+    </namerecord>
+    <namerecord nameID="264" platformID="3" platEncID="1" langID="0x409">
+      width
+    </namerecord>
+    <namerecord nameID="265" platformID="3" platEncID="1" langID="0x409">
+      Condensed
+    </namerecord>
+    <namerecord nameID="266" platformID="3" platEncID="1" langID="0x409">
+      Normal
+    </namerecord>
+    <namerecord nameID="267" platformID="3" platEncID="1" langID="0x409">
+      Extended
+    </namerecord>
+  </name>
+
+  <post>
+    <formatType value="2.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-75"/>
+    <underlineThickness value="50"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+    <psNames>
+      <!-- This file uses unique glyph names based on the information
+           found in the 'post' table. Since these names might not be unique,
+           we have to invent artificial names in case of clashes. In order to
+           be able to retain the original information, we need a name to
+           ps name mapping for those cases where they differ. That's what
+           you see below.
+            -->
+    </psNames>
+    <extraNames>
+      <!-- following are the name that are not taken from the standard Mac glyph order -->
+      <psName name="I.narrow"/>
+      <psName name="S.closed"/>
+    </extraNames>
+  </post>
+
+  <HVAR>
+    <Version value="0x00010000"/>
+    <VarStore Format="1">
+      <Format value="1"/>
+      <VarRegionList>
+        <!-- RegionAxisCount=1 -->
+        <!-- RegionCount=1 -->
+        <Region index="0">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+      </VarRegionList>
+      <!-- VarDataCount=1 -->
+      <VarData index="0">
+        <!-- ItemCount=6 -->
+        <NumShorts value="0"/>
+        <!-- VarRegionCount=0 -->
+        <Item index="0" value="[]"/>
+        <Item index="1" value="[]"/>
+        <Item index="2" value="[]"/>
+        <Item index="3" value="[]"/>
+        <Item index="4" value="[]"/>
+        <Item index="5" value="[]"/>
+      </VarData>
+    </VarStore>
+  </HVAR>
+
+  <STAT>
+    <Version value="0x00010001"/>
+    <DesignAxisRecordSize value="8"/>
+    <!-- DesignAxisCount=3 -->
+    <DesignAxisRecord>
+      <Axis index="0">
+        <AxisTag value="SRIF"/>
+        <AxisNameID value="260"/>  <!-- serif -->
+        <AxisOrdering value="0"/>
+      </Axis>
+      <Axis index="1">
+        <AxisTag value="wght"/>
+        <AxisNameID value="262"/>  <!-- weight -->
+        <AxisOrdering value="1"/>
+      </Axis>
+      <Axis index="2">
+        <AxisTag value="wdth"/>
+        <AxisNameID value="264"/>  <!-- width -->
+        <AxisOrdering value="2"/>
+      </Axis>
+    </DesignAxisRecord>
+    <!-- AxisValueCount=5 -->
+    <AxisValueArray>
+      <AxisValue index="0" Format="1">
+        <AxisIndex value="0"/>
+        <Flags value="0"/>
+        <ValueNameID value="261"/>  <!-- Serif -->
+        <Value value="1.0"/>
+      </AxisValue>
+      <AxisValue index="1" Format="2">
+        <AxisIndex value="1"/>
+        <Flags value="0"/>
+        <ValueNameID value="263"/>  <!-- Light -->
+        <NominalValue value="300.0"/>
+        <RangeMinValue value="300.0"/>
+        <RangeMaxValue value="400.0"/>
+      </AxisValue>
+      <AxisValue index="2" Format="2">
+        <AxisIndex value="2"/>
+        <Flags value="0"/>
+        <ValueNameID value="265"/>  <!-- Condensed -->
+        <NominalValue value="50.0"/>
+        <RangeMinValue value="50.0"/>
+        <RangeMaxValue value="75.0"/>
+      </AxisValue>
+      <AxisValue index="3" Format="2">
+        <AxisIndex value="2"/>
+        <Flags value="2"/>  <!-- ElidableAxisValueName -->
+        <ValueNameID value="266"/>  <!-- Normal -->
+        <NominalValue value="100.0"/>
+        <RangeMinValue value="75.0"/>
+        <RangeMaxValue value="125.0"/>
+      </AxisValue>
+      <AxisValue index="4" Format="2">
+        <AxisIndex value="2"/>
+        <Flags value="0"/>
+        <ValueNameID value="267"/>  <!-- Extended -->
+        <NominalValue value="200.0"/>
+        <RangeMinValue value="125.0"/>
+        <RangeMaxValue value="200.0"/>
+      </AxisValue>
+    </AxisValueArray>
+    <ElidedFallbackNameID value="259"/>  <!-- Regular -->
+  </STAT>
+
+  <avar>
+    <segment axis="wdth">
+      <mapping from="-1.0" to="-1.0"/>
+      <mapping from="0.0" to="0.0"/>
+      <mapping from="0.3333" to="0.5"/>
+      <mapping from="1.0" to="1.0"/>
+    </segment>
+  </avar>
+
+  <fvar>
+
+    <!-- Width -->
+    <Axis>
+      <AxisTag>wdth</AxisTag>
+      <Flags>0x0</Flags>
+      <MinValue>50.0</MinValue>
+      <DefaultValue>50.0</DefaultValue>
+      <MaxValue>200.0</MaxValue>
+      <AxisNameID>256</AxisNameID>
+    </Axis>
+
+    <!-- Serif Light Condensed -->
+    <!-- PostScript: MutatorMathTest-SerifLightCondensed -->
+    <NamedInstance flags="0x0" postscriptNameID="258" subfamilyNameID="257">
+      <coord axis="wdth" value="50.0"/>
+    </NamedInstance>
+  </fvar>
+
+  <gvar>
+    <version value="1"/>
+    <reserved value="0"/>
+  </gvar>
+
+</ttFont>

--- a/tests/data/DSv5/test_v5_MutatorSans_and_Serif.designspace
+++ b/tests/data/DSv5/test_v5_MutatorSans_and_Serif.designspace
@@ -1,0 +1,206 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<designspace format="5.0">
+  <axes elidedfallbackname="Regular">
+    <axis tag="SRIF" name="serif" values="0 1" default="0">
+      <labels>
+        <label uservalue="0" name="Sans"/>
+        <label uservalue="1" name="Serif"/>
+      </labels>
+    </axis>
+    <axis tag="wght" name="weight" minimum="300" maximum="700" default="300">
+      <map input="300" output="0"/>
+      <map input="500" output="500"/>
+      <map input="700" output="1000"/>
+      <labels>
+        <label uservalue="300" userminimum="300" usermaximum="400" name="Light"/>
+        <label uservalue="500" userminimum="400" usermaximum="600" name="Medium"/>
+        <label uservalue="700" userminimum="600" usermaximum="700" name="Bold"/>
+      </labels>
+    </axis>
+    <axis tag="wdth" name="width" minimum="50" maximum="200" default="50">
+      <map input="50" output="0"/>
+      <map input="100" output="500"/>
+      <map input="200" output="1000"/>
+      <labels>
+        <label uservalue="50" userminimum="50" usermaximum="75" name="Condensed"/>
+        <label uservalue="100" userminimum="75" usermaximum="125" name="Normal" elidable="true"/>
+        <label uservalue="200" userminimum="125" usermaximum="200" name="Extended"/>
+      </labels>
+    </axis>
+  </axes>
+  <labels>
+    <label name="S1">
+      <location>
+        <dimension name="width" uservalue="158.9044"/>
+        <dimension name="weight" uservalue="610.2436"/>
+      </location>
+    </label>
+    <label name="S2">
+      <location>
+        <dimension name="width" uservalue="159.1956"/>
+        <dimension name="weight" uservalue="642.2196"/>
+      </location>
+    </label>
+  </labels>
+  <rules>
+    <rule name="fold_I_serifs">
+      <conditionset>
+        <condition name="width" minimum="0" maximum="328"/>
+        <condition name="serif" minimum="0" maximum="0"/>
+      </conditionset>
+      <sub name="I" with="I.narrow"/>
+    </rule>
+    <rule name="fold_S_terminals">
+      <conditionset>
+        <condition name="width" minimum="0" maximum="1000"/>
+        <condition name="weight" minimum="0" maximum="500"/>
+        <condition name="serif" minimum="0" maximum="0.5"/>
+      </conditionset>
+      <sub name="S" with="S.closed"/>
+    </rule>
+  </rules>
+  <sources>
+    <source filename="MutatorSansLightCondensed.ufo" name="master.MutatorMathTest.LightCondensed.0" familyname="MutatorMathTest" stylename="LightCondensed">
+      <location>
+        <dimension name="width" xvalue="0"/>
+        <dimension name="weight" xvalue="0"/>
+      </location>
+    </source>
+    <source filename="MutatorSansBoldCondensed.ufo" name="master.MutatorMathTest.BoldCondensed.1" familyname="MutatorMathTest" stylename="BoldCondensed">
+      <location>
+        <dimension name="width" xvalue="0"/>
+        <dimension name="weight" xvalue="1000"/>
+      </location>
+    </source>
+    <source filename="MutatorSansLightWide.ufo" name="master.MutatorMathTest.LightWide.2" familyname="MutatorMathTest" stylename="LightWide">
+      <location>
+        <dimension name="width" xvalue="1000"/>
+        <dimension name="weight" xvalue="0"/>
+      </location>
+    </source>
+    <source filename="MutatorSansBoldWide.ufo" name="master.MutatorMathTest.BoldWide.3" familyname="MutatorMathTest" stylename="BoldWide">
+      <location>
+        <dimension name="width" xvalue="1000"/>
+        <dimension name="weight" xvalue="1000"/>
+      </location>
+    </source>
+    <source filename="MutatorSansLightCondensed.ufo" name="support.crossbar" layer="support.crossbar">
+      <location>
+        <dimension name="width" xvalue="0"/>
+        <dimension name="weight" xvalue="700"/>
+      </location>
+    </source>
+    <source filename="MutatorSansLightCondensed.ufo" name="support.S.wide" layer="support.S.wide">
+      <location>
+        <dimension name="width" xvalue="1000"/>
+        <dimension name="weight" xvalue="700"/>
+      </location>
+    </source>
+    <source filename="MutatorSansLightCondensed.ufo" name="support.S.middle" layer="support.S.middle">
+      <location>
+        <dimension name="width" xvalue="569.078000"/>
+        <dimension name="weight" xvalue="700"/>
+      </location>
+    </source>
+    <source filename="MutatorSerifLightCondensed.ufo" familyname="MutatorMathTest" stylename="SerifLightCondensed">
+      <location>
+        <dimension name="width" xvalue="0"/>
+        <dimension name="weight" xvalue="0"/>
+        <dimension name="serif" xvalue="1"/>
+      </location>
+    </source>
+    <source filename="MutatorSerifLightWide.ufo" familyname="MutatorMathTest" stylename="SerifLightWide">
+      <location>
+        <dimension name="width" xvalue="1000"/>
+        <dimension name="weight" xvalue="0"/>
+        <dimension name="serif" xvalue="1"/>
+      </location>
+    </source>
+  </sources>
+  <variable-fonts>
+    <variable-font name="MutatorSansVariable_Weight_Width">
+      <axis-subsets>
+        <axis-subset name="weight"/>
+        <axis-subset name="width"/>
+      </axis-subsets>
+    </variable-font>
+    <variable-font name="MutatorSansVariable_Weight">
+      <axis-subsets>
+        <axis-subset name="weight"/>
+      </axis-subsets>
+    </variable-font>
+    <variable-font name="MutatorSansVariable_Width">
+      <axis-subsets>
+        <axis-subset name="width"/>
+      </axis-subsets>
+    </variable-font>
+    <variable-font name="MutatorSerifVariable_Width">
+      <axis-subsets>
+        <axis-subset name="serif" uservalue="1"/>
+        <axis-subset name="width"/>
+      </axis-subsets>
+    </variable-font>
+  </variable-fonts>
+  <instances>
+    <instance>
+      <location>
+        <dimension name="width" xvalue="0"/>
+        <dimension name="weight" xvalue="0"/>
+      </location>
+    </instance>
+    <instance>
+      <location>
+        <dimension name="width" xvalue="0"/>
+        <dimension name="weight" xvalue="1000"/>
+      </location>
+    </instance>
+    <instance>
+      <location>
+        <dimension name="width" xvalue="1000"/>
+        <dimension name="weight" xvalue="0"/>
+      </location>
+    </instance>
+    <instance>
+      <location>
+        <dimension name="width" xvalue="1000"/>
+        <dimension name="weight" xvalue="1000"/>
+      </location>
+    </instance>
+    <instance>
+      <location>
+        <dimension name="width" xvalue="327"/>
+        <dimension name="weight" xvalue="500"/>
+      </location>
+    </instance>
+    <instance>
+      <location>
+        <dimension name="width" xvalue="327"/>
+        <dimension name="weight" xvalue="500"/>
+      </location>
+    </instance>
+    <instance>
+      <location>
+        <dimension name="width" xvalue="569.078"/>
+        <dimension name="weight" xvalue="1000"/>
+      </location>
+    </instance>
+    <instance>
+      <location>
+        <dimension name="width" xvalue="1000"/>
+        <dimension name="weight" xvalue="500"/>
+      </location>
+    </instance>
+    <instance>
+      <location>
+        <dimension name="width" xvalue="0"/>
+        <dimension name="serif" xvalue="0"/>
+      </location>
+    </instance>
+    <instance>
+      <location>
+        <dimension name="width" xvalue="0"/>
+        <dimension name="serif" xvalue="1"/>
+      </location>
+    </instance>
+  </instances>
+</designspace>

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -11,7 +11,9 @@ from ufo2ft import (
     compileOTF,
     compileTTF,
     compileVariableCFF2,
+    compileVariableCFF2s,
     compileVariableTTF,
+    compileVariableTTFs,
 )
 from ufo2ft.constants import KEEP_GLYPH_NAMES
 from ufo2ft.filters import TransformationsFilter
@@ -327,6 +329,80 @@ class IntegrationTest:
             assert pen1.bounds[1] + 10 == pen2.bounds[1]
             assert pen1.bounds[2] == pen2.bounds[2]
             assert pen1.bounds[3] + 10 == pen2.bounds[3]
+
+    def test_compileVariableTTFs(self, designspace_v5):
+        fonts = compileVariableTTFs(designspace_v5)
+
+        # NOTE: Test dumps were generated like this:
+        # for k, font in fonts.items():
+        #     font.recalcTimestamp = False
+        #     font["head"].created, font["head"].modified = 3570196637, 3601822698
+        #     font["head"].checkSumAdjustment = 0x12345678
+        #     font.saveXML(f"tests/data/DSv5/{k}-TTF.ttx")
+
+        assert set(fonts.keys()) == {
+            "MutatorSansVariable_Weight_Width",
+            "MutatorSansVariable_Weight",
+            "MutatorSansVariable_Width",
+            "MutatorSerifVariable_Width",
+        }
+        # The STAT table is set to [SRIF=0, wght=[300, 700], wdth=[50, 200]] + S1 + S2
+        expectTTX(
+            fonts["MutatorSansVariable_Weight_Width"],
+            "DSv5/MutatorSansVariable_Weight_Width-TTF.ttx",
+        )
+        # The STAT table is set to [SRIF=0, wght=[300, 700], wdth=50]
+        expectTTX(
+            fonts["MutatorSansVariable_Weight"],
+            "DSv5/MutatorSansVariable_Weight-TTF.ttx",
+        )
+        # The STAT table is set to [SRIF=0, wght=300, wdth=[50, 200]]
+        expectTTX(
+            fonts["MutatorSansVariable_Width"],
+            "DSv5/MutatorSansVariable_Width-TTF.ttx",
+        )
+        # The STAT table is set to [SRIF=1, wght=300, wdth=[50, 200]]
+        expectTTX(
+            fonts["MutatorSerifVariable_Width"],
+            "DSv5/MutatorSerifVariable_Width-TTF.ttx",
+        )
+
+    def test_compileVariableCFF2s(self, designspace_v5):
+        fonts = compileVariableCFF2s(designspace_v5)
+
+        # NOTE: Test dumps were generated like this:
+        # for k, font in fonts.items():
+        #     font.recalcTimestamp = False
+        #     font["head"].created, font["head"].modified = 3570196637, 3601822698
+        #     font["head"].checkSumAdjustment = 0x12345678
+        #     font.saveXML(f"tests/data/DSv5/{k}-CFF2.ttx")
+
+        assert set(fonts.keys()) == {
+            "MutatorSansVariable_Weight_Width",
+            "MutatorSansVariable_Weight",
+            "MutatorSansVariable_Width",
+            "MutatorSerifVariable_Width",
+        }
+        # The STAT table is set to [SRIF=0, wght=[300, 700], wdth=[50, 200]] + S1 + S2
+        expectTTX(
+            fonts["MutatorSansVariable_Weight_Width"],
+            "DSv5/MutatorSansVariable_Weight_Width-CFF2.ttx",
+        )
+        # The STAT table is set to [SRIF=0, wght=[300, 700], wdth=50]
+        expectTTX(
+            fonts["MutatorSansVariable_Weight"],
+            "DSv5/MutatorSansVariable_Weight-CFF2.ttx",
+        )
+        # The STAT table is set to [SRIF=0, wght=300, wdth=[50, 200]]
+        expectTTX(
+            fonts["MutatorSansVariable_Width"],
+            "DSv5/MutatorSansVariable_Width-CFF2.ttx",
+        )
+        # The STAT table is set to [SRIF=1, wght=300, wdth=[50, 200]]
+        expectTTX(
+            fonts["MutatorSerifVariable_Width"],
+            "DSv5/MutatorSerifVariable_Width-CFF2.ttx",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR implements building a DesignSpace version 5 using fontmake / ufo2ft. The main new feature is that a single input designspace can build several variable fonts.

This PR implements logic in ufo2ft to choose which of the source UFOs need to be compiled, based on which variable fonts the user is requesting fontmake to build. Only the needed source fonts are built, then passed over to varLib in order to merge all the requested variable fonts.

This PR needs: https://github.com/fonttools/fonttools/pull/2436

The commit names are useless and I'll squash everything later, sorry about that.

@anthrotype 