### PR TITLE
add ftConfig parameter to set fontTools' TTFont.cfg options

### DIFF
--- a/Lib/ufo2ft/_compilers/baseCompiler.py
+++ b/Lib/ufo2ft/_compilers/baseCompiler.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Callable, Optional, Type

--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -108,6 +108,7 @@ class BaseOutlineCompiler:
         colrLayerReuse=True,
         colrAutoClipBoxes=True,
         colrClipBoxQuantization=colrClipBoxQuantization,
+        ftConfig=None,
     ):
         self.ufo = font
         # use the previously filtered glyphSet, if any
@@ -126,6 +127,7 @@ class BaseOutlineCompiler:
         self.colrLayerReuse = colrLayerReuse
         self.colrAutoClipBoxes = colrAutoClipBoxes
         self.colrClipBoxQuantization = colrClipBoxQuantization
+        self.ftConfig = ftConfig or {}
         # cached values defined later on
         self._glyphBoundingBoxes = None
         self._fontBoundingBox = None
@@ -136,7 +138,7 @@ class BaseOutlineCompiler:
         """
         Compile the OpenType binary.
         """
-        self.otf = TTFont(sfntVersion=self.sfntVersion)
+        self.otf = TTFont(sfntVersion=self.sfntVersion, cfg=self.ftConfig)
 
         # only compile vertical metrics tables if vhea metrics are defined
         vertical_metrics = [
@@ -1104,6 +1106,7 @@ class OutlineOTFCompiler(BaseOutlineCompiler):
         colrLayerReuse=True,
         colrAutoClipBoxes=True,
         colrClipBoxQuantization=colrClipBoxQuantization,
+        ftConfig=None,
     ):
         if roundTolerance is not None:
             self.roundTolerance = float(roundTolerance)
@@ -1119,6 +1122,7 @@ class OutlineOTFCompiler(BaseOutlineCompiler):
             colrLayerReuse=colrLayerReuse,
             colrAutoClipBoxes=colrAutoClipBoxes,
             colrClipBoxQuantization=colrClipBoxQuantization,
+            ftConfig=ftConfig,
         )
         self.optimizeCFF = optimizeCFF
         self._defaultAndNominalWidths = None
@@ -1440,6 +1444,7 @@ class OutlineTTFCompiler(BaseOutlineCompiler):
         autoUseMyMetrics=True,
         roundCoordinates=True,
         glyphDataFormat=0,
+        ftConfig=None,
     ):
         super().__init__(
             font,
@@ -1450,6 +1455,7 @@ class OutlineTTFCompiler(BaseOutlineCompiler):
             colrLayerReuse=colrLayerReuse,
             colrAutoClipBoxes=colrAutoClipBoxes,
             colrClipBoxQuantization=colrClipBoxQuantization,
+            ftConfig=ftConfig,
         )
         self.autoUseMyMetrics = autoUseMyMetrics
         self.dropImpliedOnCurves = dropImpliedOnCurves

--- a/Lib/ufo2ft/postProcessor.py
+++ b/Lib/ufo2ft/postProcessor.py
@@ -404,4 +404,5 @@ def _reloadFont(font: TTFont) -> TTFont:
     stream = BytesIO()
     font.save(stream)
     stream.seek(0)
-    return TTFont(stream)
+    # keep the same Config (constructor will make a copy)
+    return TTFont(stream, cfg=font.cfg)


### PR DESCRIPTION
This adds a new `ftConfig` parameter to all compile methods that allows to set fonttools configuration options as defined in (e.g. to turn on/off the serialization of GPOS/GSUB with the harfbuzz repacker):

https://github.com/fonttools/fonttools/blob/main/Lib/fontTools/config/__init__.py

since these config options are set on the TTFont instance itself (in its cfg attribute) but ufo2ft creates a new TTFont instance from scratch, this new parameter will allow a client (e.g. fontmake) to specify these options and have ufo2ft configure the newly created TTFont object with them.