### PR TITLE
Restore cubicConversionError renaming

### DIFF
--- a/Lib/ufo2ft/__init__.py
+++ b/Lib/ufo2ft/__init__.py
@@ -57,6 +57,10 @@ def call_preprocessor(ufo_or_ufos, *, preProcessorClass, **kwargs):
                 "public.skipExportGlyphs", []
             )
 
+    # Preprocessors expect this parameter under a different name.
+    if "cubicConversionError" in kwargs:
+        kwargs["conversionError"] = kwargs.pop("cubicConversionError")
+
     callables = [preProcessorClass]
     if hasattr(preProcessorClass, "initDefaultFilters"):
         callables.append(preProcessorClass.initDefaultFilters)

--- a/tests/outlineCompiler_test.py
+++ b/tests/outlineCompiler_test.py
@@ -1132,6 +1132,33 @@ def test_compile_empty_ufo(FontClass):
     assert font["OS/2"].sTypoDescender == -200
 
 
+def test_pass_on_conversion_error(FontClass):
+    ufo = FontClass()
+    ufo.info.unitsPerEm = 2000
+
+    # Draw quarter circle
+    glyph = ufo.newGlyph("test")
+    pen = glyph.getPointPen()
+    pen.beginPath()
+    pen.addPoint((0, 43), segmentType="line")
+    pen.addPoint((25, 43))
+    pen.addPoint((43, 25))
+    pen.addPoint((43, 0), segmentType="curve")
+    pen.addPoint((0, 0), segmentType="line")
+    pen.endPath()
+
+    font1 = compileTTF(ufo)  # Default error: 0.001
+    font2 = compileTTF(ufo, cubicConversionError=0.0005)
+
+    # One off-curve:
+    font1_coords = list(font1["glyf"]["test"].coordinates)
+    assert font1_coords == [(0, 43), (0, 0), (43, 0), (43, 43)]
+
+    # Two off-curves:
+    font2_coords = list(font2["glyf"]["test"].coordinates)
+    assert font2_coords == [(0, 43), (0, 0), (43, 0), (43, 19), (19, 43)]
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
My colleague @hoolean found this while investigating https://github.com/fonttools/fonttools/issues/2518. He pin-pointed it to https://github.com/googlefonts/ufo2ft/commit/48cf175c2cf3e460ea13d80b7628d580a0d9a5eb#diff-ac2b4a91d2e815dc8fb72da8fa23b409950a6901f465b74e118f088da3c74aedL310-L319 where we forgot to rename one parameter. So, this parameter has been ignored since v2.25.0 (Oct 2021).