### PR TITLE
filters/featureWriters: use '...' as placeholder for loading from UFO lib

### DIFF
--- a/Lib/ufo2ft/featureCompiler.py
+++ b/Lib/ufo2ft/featureCompiler.py
@@ -193,6 +193,8 @@ class FeatureCompiler(BaseFeatureCompiler):
             )
 
     def _load_custom_feature_writers(self, featureWriters=None):
+        # type: (Font, Optional[List[Union[FeatureWriter, EllipsisType]]]) -> List[FeatureWriter]
+
         # by default, load the feature writers from the lib or the default ones;
         # ellipsis is used as a placeholder so one can optionally insert additional
         # featureWriters=[w1, ..., w2] either before or after these, or override

--- a/Lib/ufo2ft/featureCompiler.py
+++ b/Lib/ufo2ft/featureCompiler.py
@@ -193,7 +193,10 @@ class FeatureCompiler(BaseFeatureCompiler):
             )
 
     def _load_custom_feature_writers(self, featureWriters=None):
-        # type: (Font, Optional[List[Union[FeatureWriter, EllipsisType]]]) -> List[FeatureWriter]
+        # Args:
+        #   ufo: Font
+        #   filters: Optional[List[Union[FeatureWriter, EllipsisType]]])
+        # Returns: List[FeatureWriter]
 
         # by default, load the feature writers from the lib or the default ones;
         # ellipsis is used as a placeholder so one can optionally insert additional

--- a/Lib/ufo2ft/featureCompiler.py
+++ b/Lib/ufo2ft/featureCompiler.py
@@ -17,6 +17,7 @@ from ufo2ft.featureWriters import (
     KernFeatureWriter,
     MarkFeatureWriter,
     ast,
+    isValidFeatureWriter,
     loadFeatureWriters,
 )
 
@@ -165,10 +166,17 @@ class FeatureCompiler(BaseFeatureCompiler):
               under the key "com.github.googlei18n.ufo2ft.featureWriters"
               (see loadFeatureWriters).
             - if that is not found, the default list of writers will be used:
-              [KernFeatureWriter, MarkFeatureWriter]. This generates "kern"
-              (or "dist" for Indic scripts), "mark" and "mkmk" features.
+              (see FeatureCompiler.defaultFeatureWriters, and the individual
+              feature writer classes for the list of features generated).
             If the featureWriters list is empty, no automatic feature is
             generated and only pre-existing features are compiled.
+            The ``featureWriters`` parameter overrides both the writers from
+            the UFO lib and the default writers list. To extend instead of
+            replace the latter, the list can contain a special value ``...``
+            (i.e. the ``ellipsis`` singleton, not the str literal '...')
+            which gets replaced by either the UFO.lib writers or the default
+            ones; thus one can insert additional writers either before or after
+            these.
         """
         BaseFeatureCompiler.__init__(self, ufo, ttFont, glyphSet)
 
@@ -184,10 +192,36 @@ class FeatureCompiler(BaseFeatureCompiler):
                 stacklevel=2,
             )
 
+    def _load_custom_feature_writers(self, featureWriters=None):
+        # by default, load the feature writers from the lib or the default ones;
+        # ellipsis is used as a placeholder so one can optionally insert additional
+        # featureWriters=[w1, ..., w2] either before or after these, or override
+        # them by omitting the ellipsis.
+        if featureWriters is None:
+            featureWriters = [...]
+        result = []
+        seen_ellipsis = False
+        for writer in featureWriters:
+            if writer is ...:
+                if seen_ellipsis:
+                    raise ValueError("ellipsis not allowed more than once")
+                writers = loadFeatureWriters(self.ufo)
+                if writers is not None:
+                    result.extend(writers)
+                else:
+                    result.extend(self.defaultFeatureWriters)
+                seen_ellipsis = True
+            else:
+                klass = writer if isclass(writer) else type(writer)
+                if not isValidFeatureWriter(klass):
+                    raise TypeError(f"Invalid feature writer: {writer!r}")
+                result.append(writer)
+        return result
+
     def initFeatureWriters(self, featureWriters=None):
         """Initialize feature writer classes as specified in the UFO lib.
-        If none are defined in the UFO, the default feature writers are used:
-        currently, KernFeatureWriter and MarkFeatureWriter.
+        If none are defined in the UFO, the default feature writers are used
+        (see FeatureCompiler.defaultFeatureWriters).
         The 'featureWriters' argument can be used to override these.
         The method sets the `self.featureWriters` attribute with the list of
         writers.
@@ -197,10 +231,7 @@ class FeatureCompiler(BaseFeatureCompiler):
         used in the subsequent feature writers to resolve substitutions from
         glyphs with unicodes to their alternates.
         """
-        if featureWriters is None:
-            featureWriters = loadFeatureWriters(self.ufo)
-            if featureWriters is None:
-                featureWriters = self.defaultFeatureWriters
+        featureWriters = self._load_custom_feature_writers(featureWriters)
 
         gsubWriters = []
         others = []

--- a/Lib/ufo2ft/featureCompiler.py
+++ b/Lib/ufo2ft/featureCompiler.py
@@ -195,7 +195,7 @@ class FeatureCompiler(BaseFeatureCompiler):
     def _load_custom_feature_writers(self, featureWriters=None):
         # Args:
         #   ufo: Font
-        #   filters: Optional[List[Union[FeatureWriter, EllipsisType]]])
+        #   featureWriters: Optional[List[Union[FeatureWriter, EllipsisType]]])
         # Returns: List[FeatureWriter]
 
         # by default, load the feature writers from the lib or the default ones;

--- a/Lib/ufo2ft/featureWriters/ast.py
+++ b/Lib/ufo2ft/featureWriters/ast.py
@@ -209,9 +209,9 @@ def getGDEFGlyphClasses(feaLib):
     """Return GDEF GlyphClassDef base/mark/ligature/component glyphs, or
     None if no GDEF table is defined in the feature file.
     """
-    for st in feaLib.statements:
-        if isinstance(st, ast.TableBlock) and st.name == "GDEF":
-            for st in st.statements:
+    for s in feaLib.statements:
+        if isinstance(s, ast.TableBlock) and s.name == "GDEF":
+            for st in s.statements:
                 if isinstance(st, ast.GlyphClassDefStatement):
                     return _GDEFGlyphClasses(
                         frozenset(st.baseGlyphs.glyphSet())

--- a/Lib/ufo2ft/featureWriters/markFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/markFeatureWriter.py
@@ -201,15 +201,15 @@ def colorGraph(adjacency):
     """
     # Basic implementation
     # https://en.wikipedia.org/wiki/Greedy_coloring
-    color = dict()
+    colors = dict()
     # Sorted for reproducibility, probably not the optimal vertex order
     for node in sorted(adjacency):
         usedNeighbourColors = {
-            color[neighbour] for neighbour in adjacency[node] if neighbour in color
+            colors[neighbour] for neighbour in adjacency[node] if neighbour in colors
         }
-        color[node] = firstAvailable(usedNeighbourColors)
+        colors[node] = firstAvailable(usedNeighbourColors)
     groups = defaultdict(list)
-    for node, color in color.items():
+    for node, color in colors.items():
         groups[color].append(node)
     return list(groups.values())
 

--- a/Lib/ufo2ft/filters/__init__.py
+++ b/Lib/ufo2ft/filters/__init__.py
@@ -85,7 +85,7 @@ def isValidFilter(klass):
     a '__call__' (bound method), with the signature matching the same method
     from the BaseFilter class:
 
-           def __call__(self, font, feaFile, compiler=None)
+           def __call__(self, font, glyphSet=None)
     """
     if not isclass(klass):
         logger.error(f"{klass!r} is not a class")

--- a/Lib/ufo2ft/preProcessor.py
+++ b/Lib/ufo2ft/preProcessor.py
@@ -28,7 +28,7 @@ class BasePreProcessor:
     Custom filters can be applied before or after the default filters.
     These can be specified in the UFO lib.plist under the private key
     "com.github.googlei18n.ufo2ft.filters".
-    Alterantively the optional ``filters`` parameter can be used. This is a
+    Alternatively the optional ``filters`` parameter can be used. This is a
     list of filter instances (subclasses of BaseFilter) that overrides
     those defined in the UFO lib. The list can be empty, meaning no custom
     filters are run. If ``filters`` contain the special value ``...`` (i.e.

--- a/Lib/ufo2ft/preProcessor.py
+++ b/Lib/ufo2ft/preProcessor.py
@@ -46,7 +46,7 @@ class BasePreProcessor:
         layerName=None,
         skipExportGlyphs=None,
         filters=None,
-        **kwargs
+        **kwargs,
     ):
         self.ufo = ufo
         self.inplace = inplace

--- a/Lib/ufo2ft/preProcessor.py
+++ b/Lib/ufo2ft/preProcessor.py
@@ -5,14 +5,17 @@ from ufo2ft.constants import (
     COLOR_LAYERS_KEY,
     COLOR_PALETTES_KEY,
 )
-from ufo2ft.filters import BaseFilter, isValidFilter, loadFilters
+from ufo2ft.filters import isValidFilter, loadFilters
 from ufo2ft.filters.decomposeComponents import DecomposeComponentsFilter
 from ufo2ft.fontInfoData import getAttrWithFallback
 from ufo2ft.util import _GlyphSet
 
 
 def _load_custom_filters(ufo, filters=None):
-    # type: (Font, Optional[List[Union[Filter, EllipsisType]]]) -> List[Filter]
+    # Args:
+    #   ufo: Font
+    #   filters: Optional[List[Union[Filter, EllipsisType]]])
+    # Returns: List[Filter]
 
     # by default, load the filters from the lib; ellipsis is used as a placeholder
     # so one can optionally insert additional filters=[f1, ..., f2] either

--- a/Lib/ufo2ft/preProcessor.py
+++ b/Lib/ufo2ft/preProcessor.py
@@ -1,12 +1,5 @@
 import itertools
 
-try:
-    from types import EllipsisType
-except ImportError:
-    EllipsisType = type(Ellipsis)
-
-from typing import Any, List, Optional, Union
-
 from ufo2ft.constants import (
     COLOR_LAYER_MAPPING_KEY,
     COLOR_LAYERS_KEY,
@@ -18,9 +11,9 @@ from ufo2ft.fontInfoData import getAttrWithFallback
 from ufo2ft.util import _GlyphSet
 
 
-def _load_custom_filters(
-    ufo: Any, filters: Optional[List[Union[BaseFilter, EllipsisType]]] = None
-) -> List[BaseFilter]:
+def _load_custom_filters(ufo, filters=None):
+    # type: (Font, Optional[List[Union[Filter, EllipsisType]]]) -> List[Filter]
+
     # by default, load the filters from the lib; ellipsis is used as a placeholder
     # so one can optionally insert additional filters=[f1, ..., f2] either
     # before or after these, or override them by omitting the ellipsis.

--- a/tests/preProcessor_test.py
+++ b/tests/preProcessor_test.py
@@ -116,6 +116,21 @@ class TTFPreProcessorTest:
         # filter2, before overlaps were removed in a post-filter filter1
         assert len(glyphSets0["d"].components) == 0
 
+    def test_custom_filters_in_both_lib_and_argument_with_ellipsis(self, FontClass):
+        from ufo2ft.filters import TransformationsFilter
+
+        ufo = FontClass(getpath("TestFont.ufo"))
+        ufo.lib[FILTERS_KEY] = [
+            {"name": "transformations", "kwargs": {"OffsetX": 10}, "pre": True}
+        ]
+
+        glyphSet = TTFPreProcessor(
+            ufo, filters=[..., TransformationsFilter(OffsetY=-10)]
+        ).process()
+
+        a = glyphSet["a"]
+        assert (a[0][0].x, a[0][0].y) == (ufo["a"][0][0].x + 10, ufo["a"][0][0].y - 10)
+
 
 class TTFInterpolatablePreProcessorTest:
     def test_no_inplace(self, FontClass):
@@ -204,6 +219,34 @@ class TTFInterpolatablePreProcessorTest:
         # A component was shifted to overlap with another in a pre-filter
         # filter2, before overlaps were removed in a post-filter filter1
         assert len(glyphSets[0]["d"].components) == 0
+
+    def test_custom_filters_in_both_lib_and_argument_with_ellipsis(self, FontClass):
+        from ufo2ft.filters import TransformationsFilter
+
+        ufo1 = FontClass(getpath("TestFont.ufo"))
+        ufo1.lib[FILTERS_KEY] = [
+            {"name": "transformations", "kwargs": {"OffsetX": 10}, "pre": True}
+        ]
+
+        ufo2 = FontClass(getpath("TestFont.ufo"))
+        ufo2.lib[FILTERS_KEY] = [
+            {"name": "transformations", "kwargs": {"OffsetX": 20}, "pre": True}
+        ]
+
+        glyphSets = TTFInterpolatablePreProcessor(
+            [ufo1, ufo2], filters=[..., TransformationsFilter(OffsetY=-10)]
+        ).process()
+
+        a1 = glyphSets[0]["a"]
+        assert (a1[0][0].x, a1[0][0].y) == (
+            ufo1["a"][0][0].x + 10,
+            ufo1["a"][0][0].y - 10,
+        )
+        a2 = glyphSets[1]["a"]
+        assert (a2[0][0].x, a2[0][0].y) == (
+            ufo2["a"][0][0].x + 20,
+            ufo2["a"][0][0].y - 10,
+        )
 
 
 class SkipExportGlyphsTest:


### PR DESCRIPTION
Currently the `filters` and `featureWriters` parameters always override the ones defined in the UFO lib.plist, and it's impossible to extend instead of replace these, e.g. inserting some additional filter or writer either before or after.

This PR allows to pass a special value `...` (the actual [``Ellipsis`` singleton](https://medium.com/techtofreedom/3-uses-of-the-ellipsis-in-python-25795aac723d), not the str literal '...') in both these lists, which acts as a placeholder to signal one wants to extend the list of predefined filters/writers.

E.g.:

```python
filters=[..., DecomposeTransformedComponentsFilter(pre=True)]
```

The ellipsis is replaced by the custom filters defined in the UFO lib (if any), and the additional one is appended to the list.
Only one ellipsis is allowed in the list.
Same for the featureWriters.

Fontmake will also be updated to allow passing --filter='...' or --feature-writer='...' CLI options to use this feature.

Part of fixing https://github.com/googlefonts/fontmake/issues/872