### PR TITLE
[DottedCircleFilter] Don't add a new OPENTYPE_CATEGORIES lib

### DIFF
--- a/Lib/ufo2ft/filters/dottedCircleFilter.py
+++ b/Lib/ufo2ft/filters/dottedCircleFilter.py
@@ -249,7 +249,8 @@ class DottedCircleFilter(BaseFilter):
         if ast.findTable(feaFile, "GDEF") is None:
             # We have no GDEF table. GDEFFeatureWriter will create one
             # using the font's lib.
-            font.lib.setdefault(OPENTYPE_CATEGORIES_KEY, {})[dotted_circle] = "base"
+            if OPENTYPE_CATEGORIES_KEY in font.lib:
+                font.lib[OPENTYPE_CATEGORIES_KEY][dotted_circle] = "base"
             return
         # We have GDEF table, so we need to find the GlyphClassDef, and add
         # ourselves to the baseGlyphs set.


### PR DESCRIPTION
If the dotted circle filter doesn't find a GDEF statement while trying to make the dotted circle glyph into a base glyph, it adds the glyph to the OPENTYPE_CATEGORIES part of the font's lib instead. If there isn't a OPENTYPE_CATEGORIES lib, it makes one. This is a mistake, because the dotted circle glyph becomes the only thing in OPENTYPE_CATEGORIES, and everything else *not* in the dictionary is assumed to be base; this is not what you want.