### PR TITLE
outlineTTFCompiler: set overlap bits for ttGlyph

### DIFF
--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -1399,7 +1399,7 @@ class OutlineTTFCompiler(BaseOutlineCompiler):
                 logger.error("%r has invalid curve format; skipped", name)
                 ttGlyph = Glyph()
             else:
-                ttGlyph = pen.glyph()
+                ttGlyph = pen.glyph(overlapBit=glyph.trueTypeOverlap)
             ttGlyphs[name] = ttGlyph
         return ttGlyphs
 
@@ -1525,6 +1525,7 @@ class StubGlyph:
         self.unicodes = unicodes if unicodes is not None else []
         self.components = []
         self.anchors = []
+        self.trueTypeOverlap = False
         if self.unicodes:
             self.unicode = self.unicodes[0]
         else:


### PR DESCRIPTION
I have a few PRs I'm working on which should enable users to manually set which glyphs should have overlap bits enabled. I also plan to automatically calculate these bits of the user hasn't specified any glyphs.

Depends on https://github.com/fonttools/ufoLib2/pull/217, https://github.com/robotools/defcon/pull/404 and a fontTools pen pr I'm working on. The auto stuff is a touch harder so I may need to revise this PR at some point.