### PR TITLE
Split kerning by script, not by direction

### DIFF
--- a/Lib/ufo2ft/constants.py
+++ b/Lib/ufo2ft/constants.py
@@ -38,6 +38,8 @@ OPENTYPE_META_KEY = "public.openTypeMeta"
 
 UNICODE_VARIATION_SEQUENCES_KEY = "public.unicodeVariationSequences"
 
+COMMON_SCRIPT = "Zyyy"
+
 INDIC_SCRIPTS = [
     "Beng",  # Bengali
     "Cham",  # Cham

--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
@@ -71,25 +71,37 @@ class KerningPair:
 
     @property
     def firstIsClass(self):
-        return isinstance(self.side1, ast.GlyphClassName)
+        return isinstance(self.side1, (ast.GlyphClassName, ast.GlyphClass))
 
     @property
     def secondIsClass(self):
-        return isinstance(self.side2, ast.GlyphClassName)
+        return isinstance(self.side2, (ast.GlyphClassName, ast.GlyphClass))
+
+    @property
+    def firstGlyphs(self):
+        if self.firstIsClass:
+            if isinstance(self.side1, ast.GlyphClassName):
+                classDef1 = self.side1.glyphclass
+            else:
+                classDef1 = self.side1
+            return {g.asFea() for g in classDef1.glyphSet()}
+        else:
+            return {self.side1.asFea()}
+
+    @property
+    def secondGlyphs(self):
+        if self.secondIsClass:
+            if isinstance(self.side2, ast.GlyphClassName):
+                classDef2 = self.side2.glyphclass
+            else:
+                classDef2 = self.side2
+            return {g.asFea() for g in classDef2.glyphSet()}
+        else:
+            return {self.side2.asFea()}
 
     @property
     def glyphs(self):
-        if self.firstIsClass:
-            classDef1 = self.side1.glyphclass
-            glyphs1 = {g.asFea() for g in classDef1.glyphSet()}
-        else:
-            glyphs1 = {self.side1.asFea()}
-        if self.secondIsClass:
-            classDef2 = self.side2.glyphclass
-            glyphs2 = {g.asFea() for g in classDef2.glyphSet()}
-        else:
-            glyphs2 = {self.side2.asFea()}
-        return glyphs1 | glyphs2
+        return self.firstGlyphs | self.secondGlyphs
 
     def __repr__(self):
         return "<{} {} {} {}{}{}>".format(

--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
@@ -1,4 +1,5 @@
 import itertools
+import logging
 from types import SimpleNamespace
 
 from fontTools import unicodedata
@@ -128,6 +129,9 @@ class KerningPair:
                 yield secondScripts[0], localPair
             # One script and it's different on both sides and it's not common
             elif len(firstScripts) == 1 and len(secondScripts) == 1:
+                logging.getLogger("KernFeatureWriter.KerningPair").info(
+                    "Mixed script kerning pair %s ignored" % localPair
+                )
                 pass
             else:
                 # At this point, we have a pair which has different sets of

--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
@@ -52,7 +52,7 @@ class KerningPair:
             if len(side1) == 1:
                 self.side1 = ast.GlyphName(list(side1)[0])
             else:
-                self.side1 = ast.GlyphClass([ast.GlyphName(g) for g in side1])
+                self.side1 = ast.GlyphClass([ast.GlyphName(g) for g in sorted(side1)])
         else:
             raise AssertionError(side1)
 
@@ -64,7 +64,7 @@ class KerningPair:
             if len(side2) == 1:
                 self.side2 = ast.GlyphName(list(side2)[0])
             else:
-                self.side2 = ast.GlyphClass([ast.GlyphName(g) for g in side2])
+                self.side2 = ast.GlyphClass([ast.GlyphName(g) for g in sorted(side2)])
         else:
             raise AssertionError(side2)
 
@@ -75,7 +75,7 @@ class KerningPair:
 
     def partitionByScript(self, glyphScripts):
         """Split a potentially mixed-script pair into pairs that make sense based
-        on a the dominant script, and yield each combination with its dominant script."""
+        on the dominant script, and yield each combination with its dominant script."""
 
         # First, partition the pair by their assigned scripts
         allFirstScripts = {}
@@ -130,6 +130,14 @@ class KerningPair:
             elif len(firstScripts) == 1 and len(secondScripts) == 1:
                 pass
             else:
+                # At this point, we have a pair which has different sets of
+                # scripts on each side, and we have to find commonalities.
+                # For example, the pair
+                #   [A A-cy] {Latn, Cyrl}  --  [T Te-cy Tau] {Latn, Cyrl, Grek}
+                # must be split into
+                #   A -- T
+                #   A-cy -- Te-cy
+                # and the Tau ignored.
                 commonScripts = set(firstScripts) & set(secondScripts)
                 commonFirstGlyphs = set()
                 commonSecondGlyphs = set()

--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 
 from fontTools import unicodedata
 
-from ufo2ft.constants import INDIC_SCRIPTS, USE_SCRIPTS
+from ufo2ft.constants import COMMON_SCRIPT, INDIC_SCRIPTS, USE_SCRIPTS
 from ufo2ft.featureWriters import BaseFeatureWriter, ast
 from ufo2ft.util import DFLT_SCRIPTS, classifyGlyphs, quantize, unicodeScriptDirection
 
@@ -82,11 +82,11 @@ class KerningPair:
         allSecondScripts = {}
         for g in self.firstGlyphs:
             if g not in glyphScripts:
-                glyphScripts[g] = set(["Zyyy"])
+                glyphScripts[g] = set([COMMON_SCRIPT])
             allFirstScripts.setdefault(tuple(glyphScripts[g]), []).append(g)
         for g in self.secondGlyphs:
             if g not in glyphScripts:
-                glyphScripts[g] = set(["Zyyy"])
+                glyphScripts[g] = set([COMMON_SCRIPT])
             allSecondScripts.setdefault(tuple(glyphScripts[g]), []).append(g)
 
         # Super common case
@@ -409,7 +409,7 @@ class KernFeatureWriter(BaseFeatureWriter):
         if not self.context.knownScripts:
             # If there are no languagesystems, consider everything common;
             # it'll all end in DFLT/dflt anyway
-            return "Zyyy"
+            return COMMON_SCRIPT
         return [
             x
             for x in unicodedata.script_extension(chr(uv))
@@ -471,7 +471,7 @@ class KernFeatureWriter(BaseFeatureWriter):
                 lookup = script_lookups.get(key)
                 if not lookup:
                     lookup = self._makeKerningLookup(
-                        key.replace("Zyyy", "Common"),  # For neatness
+                        key.replace(COMMON_SCRIPT, "Common"),  # For neatness
                         ignoreMarks=ignoreMarks,
                     )
                     script_lookups[key] = lookup
@@ -496,8 +496,10 @@ class KernFeatureWriter(BaseFeatureWriter):
         kernScripts = scriptGroups.get(feature.name, {})
 
         # Ensure we have kerning for pure common script runs (e.g. ">1")
-        if feature.name == "kern" and "Zyyy" in lookups:
-            ast.addLookupReferences(feature, lookups["Zyyy"].values(), "DFLT", ["dflt"])
+        if feature.name == "kern" and COMMON_SCRIPT in lookups:
+            ast.addLookupReferences(
+                feature, lookups[COMMON_SCRIPT].values(), "DFLT", ["dflt"]
+            )
 
         for script, script_lookups in lookups.items():
             ot_scripts = unicodedata.ot_tags_from_script(script)

--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
@@ -45,6 +45,11 @@ class KerningPair:
             self.side1 = ast.GlyphName(side1)
         elif isinstance(side1, ast.GlyphClassDefinition):
             self.side1 = ast.GlyphClassName(side1)
+        elif isinstance(side1, (list, set)):
+            if len(side1) == 1:
+                self.side1 = ast.GlyphName(list(side1)[0])
+            else:
+                self.side1 = ast.GlyphClass([ast.GlyphName(g) for g in side1])
         else:
             raise AssertionError(side1)
 
@@ -52,6 +57,11 @@ class KerningPair:
             self.side2 = ast.GlyphName(side2)
         elif isinstance(side2, ast.GlyphClassDefinition):
             self.side2 = ast.GlyphClassName(side2)
+        elif isinstance(side2, (list, set)):
+            if len(side2) == 1:
+                self.side2 = ast.GlyphName(list(side2)[0])
+            else:
+                self.side2 = ast.GlyphClass([ast.GlyphName(g) for g in side2])
         else:
             raise AssertionError(side2)
 

--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
@@ -129,7 +129,8 @@ class KerningPair:
                 yield secondScripts[0], localPair
             # One script and it's different on both sides and it's not common
             elif len(firstScripts) == 1 and len(secondScripts) == 1:
-                logging.getLogger("KernFeatureWriter.KerningPair").info(
+                logger = ".".join([self.__class__.__module__, self.__class__.__name__])
+                logging.getLogger(logger).info(
                     "Mixed script kerning pair %s ignored" % localPair
                 )
                 pass

--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
@@ -1,11 +1,11 @@
-from types import SimpleNamespace
 import itertools
+from types import SimpleNamespace
 
 from fontTools import unicodedata
 
 from ufo2ft.constants import INDIC_SCRIPTS, USE_SCRIPTS
 from ufo2ft.featureWriters import BaseFeatureWriter, ast
-from ufo2ft.util import classifyGlyphs, quantize, unicodeScriptDirection, DFLT_SCRIPTS
+from ufo2ft.util import DFLT_SCRIPTS, classifyGlyphs, quantize, unicodeScriptDirection
 
 SIDE1_PREFIX = "public.kern1."
 SIDE2_PREFIX = "public.kern2."
@@ -422,10 +422,10 @@ class KernFeatureWriter(BaseFeatureWriter):
         cmap = self.makeUnicodeToGlyphNameMapping()
         gsub = self.compileGSUB()
         dirGlyphs = classifyGlyphs(unicodeScriptDirection, cmap, gsub)
-        directions = self._intersectPairs("directions", dirGlyphs)
+        self._intersectPairs("directions", dirGlyphs)
 
         scriptGlyphs = classifyGlyphs(self.knownScriptsPerCodepoint, cmap, gsub)
-        allScripts = self._intersectPairs("scripts", scriptGlyphs)
+        self._intersectPairs("scripts", scriptGlyphs)
         bidiGlyphs = classifyGlyphs(unicodeBidiType, cmap, gsub)
         self._intersectPairs("bidiTypes", bidiGlyphs)
         pairs = self.context.kerning.pairs
@@ -475,7 +475,7 @@ class KernFeatureWriter(BaseFeatureWriter):
                         ignoreMarks=ignoreMarks,
                     )
                     script_lookups[key] = lookup
-                self._addPairToLookup(lookup, pair, rtl="RTL" in pair.directions)
+                self._addPairToLookup(lookup, splitpair, rtl="RTL" in pair.directions)
 
     def _makeFeatureBlocks(self, lookups):
         features = {}

--- a/Lib/ufo2ft/featureWriters/markFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/markFeatureWriter.py
@@ -559,7 +559,7 @@ class MarkFeatureWriter(BaseFeatureWriter):
                 # We keep the NamedAnchor if the markClass is allowed in the
                 # current lookup.
                 def include(anchor):
-                    return anchor.markClass.name in markClasses
+                    return anchor.markClass.name in markClasses  # noqa: B023
 
                 filteredAttachment = attachment.filter(include)
                 if filteredAttachment:

--- a/Lib/ufo2ft/util.py
+++ b/Lib/ufo2ft/util.py
@@ -264,12 +264,12 @@ def closeGlyphsOverGSUB(gsub, glyphs):
 
 def classifyGlyphs(unicodeFunc, cmap, gsub=None):
     """'unicodeFunc' is a callable that takes a Unicode codepoint and
-    returns a string denoting some Unicode property associated with the
-    given character (or None if a character is considered 'neutral').
-    'cmap' is a dictionary mapping Unicode codepoints to glyph names.
-    'gsub' is an (optional) fonttools GSUB table object, used to find all
-    the glyphs that are "reachable" via substitutions from the initial
-    sets of glyphs defined in the cmap.
+    returns a string, or collection of strings, denoting some Unicode
+    property associated with the given character (or None if a character
+    is considered 'neutral'). 'cmap' is a dictionary mapping Unicode
+    codepoints to glyph names. 'gsub' is an (optional) fonttools GSUB
+    table object, used to find all the glyphs that are "reachable" via
+    substitutions from the initial sets of glyphs defined in the cmap.
 
     Returns a dictionary of glyph sets associated with the given Unicode
     properties.

--- a/Lib/ufo2ft/util.py
+++ b/Lib/ufo2ft/util.py
@@ -277,11 +277,14 @@ def classifyGlyphs(unicodeFunc, cmap, gsub=None):
     glyphSets = {}
     neutralGlyphs = set()
     for uv, glyphName in cmap.items():
-        key = unicodeFunc(uv)
-        if key is None:
+        key_or_keys = unicodeFunc(uv)
+        if key_or_keys is None:
             neutralGlyphs.add(glyphName)
+        elif isinstance(key_or_keys, (list, set)):
+            for key in key_or_keys:
+                glyphSets.setdefault(key, set()).add(glyphName)
         else:
-            glyphSets.setdefault(key, set()).add(glyphName)
+            glyphSets.setdefault(key_or_keys, set()).add(glyphName)
 
     if gsub is not None:
         if neutralGlyphs:

--- a/tests/featureCompiler_test.py
+++ b/tests/featureCompiler_test.py
@@ -208,7 +208,11 @@ class FeatureCompilerTest:
                 foo = ast.FeatureBlock("FOO ")
                 foo.statements.append(
                     ast.SingleSubstStatement(
-                        "a", "v", prefix="", suffix="", forceChain=None
+                        [ast.GlyphName("a")],
+                        [ast.GlyphName("v")],
+                        prefix="",
+                        suffix="",
+                        forceChain=None,
                     )
                 )
                 feaFile.statements.append(foo)

--- a/tests/featureWriters/kernFeatureWriter_test.py
+++ b/tests/featureWriters/kernFeatureWriter_test.py
@@ -120,9 +120,10 @@ class KernFeatureWriterTest(FeatureWriterTest):
 
         lookups = getLookups(feaFile)
         assert len(lookups) == 1
-        kern_ltr = lookups[0]
-        assert kern_ltr.name == "kern_ltr"
-        rules = getPairPosRules(kern_ltr)
+        kern_lookup = lookups[0]
+        # We have no codepoints defined for these, so they're considered common
+        assert kern_lookup.name == "kern_Common"
+        rules = getPairPosRules(kern_lookup)
         assert len(rules) == 1
         assert str(rules[0]) == "pos @kern1.A @kern2.B 10;"
 
@@ -138,14 +139,16 @@ class KernFeatureWriterTest(FeatureWriterTest):
 
         assert str(feaFile) == dedent(
             """\
-            lookup kern_ltr {
+            lookup kern_Common {
                 lookupflag IgnoreMarks;
                 pos four six -55;
                 pos one six -30;
-            } kern_ltr;
+            } kern_Common;
 
             feature kern {
-                lookup kern_ltr;
+                script DFLT;
+                language dflt;
+                lookup kern_Common;
             } kern;
             """
         )
@@ -156,13 +159,15 @@ class KernFeatureWriterTest(FeatureWriterTest):
 
         assert str(feaFile) == dedent(
             """\
-            lookup kern_ltr {
+            lookup kern_Common {
                 pos four six -55;
                 pos one six -30;
-            } kern_ltr;
+            } kern_Common;
 
             feature kern {
-                lookup kern_ltr;
+                script DFLT;
+                language dflt;
+                lookup kern_Common;
             } kern;
             """
         )
@@ -170,7 +175,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
     def test_mark_to_base_kern(self, FontClass):
         font = FontClass()
         for name in ("A", "B", "C"):
-            font.newGlyph(name)
+            font.newGlyph(name).unicode = ord(name)
         font.newGlyph("acutecomb").unicode = 0x0301
         font.kerning.update({("A", "acutecomb"): -55.0, ("B", "C"): -30.0})
 
@@ -186,20 +191,23 @@ class KernFeatureWriterTest(FeatureWriterTest):
 
         # default is ignoreMarks=True
         feaFile = self.writeFeatures(font)
+        # Zyyy because no languagesystems defined
         assert str(feaFile) == dedent(
             """
-            lookup kern_ltr {
+            lookup kern_Common {
                 lookupflag IgnoreMarks;
                 pos B C -30;
-            } kern_ltr;
+            } kern_Common;
 
-            lookup kern_ltr_marks {
+            lookup kern_Common_marks {
                 pos A acutecomb -55;
-            } kern_ltr_marks;
+            } kern_Common_marks;
 
             feature kern {
-                lookup kern_ltr;
-                lookup kern_ltr_marks;
+                script DFLT;
+                language dflt;
+                lookup kern_Common;
+                lookup kern_Common_marks;
             } kern;
             """
         )
@@ -207,13 +215,15 @@ class KernFeatureWriterTest(FeatureWriterTest):
         feaFile = self.writeFeatures(font, ignoreMarks=False)
         assert str(feaFile) == dedent(
             """
-            lookup kern_ltr {
+            lookup kern_Common {
                 pos A acutecomb -55;
                 pos B C -30;
-            } kern_ltr;
+            } kern_Common;
 
             feature kern {
-                lookup kern_ltr;
+                script DFLT;
+                language dflt;
+                lookup kern_Common;
             } kern;
             """
         )
@@ -239,12 +249,14 @@ class KernFeatureWriterTest(FeatureWriterTest):
         feaFile = self.writeFeatures(font)
         assert str(feaFile) == dedent(
             """
-            lookup kern_ltr_marks {
+            lookup kern_Common_marks {
                 pos A acutecomb -55;
-            } kern_ltr_marks;
+            } kern_Common_marks;
 
             feature kern {
-                lookup kern_ltr_marks;
+                script DFLT;
+                language dflt;
+                lookup kern_Common_marks;
             } kern;
             """
         )
@@ -277,13 +289,15 @@ class KernFeatureWriterTest(FeatureWriterTest):
         expected = existing + dedent(
             """
 
-            lookup kern_ltr {
+            lookup kern_Common {
                 lookupflag IgnoreMarks;
                 pos seven six 25;
-            } kern_ltr;
+            } kern_Common;
 
             feature kern {
-                lookup kern_ltr;
+                script DFLT;
+                language dflt;
+                lookup kern_Common;
             } kern;
             """
         )
@@ -319,13 +333,15 @@ class KernFeatureWriterTest(FeatureWriterTest):
 
         expected = dedent(
             """\
-            lookup kern_ltr {
+            lookup kern_Common {
                 lookupflag IgnoreMarks;
                 pos seven six 25;
-            } kern_ltr;
+            } kern_Common;
 
             feature kern {
-                lookup kern_ltr;
+                script DFLT;
+                language dflt;
+                lookup kern_Common;
             } kern;
 
             feature kern {
@@ -342,13 +358,15 @@ class KernFeatureWriterTest(FeatureWriterTest):
         generated = self.writeFeatures(ufo, mode="append")
         assert str(generated) == dedent(
             """
-            lookup kern_ltr {
+            lookup kern_Common {
                 lookupflag IgnoreMarks;
                 pos seven six 25;
-            } kern_ltr;
+            } kern_Common;
 
             feature kern {
-                lookup kern_ltr;
+                script DFLT;
+                language dflt;
+                lookup kern_Common;
             } kern;
             """
         )
@@ -376,13 +394,15 @@ class KernFeatureWriterTest(FeatureWriterTest):
 
         expected = dedent(
             """\
-            lookup kern_ltr {
+            lookup kern_Common {
                 lookupflag IgnoreMarks;
                 pos seven six 25;
-            } kern_ltr;
+            } kern_Common;
 
             feature kern {
-                lookup kern_ltr;
+                script DFLT;
+                language dflt;
+                lookup kern_Common;
             } kern;
 
             feature kern {
@@ -425,13 +445,15 @@ class KernFeatureWriterTest(FeatureWriterTest):
             } kern;
 
 
-            lookup kern_ltr {
+            lookup kern_Common {
                 lookupflag IgnoreMarks;
                 pos seven six 25;
-            } kern_ltr;
+            } kern_Common;
 
             feature kern {
-                lookup kern_ltr;
+                script DFLT;
+                language dflt;
+                lookup kern_Common;
             } kern;
             """
         )
@@ -442,13 +464,15 @@ class KernFeatureWriterTest(FeatureWriterTest):
         generated = self.writeFeatures(ufo, mode="append")
         assert str(generated) == dedent(
             """
-            lookup kern_ltr {
+            lookup kern_Common {
                 lookupflag IgnoreMarks;
                 pos seven six 25;
-            } kern_ltr;
+            } kern_Common;
 
             feature kern {
-                lookup kern_ltr;
+                script DFLT;
+                language dflt;
+                lookup kern_Common;
             } kern;
             """
         )
@@ -485,13 +509,15 @@ class KernFeatureWriterTest(FeatureWriterTest):
         generated = self.writeFeatures(ufo, mode="append")
         assert str(generated) == dedent(
             """
-            lookup kern_ltr {
+            lookup kern_Common {
                 lookupflag IgnoreMarks;
                 pos seven six 25;
-            } kern_ltr;
+            } kern_Common;
 
             feature kern {
-                lookup kern_ltr;
+                script DFLT;
+                language dflt;
+                lookup kern_Common;
             } kern;
             """
         )
@@ -517,13 +543,15 @@ class KernFeatureWriterTest(FeatureWriterTest):
 
         assert str(generated) == dedent(
             """
-            lookup kern_rtl {
+            lookup kern_Arab {
                 lookupflag IgnoreMarks;
                 pos four-ar seven-ar -30;
-            } kern_rtl;
+            } kern_Arab;
 
             feature kern {
-                lookup kern_rtl;
+                script arab;
+                language dflt;
+                lookup kern_Arab;
             } kern;
             """
         )
@@ -707,6 +735,11 @@ class KernFeatureWriterTest(FeatureWriterTest):
                 sub reh-ar by reh-ar.fina;
                 language URD;
             } fina;
+
+            feature isol {
+                script arab;
+                sub alef-ar by alef-ar.isol;
+            } isol;
             """
         )
 
@@ -720,30 +753,40 @@ class KernFeatureWriterTest(FeatureWriterTest):
             @kern1.reh = [reh-ar zain-ar reh-ar.fina];
             @kern2.alef = [alef-ar alef-ar.isol];
 
-            lookup kern_dflt {
-                pos seven four -25;
-            } kern_dflt;
-
-            lookup kern_ltr {
-                enum pos @kern1.A V -40;
-            } kern_ltr;
-
-            lookup kern_rtl {
+            lookup kern_Arab {
                 pos four-ar seven-ar -30;
                 pos reh-ar.fina lam-ar.init <-80 0 -80 0>;
                 pos @kern1.reh @kern2.alef <-100 0 -100 0>;
-            } kern_rtl;
+            } kern_Arab;
+
+            lookup kern_Latn {
+                enum pos @kern1.A V -40;
+            } kern_Latn;
+
+            lookup kern_Common {
+                pos seven four -25;
+            } kern_Common;
 
             feature kern {
-                lookup kern_dflt;
+                script DFLT;
+                language dflt;
+                lookup kern_Common;
+                script arab;
+                language dflt;
+                lookup kern_Arab;
+                language URD;
                 script latn;
                 language dflt;
-                lookup kern_ltr;
+                lookup kern_Common;
                 language TRK;
                 script arab;
                 language dflt;
-                lookup kern_rtl;
+                lookup kern_Common;
                 language URD;
+                script latn;
+                language dflt;
+                lookup kern_Latn;
+                language TRK;
             } kern;
             """
         )
@@ -804,6 +847,11 @@ class KernFeatureWriterTest(FeatureWriterTest):
                 language URD;
             } fina;
 
+            feature isol {
+                script arab;
+                sub alef-ar by alef-ar.isol;
+            } isol;
+
             @Bases = [A V Aacute alef-ar reh-ar zain-ar lam-ar
                       alef-ar.isol lam-ar.init reh-ar.fina];
             @Marks = [acutecomb fatha-ar];
@@ -823,43 +871,53 @@ class KernFeatureWriterTest(FeatureWriterTest):
             @kern1.reh = [reh-ar zain-ar reh-ar.fina];
             @kern2.alef = [alef-ar alef-ar.isol];
 
-            lookup kern_dflt {
-                lookupflag IgnoreMarks;
-                pos seven four -25;
-            } kern_dflt;
-
-            lookup kern_ltr {
-                lookupflag IgnoreMarks;
-                enum pos @kern1.A V -40;
-            } kern_ltr;
-
-            lookup kern_ltr_marks {
-                pos V acutecomb 70;
-            } kern_ltr_marks;
-
-            lookup kern_rtl {
+            lookup kern_Arab {
                 lookupflag IgnoreMarks;
                 pos four-ar seven-ar -30;
                 pos reh-ar.fina lam-ar.init <-80 0 -80 0>;
                 pos @kern1.reh @kern2.alef <-100 0 -100 0>;
-            } kern_rtl;
+            } kern_Arab;
 
-            lookup kern_rtl_marks {
+            lookup kern_Arab_marks {
                 pos reh-ar fatha-ar <80 0 80 0>;
-            } kern_rtl_marks;
+            } kern_Arab_marks;
+
+            lookup kern_Latn {
+                lookupflag IgnoreMarks;
+                enum pos @kern1.A V -40;
+            } kern_Latn;
+
+            lookup kern_Latn_marks {
+                pos V acutecomb 70;
+            } kern_Latn_marks;
+
+            lookup kern_Common {
+                lookupflag IgnoreMarks;
+                pos seven four -25;
+            } kern_Common;
 
             feature kern {
-                lookup kern_dflt;
+                script DFLT;
+                language dflt;
+                lookup kern_Common;
+                script arab;
+                language dflt;
+                lookup kern_Arab;
+                lookup kern_Arab_marks;
+                language URD;
                 script latn;
                 language dflt;
-                lookup kern_ltr;
-                lookup kern_ltr_marks;
+                lookup kern_Common;
                 language TRK;
                 script arab;
                 language dflt;
-                lookup kern_rtl;
-                lookup kern_rtl_marks;
+                lookup kern_Common;
                 language URD;
+                script latn;
+                language dflt;
+                lookup kern_Latn;
+                lookup kern_Latn_marks;
+                language TRK;
             } kern;
             """
         )
@@ -904,6 +962,11 @@ class KernFeatureWriterTest(FeatureWriterTest):
                 sub reh-ar by reh-ar.fina;
             } fina;
 
+            feature isol {
+                script arab;
+                sub alef-ar by alef-ar.isol;
+            } isol;
+
             @Bases = [alef-ar reh-ar zain-ar lam-ar alef-ar.isol lam-ar.init reh-ar.fina];
             @Marks = [fatha-ar];
             table GDEF {
@@ -921,19 +984,22 @@ class KernFeatureWriterTest(FeatureWriterTest):
             @kern1.reh = [reh-ar zain-ar reh-ar.fina];
             @kern2.alef = [alef-ar alef-ar.isol];
 
-            lookup kern_rtl {
+            lookup kern_Arab {
                 lookupflag IgnoreMarks;
                 pos reh-ar.fina lam-ar.init <-80 0 -80 0>;
                 pos @kern1.reh @kern2.alef <-100 0 -100 0>;
-            } kern_rtl;
+            } kern_Arab;
 
-            lookup kern_rtl_marks {
+            lookup kern_Arab_marks {
                 pos reh-ar fatha-ar <80 0 80 0>;
-            } kern_rtl_marks;
+            } kern_Arab_marks;
 
             feature kern {
-                lookup kern_rtl;
-                lookup kern_rtl_marks;
+                script arab;
+                language dflt;
+                lookup kern_Arab;
+                lookup kern_Arab_marks;
+                language ARA;
             } kern;
             """
         )
@@ -947,23 +1013,26 @@ class KernFeatureWriterTest(FeatureWriterTest):
 
         assert str(generated) == dedent(
             """
-            lookup kern_ltr {
+            lookup kern_Latn {
                 lookupflag IgnoreMarks;
                 pos A V -40;
-            } kern_ltr;
+            } kern_Latn;
 
-            lookup kern_rtl {
+            lookup kern_Common {
                 lookupflag IgnoreMarks;
                 pos reh-ar alef-ar <-100 0 -100 0>;
-            } kern_rtl;
+            } kern_Common;
 
             feature kern {
                 script DFLT;
                 language dflt;
-                lookup kern_rtl;
+                lookup kern_Common;
                 script latn;
                 language dflt;
-                lookup kern_ltr;
+                lookup kern_Latn;
+                script latn;
+                language dflt;
+                lookup kern_Common;
             } kern;
             """
         )
@@ -974,33 +1043,50 @@ class KernFeatureWriterTest(FeatureWriterTest):
 
         assert str(generated) == dedent(
             """
-            lookup kern_ltr {
-                lookupflag IgnoreMarks;
-                pos A V -40;
-            } kern_ltr;
-
-            lookup kern_rtl {
+            lookup kern_Arab {
                 lookupflag IgnoreMarks;
                 pos reh-ar alef-ar <-100 0 -100 0>;
-            } kern_rtl;
+            } kern_Arab;
+
+            lookup kern_Common {
+                lookupflag IgnoreMarks;
+                pos A V -40;
+            } kern_Common;
 
             feature kern {
                 script DFLT;
                 language dflt;
-                lookup kern_ltr;
+                lookup kern_Common;
                 script arab;
                 language dflt;
-                lookup kern_rtl;
+                lookup kern_Common;
+                script arab;
+                language dflt;
+                lookup kern_Arab;
             } kern;
             """
         )
 
-    def test_kern_LTR_and_RTL_cannot_use_DFLT(self, FontClass):
+    def test_kern_LTR_and_RTL_no_DFLT(self, FontClass):
         glyphs = {"A": 0x41, "V": 0x56, "reh-ar": 0x631, "alef-ar": 0x627}
         kerning = {("A", "V"): -40, ("reh-ar", "alef-ar"): -100}
         ufo = makeUFO(FontClass, glyphs, kerning=kerning)
-        with pytest.raises(ValueError, match="cannot use DFLT script"):
-            self.writeFeatures(ufo)
+        generated = self.writeFeatures(ufo)
+        assert "\n" + str(generated) == dedent(
+            """
+            lookup kern_Common {
+                lookupflag IgnoreMarks;
+                pos A V -40;
+                pos reh-ar alef-ar <-100 0 -100 0>;
+            } kern_Common;
+
+            feature kern {
+                script DFLT;
+                language dflt;
+                lookup kern_Common;
+            } kern;
+            """
+        )
 
     def test_dist_LTR(self, FontClass):
         glyphs = {"aaMatra_kannada": 0x0CBE, "ailength_kannada": 0xCD6}
@@ -1026,27 +1112,18 @@ class KernFeatureWriterTest(FeatureWriterTest):
             @kern1.KND_aaMatra_R = [aaMatra_kannada];
             @kern2.KND_ailength_L = [aaMatra_kannada];
 
-            lookup kern_ltr {
+            lookup kern_Knda {
                 lookupflag IgnoreMarks;
                 pos @kern1.KND_aaMatra_R @kern2.KND_ailength_L 34;
-            } kern_ltr;
-
-            feature kern {
-                script DFLT;
-                language dflt;
-                lookup kern_ltr;
-                script latn;
-                language dflt;
-                lookup kern_ltr;
-            } kern;
+            } kern_Knda;
 
             feature dist {
                 script knda;
                 language dflt;
-                lookup kern_ltr;
+                lookup kern_Knda;
                 script knd2;
                 language dflt;
-                lookup kern_ltr;
+                lookup kern_Knda;
             } dist;
             """
         )
@@ -1066,24 +1143,15 @@ class KernFeatureWriterTest(FeatureWriterTest):
 
         assert str(generated) == dedent(
             """
-            lookup kern_rtl {
+            lookup kern_Khar {
                 lookupflag IgnoreMarks;
                 pos u10A1E u10A06 <117 0 117 0>;
-            } kern_rtl;
-
-            feature kern {
-                script DFLT;
-                language dflt;
-                lookup kern_rtl;
-                script arab;
-                language dflt;
-                lookup kern_rtl;
-            } kern;
+            } kern_Khar;
 
             feature dist {
                 script khar;
                 language dflt;
-                lookup kern_rtl;
+                lookup kern_Khar;
             } dist;
             """
         )
@@ -1120,33 +1188,31 @@ class KernFeatureWriterTest(FeatureWriterTest):
             @kern1.KND_aaMatra_R = [aaMatra_kannada];
             @kern2.KND_ailength_L = [aaMatra_kannada];
 
-            lookup kern_ltr {
-                lookupflag IgnoreMarks;
-                pos @kern1.KND_aaMatra_R @kern2.KND_ailength_L 34;
-            } kern_ltr;
-
-            lookup kern_rtl {
+            lookup kern_Khar {
                 lookupflag IgnoreMarks;
                 pos u10A1E u10A06 <117 0 117 0>;
-            } kern_rtl;
+            } kern_Khar;
+
+            lookup kern_Knda {
+                lookupflag IgnoreMarks;
+                pos @kern1.KND_aaMatra_R @kern2.KND_ailength_L 34;
+            } kern_Knda;
 
             feature dist {
-                script knda;
-                language dflt;
-                lookup kern_ltr;
-                script knd2;
-                language dflt;
-                lookup kern_ltr;
                 script khar;
                 language dflt;
-                lookup kern_rtl;
+                lookup kern_Khar;
+                script knda;
+                language dflt;
+                lookup kern_Knda;
+                script knd2;
+                language dflt;
+                lookup kern_Knda;
             } dist;
             """
         )
 
-    def test_skip_ambiguous_direction_pair(self, FontClass, caplog):
-        caplog.set_level(logging.ERROR)
-
+    def test_ambiguous_direction_pair(self, FontClass, caplog):
         ufo = FontClass()
         ufo.newGlyph("A").unicode = 0x41
         ufo.newGlyph("one").unicode = 0x31
@@ -1175,9 +1241,44 @@ class KernFeatureWriterTest(FeatureWriterTest):
         with caplog.at_level(logging.WARNING, logger=logger):
             generated = self.writeFeatures(ufo)
 
-        assert not generated
-        assert len(caplog.records) == 5
-        assert "skipped kern pair with ambiguous direction" in caplog.text
+        assert str(generated) == dedent(
+            """
+            lookup kern_Arab {
+                lookupflag IgnoreMarks;
+                pos bar bar 1;
+                pos reh-ar one-ar 4;
+            } kern_Arab;
+
+            lookup kern_Latn {
+                lookupflag IgnoreMarks;
+                pos bar A 2;
+                pos bar bar 1;
+            } kern_Latn;
+
+            lookup kern_Common {
+                lookupflag IgnoreMarks;
+                pos yod-hb one 5;
+            } kern_Common;
+
+            feature kern {
+                script DFLT;
+                language dflt;
+                lookup kern_Common;
+                script latn;
+                language dflt;
+                lookup kern_Latn;
+                script arab;
+                language dflt;
+                lookup kern_Arab;
+                script latn;
+                language dflt;
+                lookup kern_Common;
+                script arab;
+                language dflt;
+                lookup kern_Common;
+            } kern;
+        """
+        )
 
     def test_kern_RTL_and_DFLT_numbers(self, FontClass):
         glyphs = {"four": 0x34, "seven": 0x37, "bet-hb": 0x5D1, "yod-hb": 0x5D9}
@@ -1194,19 +1295,26 @@ class KernFeatureWriterTest(FeatureWriterTest):
 
         assert str(generated) == dedent(
             """
-            lookup kern_dflt {
-                lookupflag IgnoreMarks;
-                pos seven four -25;
-            } kern_dflt;
-
-            lookup kern_rtl {
+            lookup kern_Hebr {
                 lookupflag IgnoreMarks;
                 pos yod-hb bet-hb <-100 0 -100 0>;
-            } kern_rtl;
+            } kern_Hebr;
+
+            lookup kern_Common {
+                lookupflag IgnoreMarks;
+                pos seven four -25;
+            } kern_Common;
 
             feature kern {
-                lookup kern_dflt;
-                lookup kern_rtl;
+                script DFLT;
+                language dflt;
+                lookup kern_Common;
+                script hebr;
+                language dflt;
+                lookup kern_Common;
+                script hebr;
+                language dflt;
+                lookup kern_Hebr;
             } kern;
             """
         )
@@ -1222,14 +1330,16 @@ class KernFeatureWriterTest(FeatureWriterTest):
 
         assert str(feaFile) == dedent(
             """\
-            lookup kern_ltr {
+            lookup kern_Common {
                 lookupflag IgnoreMarks;
                 pos four six -55;
                 pos one six -25;
-            } kern_ltr;
+            } kern_Common;
 
             feature kern {
-                lookup kern_ltr;
+                script DFLT;
+                language dflt;
+                lookup kern_Common;
             } kern;
             """
         )

--- a/tests/featureWriters/kernFeatureWriter_test.py
+++ b/tests/featureWriters/kernFeatureWriter_test.py
@@ -541,7 +541,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
 
         generated = self.writeFeatures(ufo)
 
-        assert str(generated) == dedent(
+        assert dedent(str(generated)) == dedent(
             """
             lookup kern_Arab {
                 lookupflag IgnoreMarks;
@@ -747,7 +747,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
 
         newFeatures = self.writeFeatures(ufo, ignoreMarks=False)
 
-        assert str(newFeatures) == dedent(
+        assert dedent(str(newFeatures)) == dedent(
             """\
             @kern1.A = [A Aacute];
             @kern1.reh = [reh-ar zain-ar reh-ar.fina];
@@ -771,20 +771,16 @@ class KernFeatureWriterTest(FeatureWriterTest):
                 script DFLT;
                 language dflt;
                 lookup kern_Common;
+
                 script arab;
                 language dflt;
+                lookup kern_Common;
                 lookup kern_Arab;
                 language URD;
+
                 script latn;
                 language dflt;
                 lookup kern_Common;
-                language TRK;
-                script arab;
-                language dflt;
-                lookup kern_Common;
-                language URD;
-                script latn;
-                language dflt;
                 lookup kern_Latn;
                 language TRK;
             } kern;
@@ -865,7 +861,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
 
         newFeatures = self.writeFeatures(ufo)
 
-        assert str(newFeatures) == dedent(
+        assert dedent(str(newFeatures)) == dedent(
             """\
             @kern1.A = [A Aacute];
             @kern1.reh = [reh-ar zain-ar reh-ar.fina];
@@ -900,21 +896,17 @@ class KernFeatureWriterTest(FeatureWriterTest):
                 script DFLT;
                 language dflt;
                 lookup kern_Common;
+
                 script arab;
                 language dflt;
+                lookup kern_Common;
                 lookup kern_Arab;
                 lookup kern_Arab_marks;
                 language URD;
+
                 script latn;
                 language dflt;
                 lookup kern_Common;
-                language TRK;
-                script arab;
-                language dflt;
-                lookup kern_Common;
-                language URD;
-                script latn;
-                language dflt;
                 lookup kern_Latn;
                 lookup kern_Latn_marks;
                 language TRK;
@@ -979,7 +971,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
 
         newFeatures = self.writeFeatures(ufo)
 
-        assert str(newFeatures) == dedent(
+        assert dedent(str(newFeatures)) == dedent(
             """\
             @kern1.reh = [reh-ar zain-ar reh-ar.fina];
             @kern2.alef = [alef-ar alef-ar.isol];
@@ -1011,7 +1003,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
         ufo = makeUFO(FontClass, glyphs, kerning=kerning, features=features)
         generated = self.writeFeatures(ufo)
 
-        assert str(generated) == dedent(
+        assert dedent(str(generated)) == dedent(
             """
             lookup kern_Latn {
                 lookupflag IgnoreMarks;
@@ -1027,12 +1019,11 @@ class KernFeatureWriterTest(FeatureWriterTest):
                 script DFLT;
                 language dflt;
                 lookup kern_Common;
-                script latn;
-                language dflt;
-                lookup kern_Latn;
+
                 script latn;
                 language dflt;
                 lookup kern_Common;
+                lookup kern_Latn;
             } kern;
             """
         )
@@ -1041,7 +1032,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
         ufo = makeUFO(FontClass, glyphs, kerning=kerning, features=features)
         generated = self.writeFeatures(ufo)
 
-        assert str(generated) == dedent(
+        assert dedent(str(generated)) == dedent(
             """
             lookup kern_Arab {
                 lookupflag IgnoreMarks;
@@ -1057,11 +1048,10 @@ class KernFeatureWriterTest(FeatureWriterTest):
                 script DFLT;
                 language dflt;
                 lookup kern_Common;
+
                 script arab;
                 language dflt;
                 lookup kern_Common;
-                script arab;
-                language dflt;
                 lookup kern_Arab;
             } kern;
             """
@@ -1107,7 +1097,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
         ufo = makeUFO(FontClass, glyphs, groups, kerning, features)
         generated = self.writeFeatures(ufo)
 
-        assert str(generated) == dedent(
+        assert dedent(str(generated)) == dedent(
             """\
             @kern1.KND_aaMatra_R = [aaMatra_kannada];
             @kern2.KND_ailength_L = [aaMatra_kannada];
@@ -1118,10 +1108,11 @@ class KernFeatureWriterTest(FeatureWriterTest):
             } kern_Knda;
 
             feature dist {
-                script knda;
+                script knd2;
                 language dflt;
                 lookup kern_Knda;
-                script knd2;
+
+                script knda;
                 language dflt;
                 lookup kern_Knda;
             } dist;
@@ -1183,7 +1174,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
         ufo = makeUFO(FontClass, glyphs, groups, kerning, features)
         generated = self.writeFeatures(ufo)
 
-        assert str(generated) == dedent(
+        assert dedent(str(generated)) == dedent(
             """\
             @kern1.KND_aaMatra_R = [aaMatra_kannada];
             @kern2.KND_ailength_L = [aaMatra_kannada];
@@ -1202,10 +1193,12 @@ class KernFeatureWriterTest(FeatureWriterTest):
                 script khar;
                 language dflt;
                 lookup kern_Khar;
-                script knda;
+
+                script knd2;
                 language dflt;
                 lookup kern_Knda;
-                script knd2;
+
+                script knda;
                 language dflt;
                 lookup kern_Knda;
             } dist;
@@ -1241,7 +1234,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
         with caplog.at_level(logging.WARNING, logger=logger):
             generated = self.writeFeatures(ufo)
 
-        assert str(generated) == dedent(
+        assert dedent(str(generated)) == dedent(
             """
             lookup kern_Arab {
                 lookupflag IgnoreMarks;
@@ -1264,18 +1257,16 @@ class KernFeatureWriterTest(FeatureWriterTest):
                 script DFLT;
                 language dflt;
                 lookup kern_Common;
-                script latn;
-                language dflt;
-                lookup kern_Latn;
+
                 script arab;
                 language dflt;
+                lookup kern_Common;
                 lookup kern_Arab;
+
                 script latn;
                 language dflt;
                 lookup kern_Common;
-                script arab;
-                language dflt;
-                lookup kern_Common;
+                lookup kern_Latn;
             } kern;
         """
         )
@@ -1293,7 +1284,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
         ufo = makeUFO(FontClass, glyphs, kerning=kerning, features=features)
         generated = self.writeFeatures(ufo)
 
-        assert str(generated) == dedent(
+        assert dedent(str(generated)) == dedent(
             """
             lookup kern_Hebr {
                 lookupflag IgnoreMarks;
@@ -1309,11 +1300,10 @@ class KernFeatureWriterTest(FeatureWriterTest):
                 script DFLT;
                 language dflt;
                 lookup kern_Common;
+
                 script hebr;
                 language dflt;
                 lookup kern_Common;
-                script hebr;
-                language dflt;
                 lookup kern_Hebr;
             } kern;
             """

--- a/tests/featureWriters/kernFeatureWriter_test.py
+++ b/tests/featureWriters/kernFeatureWriter_test.py
@@ -46,7 +46,8 @@ class KernFeatureWriterTest(FeatureWriterTest):
 
     FeatureWriter = KernFeatureWriter
 
-    def test_split_pair(self):
+    def test_split_pair(self, caplog):
+        caplog.set_level(logging.INFO)
         glyphScripts = {
             "V": {"Latn"},
             "W": {"Latn"},
@@ -61,6 +62,10 @@ class KernFeatureWriterTest(FeatureWriterTest):
         split = dict(pair.partitionByScript(glyphScripts))
         assert len(split) == 1
         assert str(split["Latn"]) == "<KerningPair [V W] W -20 {'Latn'}>"
+        assert (
+            "Mixed script kerning pair <KerningPair [V W] gba-nko -20> ignored"
+            in caplog.text
+        )
 
         # Everyone gets common-script glyphs, but they get it per-script
         pair = KerningPair(["V", "gba-nko", "W"], "period", -20)


### PR DESCRIPTION
Currently we split kerning into lookups based on a single factor, horizontal direction. However, shaping engines will perform script segmentation and so there will never be any cross-script kerning. By splitting the kerning into lookups based on the script of the glyphs involved, we can produce smaller lookups for large multi-script fonts, hopefully causing less overflows (faster compilation) and reducing file space by giving the binary compiler a better starting point for splitting lookups into subtables.

There are a few failsafes, such as glyphs without identifiable scripts (as well as purely common-script glyphs) go into a "Common" pot which is added to DFLT/dflt.

This may be easiest to review commit by commit; the changes are fairly small and self-contained apart from f56eaf6 which is the big rewrite.