### PR TITLE
featureWriters.__main__ must load font with ufoLib2.Font.open

### DIFF
--- a/Lib/ufo2ft/featureWriters/__main__.py
+++ b/Lib/ufo2ft/featureWriters/__main__.py
@@ -10,7 +10,7 @@ from ufo2ft.featureWriters import loadFeatureWriterFromString, logger
 try:
     import ufoLib2
 
-    loader = ufoLib2.Font
+    loader = ufoLib2.Font.open
 except ImportError:
     import defcon
 


### PR DESCRIPTION
defcon-like Font(path) doesn't work anymore
https://github.com/googlefonts/fontmake/issues/894#issuecomment-1263640820