### PR TITLE
Revert "Split kerning by script, not by direction (#636)"

### DIFF
--- a/Lib/ufo2ft/constants.py
+++ b/Lib/ufo2ft/constants.py
@@ -38,8 +38,6 @@ OPENTYPE_META_KEY = "public.openTypeMeta"
 
 UNICODE_VARIATION_SEQUENCES_KEY = "public.unicodeVariationSequences"
 
-COMMON_SCRIPT = "Zyyy"
-
 INDIC_SCRIPTS = [
     "Beng",  # Bengali
     "Cham",  # Cham

--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
@@ -1,22 +1,12 @@
-from __future__ import annotations
-
-import itertools
-import logging
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
 from fontTools import unicodedata
 from fontTools.feaLib import ast
 
-from ufo2ft.constants import COMMON_SCRIPT, INDIC_SCRIPTS, USE_SCRIPTS
-from ufo2ft.featureWriters import BaseFeatureWriter
-from ufo2ft.featureWriters.ast import (
-    addLookupReferences,
-    getScriptLanguageSystems,
-    makeGlyphClassDefinitions,
-    makeLookupFlag,
-)
-from ufo2ft.util import DFLT_SCRIPTS, classifyGlyphs, quantize, unicodeScriptDirection
+from ufo2ft.constants import INDIC_SCRIPTS, USE_SCRIPTS
+from ufo2ft.featureWriters import BaseFeatureWriter, ast
+from ufo2ft.util import classifyGlyphs, quantize, unicodeScriptDirection
 
 if TYPE_CHECKING:
     from typing import Iterator, Literal
@@ -52,27 +42,13 @@ def unicodeBidiType(uv: int) -> Literal["R"] | Literal["L"] | None:
 
 class KerningPair:
 
-    __slots__ = ("side1", "side2", "value", "scripts", "directions", "bidiTypes")
+    __slots__ = ("side1", "side2", "value", "directions", "bidiTypes")
 
-    def __init__(
-        self,
-        side1: str | ast.GlyphClassDefinition | list[str] | set[str],
-        side2: str | ast.GlyphClassDefinition | list[str] | set[str],
-        value: float,
-        scripts: set[str] | None = None,
-        directions: set[str] | None = None,
-        bidiTypes: set[str] | None = None,
-    ):
-        self.side1: ast.GlyphName | ast.GlyphClassName | ast.GlyphClass
+    def __init__(self, side1, side2, value, directions=None, bidiTypes=None):
         if isinstance(side1, str):
             self.side1 = ast.GlyphName(side1)
         elif isinstance(side1, ast.GlyphClassDefinition):
             self.side1 = ast.GlyphClassName(side1)
-        elif isinstance(side1, (list, set)):
-            if len(side1) == 1:
-                self.side1 = ast.GlyphName(list(side1)[0])
-            else:
-                self.side1 = ast.GlyphClass([ast.GlyphName(g) for g in sorted(side1)])
         else:
             raise AssertionError(side1)
 
@@ -81,154 +57,42 @@ class KerningPair:
             self.side2 = ast.GlyphName(side2)
         elif isinstance(side2, ast.GlyphClassDefinition):
             self.side2 = ast.GlyphClassName(side2)
-        elif isinstance(side2, (list, set)):
-            if len(side2) == 1:
-                self.side2 = ast.GlyphName(list(side2)[0])
-            else:
-                self.side2 = ast.GlyphClass([ast.GlyphName(g) for g in sorted(side2)])
         else:
             raise AssertionError(side2)
 
-        self.value: float = value
-        self.scripts: set[str] = scripts or set()
-        self.directions: set[str] = directions or set()
-        self.bidiTypes: set[str] = bidiTypes or set()
-
-    # pyright: basic
-    def partitionByScript(
-        self, glyphScripts: dict[str, set[str]]
-    ) -> Iterator[tuple[str, KerningPair]]:
-        """Split a potentially mixed-script pair into pairs that make sense based
-        on the dominant script, and yield each combination with its dominant script."""
-
-        # First, partition the pair by their assigned scripts
-        allFirstScripts: dict[tuple[str, ...], list[str]] = {}
-        allSecondScripts: dict[tuple[str, ...], list[str]] = {}
-        for glyph in self.firstGlyphs:
-            if glyph not in glyphScripts:
-                glyphScripts[glyph] = {COMMON_SCRIPT}
-            allFirstScripts.setdefault(tuple(glyphScripts[glyph]), []).append(glyph)
-        for glyph in self.secondGlyphs:
-            if glyph not in glyphScripts:
-                glyphScripts[glyph] = {COMMON_SCRIPT}
-            allSecondScripts.setdefault(tuple(glyphScripts[glyph]), []).append(glyph)
-
-        # Super common case: both sides are of the same, one script. Nothing to do, emit
-        # self as is.
-        if (
-            len(allFirstScripts.keys()) == 1
-            and allFirstScripts.keys() == allSecondScripts.keys()
-        ):
-            for script in list(allFirstScripts.keys())[0]:
-                yield script, self
-            return
-
-        # Now let's go through the script combinations
-        for firstScripts, secondScripts in itertools.product(
-            allFirstScripts.keys(), allSecondScripts.keys()
-        ):
-            localPair = KerningPair(
-                sorted(allFirstScripts[firstScripts]),
-                sorted(allSecondScripts[secondScripts]),
-                self.value,
-                scripts=self.scripts,
-                directions=self.directions,
-                bidiTypes=self.bidiTypes,
-            )
-            # Handle very obvious common cases: one script, same on both sides
-            if (
-                len(firstScripts) == 1
-                and len(secondScripts) == 1
-                and firstScripts == secondScripts
-            ):
-                localPair.scripts = {firstScripts[0]}
-                yield firstScripts[0], localPair
-            # First is single script, second is common
-            elif len(firstScripts) == 1 and set(secondScripts).issubset(DFLT_SCRIPTS):
-                localPair.scripts = {firstScripts[0]}
-                yield firstScripts[0], localPair
-            # First is common, second is single script
-            elif set(firstScripts).issubset(DFLT_SCRIPTS) and len(secondScripts) == 1:
-                localPair.scripts = {secondScripts[0]}
-                yield secondScripts[0], localPair
-            # One script and it's different on both sides and it's not common
-            elif len(firstScripts) == 1 and len(secondScripts) == 1:
-                logger = ".".join([self.__class__.__module__, self.__class__.__name__])
-                logging.getLogger(logger).info(
-                    "Mixed script kerning pair %s ignored" % localPair
-                )
-                pass
-            else:
-                # At this point, we have a pair which has different sets of
-                # scripts on each side, and we have to find commonalities.
-                # For example, the pair
-                #   [A A-cy] {Latn, Cyrl}  --  [T Te-cy Tau] {Latn, Cyrl, Grek}
-                # must be split into
-                #   A -- T
-                #   A-cy -- Te-cy
-                # and the Tau ignored.
-                commonScripts = set(firstScripts) & set(secondScripts)
-                commonFirstGlyphs = set()
-                commonSecondGlyphs = set()
-                for scripts, glyphs in allFirstScripts.items():
-                    if commonScripts.issubset(set(scripts)):
-                        commonFirstGlyphs |= set(glyphs)
-                for scripts, glyphs in allSecondScripts.items():
-                    if commonScripts.issubset(set(scripts)):
-                        commonSecondGlyphs |= set(glyphs)
-                for common in commonScripts:
-                    localPair = KerningPair(
-                        commonFirstGlyphs,
-                        commonSecondGlyphs,
-                        self.value,
-                        directions=self.directions,
-                        bidiTypes=self.bidiTypes,
-                        scripts={common},
-                    )
-                    yield common, localPair
+        self.value = value
+        self.directions = directions or set()
+        self.bidiTypes = bidiTypes or set()
 
     @property
-    def firstIsClass(self) -> bool:
-        return isinstance(self.side1, (ast.GlyphClassName, ast.GlyphClass))
+    def firstIsClass(self):
+        return isinstance(self.side1, ast.GlyphClassName)
 
     @property
-    def secondIsClass(self) -> bool:
-        return isinstance(self.side2, (ast.GlyphClassName, ast.GlyphClass))
+    def secondIsClass(self):
+        return isinstance(self.side2, ast.GlyphClassName)
 
     @property
-    def firstGlyphs(self) -> set[str]:
+    def glyphs(self):
         if self.firstIsClass:
-            if isinstance(self.side1, ast.GlyphClassName):
-                classDef1 = self.side1.glyphclass
-            else:
-                classDef1 = self.side1
-            return {g.asFea() for g in classDef1.glyphSet()}
+            classDef1 = self.side1.glyphclass
+            glyphs1 = {g.asFea() for g in classDef1.glyphSet()}
         else:
-            return {self.side1.asFea()}
-
-    @property
-    def secondGlyphs(self) -> set[str]:
+            glyphs1 = {self.side1.asFea()}
         if self.secondIsClass:
-            if isinstance(self.side2, ast.GlyphClassName):
-                classDef2 = self.side2.glyphclass
-            else:
-                classDef2 = self.side2
-            return {g.asFea() for g in classDef2.glyphSet()}
+            classDef2 = self.side2.glyphclass
+            glyphs2 = {g.asFea() for g in classDef2.glyphSet()}
         else:
-            return {self.side2.asFea()}
+            glyphs2 = {self.side2.asFea()}
+        return glyphs1 | glyphs2
 
-    @property
-    def glyphs(self) -> set[str]:
-        return self.firstGlyphs | self.secondGlyphs
-
-    def __repr__(self) -> str:
-        return "<{} {} {} {}{}{}{}>".format(
+    def __repr__(self):
+        return "<{} {} {} {}{}{}>".format(
             self.__class__.__name__,
             self.side1,
             self.side2,
             self.value,
             " %r" % self.directions if self.directions else "",
-            " %r" % self.scripts if self.scripts else "",
             " %r" % self.bidiTypes if self.bidiTypes else "",
         )
 
@@ -257,7 +121,7 @@ class KernFeatureWriter(BaseFeatureWriter):
 
         feaScripts = getScriptLanguageSystems(feaFile)
         ctx.scriptGroups = self._groupScriptsByTagAndDirection(feaScripts)
-        ctx.knownScripts = feaScripts.keys()
+
         return ctx
 
     def shouldContinue(self):
@@ -297,7 +161,7 @@ class KernFeatureWriter(BaseFeatureWriter):
 
         lookupGroups = []
         for _, lookupGroup in sorted(lookups.items()):
-            lookupGroups.extend(lookupGroup.values())
+            lookupGroups.extend(lookupGroup)
 
         self._insert(
             feaFile=feaFile,
@@ -431,59 +295,99 @@ class KernFeatureWriter(BaseFeatureWriter):
             enumerated=enumerated,
         )
 
-    def _makeKerningLookup(self, name, ignoreMarks=True):
-        lookup = ast.LookupBlock(name)
-        if ignoreMarks and self.options.ignoreMarks:
-            lookup.statements.append(makeLookupFlag("IgnoreMarks"))
-        return lookup
+    def _makeKerningLookup(
+        self, name, pairs, exclude=None, rtl=False, ignoreMarks=True
+    ):
+        assert pairs
+        rules = []
+        for pair in pairs:
+            if exclude is not None and exclude(pair):
+                self.log.debug("pair excluded from '%s' lookup: %r", name, pair)
+                continue
+            rules.append(
+                self._makePairPosRule(
+                    pair, rtl=rtl, quantization=self.options.quantization
+                )
+            )
 
-    def _addPairToLookup(self, lookup, pair, rtl=False):
-        lookup.statements.append(
-            self._makePairPosRule(pair, rtl=rtl, quantization=self.options.quantization)
-        )
-
-    def knownScriptsPerCodepoint(self, uv):
-        if not self.context.knownScripts:
-            # If there are no languagesystems, consider everything common;
-            # it'll all end in DFLT/dflt anyway
-            return COMMON_SCRIPT
-        return [
-            x
-            for x in unicodedata.script_extension(chr(uv))
-            if x in self.context.knownScripts or x in DFLT_SCRIPTS
-        ]
+        if rules:
+            lookup = ast.LookupBlock(name)
+            if ignoreMarks and self.options.ignoreMarks:
+                lookup.statements.append(ast.makeLookupFlag("IgnoreMarks"))
+            lookup.statements.extend(rules)
+            return lookup
 
     def _makeKerningLookups(self):
+        cmap = self.makeUnicodeToGlyphNameMapping()
+        if any(unicodeScriptDirection(uv) == "RTL" for uv in cmap):
+            # If there are any characters from globally RTL scripts in the
+            # cmap, we compile a temporary GSUB table to resolve substitutions
+            # and group glyphs by script horizontal direction and bidirectional
+            # type. We then mark each kerning pair with these properties when
+            # any of the glyphs involved in a pair intersects these groups.
+            gsub = self.compileGSUB()
+            dirGlyphs = classifyGlyphs(unicodeScriptDirection, cmap, gsub)
+            directions = self._intersectPairs("directions", dirGlyphs)
+            shouldSplit = "RTL" in directions
+            if shouldSplit:
+                bidiGlyphs = classifyGlyphs(unicodeBidiType, cmap, gsub)
+                self._intersectPairs("bidiTypes", bidiGlyphs)
+        else:
+            shouldSplit = False
+
         marks = self.context.gdefClasses.mark
         lookups = {}
-        cmap = self.makeUnicodeToGlyphNameMapping()
-        gsub = self.compileGSUB()
-        dirGlyphs = classifyGlyphs(unicodeScriptDirection, cmap, gsub)
-        self._intersectPairs("directions", dirGlyphs)
+        if shouldSplit:
+            # make one DFLT lookup with script-agnostic characters, and two
+            # LTR/RTL lookups excluding pairs from the opposite group.
+            # We drop kerning pairs with ambiguous direction: i.e. those containing
+            # glyphs from scripts with different overall horizontal direction, or
+            # glyphs with incompatible bidirectional type (e.g. arabic letters vs
+            # arabic numerals).
+            pairs = []
+            for pair in self.context.kerning.pairs:
+                if ("RTL" in pair.directions and "LTR" in pair.directions) or (
+                    "R" in pair.bidiTypes and "L" in pair.bidiTypes
+                ):
+                    self.log.warning(
+                        "skipped kern pair with ambiguous direction: %r", pair
+                    )
+                    continue
+                pairs.append(pair)
+            if not pairs:
+                return lookups
 
-        scriptGlyphs = classifyGlyphs(self.knownScriptsPerCodepoint, cmap, gsub)
-        self._intersectPairs("scripts", scriptGlyphs)
-        bidiGlyphs = classifyGlyphs(unicodeBidiType, cmap, gsub)
-        self._intersectPairs("bidiTypes", bidiGlyphs)
-        pairs = self.context.kerning.pairs
-
-        glyphScripts = {}
-        for script, glyphs in scriptGlyphs.items():
-            for g in glyphs:
-                glyphScripts.setdefault(g, set()).add(script)
-
-        if self.options.ignoreMarks:
-            basePairs, markPairs = self._splitBaseAndMarkPairs(
-                self.context.kerning.pairs, marks
-            )
-            if basePairs:
-                self._makeSplitScriptKernLookups(lookups, basePairs, glyphScripts)
-            if markPairs:
-                self._makeSplitScriptKernLookups(
-                    lookups, markPairs, glyphScripts, ignoreMarks=False, suffix="_marks"
-                )
+            if self.options.ignoreMarks:
+                # If there are pairs with a mix of mark/base then the IgnoreMarks
+                # flag is unnecessary and should not be set
+                basePairs, markPairs = self._splitBaseAndMarkPairs(pairs, marks)
+                if basePairs:
+                    self._makeSplitDirectionKernLookups(lookups, basePairs)
+                if markPairs:
+                    self._makeSplitDirectionKernLookups(
+                        lookups, markPairs, ignoreMarks=False, suffix="_marks"
+                    )
+            else:
+                self._makeSplitDirectionKernLookups(lookups, pairs)
         else:
-            self._makeSplitScriptKernLookups(lookups, pairs, glyphScripts)
+            # only make a single (implicitly LTR) lookup including all base/base pairs
+            # and a single lookup including all base/mark pairs (if any)
+            pairs = self.context.kerning.pairs
+            if self.options.ignoreMarks:
+                basePairs, markPairs = self._splitBaseAndMarkPairs(pairs, marks)
+                lookups["LTR"] = []
+                if basePairs:
+                    lookups["LTR"].append(
+                        self._makeKerningLookup("kern_ltr", basePairs)
+                    )
+                if markPairs:
+                    lookups["LTR"].append(
+                        self._makeKerningLookup(
+                            "kern_ltr_marks", markPairs, ignoreMarks=False
+                        )
+                    )
+            else:
+                lookups["LTR"] = [self._makeKerningLookup("kern_ltr", pairs)]
         return lookups
 
     def _splitBaseAndMarkPairs(self, pairs, marks):
@@ -498,68 +402,111 @@ class KernFeatureWriter(BaseFeatureWriter):
             basePairs[:] = pairs
         return basePairs, markPairs
 
-    def _makeSplitScriptKernLookups(
-        self, lookups, pairs, glyphScripts, ignoreMarks=True, suffix=""
+    def _makeSplitDirectionKernLookups(
+        self, lookups, pairs, ignoreMarks=True, suffix=""
     ):
-        for pair in pairs:
-            for script, splitpair in pair.partitionByScript(glyphScripts):
-                key = "kern_" + script + suffix
-                script_lookups = lookups.setdefault(script, {})
-                lookup = script_lookups.get(key)
-                if not lookup:
-                    lookup = self._makeKerningLookup(
-                        key.replace(COMMON_SCRIPT, "Common"),  # For neatness
-                        ignoreMarks=ignoreMarks,
-                    )
-                    script_lookups[key] = lookup
-                self._addPairToLookup(lookup, splitpair, rtl="RTL" in pair.directions)
+        dfltKern = self._makeKerningLookup(
+            "kern_dflt" + suffix,
+            pairs,
+            exclude=(lambda pair: {"LTR", "RTL"}.intersection(pair.directions)),
+            rtl=False,
+            ignoreMarks=ignoreMarks,
+        )
+        if dfltKern:
+            lookups.setdefault("DFLT", []).append(dfltKern)
+
+        ltrKern = self._makeKerningLookup(
+            "kern_ltr" + suffix,
+            pairs,
+            exclude=(lambda pair: not pair.directions or "RTL" in pair.directions),
+            rtl=False,
+            ignoreMarks=ignoreMarks,
+        )
+        if ltrKern:
+            lookups.setdefault("LTR", []).append(ltrKern)
+
+        rtlKern = self._makeKerningLookup(
+            "kern_rtl" + suffix,
+            pairs,
+            exclude=(lambda pair: not pair.directions or "LTR" in pair.directions),
+            rtl=True,
+            ignoreMarks=ignoreMarks,
+        )
+        if rtlKern:
+            lookups.setdefault("RTL", []).append(rtlKern)
 
     def _makeFeatureBlocks(self, lookups):
         features = {}
         if "kern" in self.context.todo:
             kern = ast.FeatureBlock("kern")
-            self._registerLookups(kern, lookups)
+            self._registerKernLookups(kern, lookups)
             if kern.statements:
                 features["kern"] = kern
         if "dist" in self.context.todo:
             dist = ast.FeatureBlock("dist")
-            self._registerLookups(dist, lookups)
+            self._registerDistLookups(dist, lookups)
             if dist.statements:
                 features["dist"] = dist
         return features
 
-    def _registerLookups(self, feature, lookups):
+    def _registerKernLookups(self, feature, lookups):
+        if "DFLT" in lookups:
+            ast.addLookupReferences(feature, lookups["DFLT"])
+
         scriptGroups = self.context.scriptGroups
-        scripts = scriptGroups.get(feature.name, {})
+        if "dist" in self.context.todo:
+            distScripts = scriptGroups["dist"]
+        else:
+            distScripts = {}
+        kernScripts = scriptGroups.get("kern", {})
+        ltrScripts = kernScripts.get("LTR", [])
+        rtlScripts = kernScripts.get("RTL", [])
 
-        # Ensure we have kerning for pure common script runs (e.g. ">1")
-        if feature.name == "kern" and COMMON_SCRIPT in lookups:
-            addLookupReferences(
-                feature, lookups[COMMON_SCRIPT].values(), "DFLT", ["dflt"]
-            )
-        if not scripts:
-            return
+        ltrLookups = lookups.get("LTR")
+        rtlLookups = lookups.get("RTL")
+        if ltrLookups and rtlLookups:
+            if ltrScripts and rtlScripts:
+                for script, langs in ltrScripts:
+                    ast.addLookupReferences(feature, ltrLookups, script, langs)
+                for script, langs in rtlScripts:
+                    ast.addLookupReferences(feature, rtlLookups, script, langs)
+            elif ltrScripts:
+                ast.addLookupReferences(feature, rtlLookups, script="DFLT")
+                for script, langs in ltrScripts:
+                    ast.addLookupReferences(feature, ltrLookups, script, langs)
+            elif rtlScripts:
+                ast.addLookupReferences(feature, ltrLookups, script="DFLT")
+                for script, langs in rtlScripts:
+                    ast.addLookupReferences(feature, rtlLookups, script, langs)
+            else:
+                if not (distScripts.get("LTR") and distScripts.get("RTL")):
+                    raise ValueError(
+                        "cannot use DFLT script for both LTR and RTL kern "
+                        "lookups; add 'languagesystems' to features for at "
+                        "least one LTR or RTL script using the kern feature"
+                    )
+        elif ltrLookups:
+            if not (rtlScripts or distScripts):
+                ast.addLookupReferences(feature, ltrLookups)
+            else:
+                ast.addLookupReferences(feature, ltrLookups, script="DFLT")
+                for script, langs in ltrScripts:
+                    ast.addLookupReferences(feature, ltrLookups, script, langs)
+        elif rtlLookups:
+            if not (ltrScripts or distScripts):
+                ast.addLookupReferences(feature, rtlLookups)
+            else:
+                ast.addLookupReferences(feature, rtlLookups, script="DFLT")
+                for script, langs in rtlScripts:
+                    ast.addLookupReferences(feature, rtlLookups, script, langs)
 
-        # Collapse scripts
-        scripts = scripts.get("LTR", []) + scripts.get("RTL", [])
-        otscript2uniscript = {}
-        for uniscript in lookups.keys():
-            for ot2script in unicodedata.ot_tags_from_script(uniscript):
-                otscript2uniscript[ot2script] = uniscript
-
-        for script, langs in sorted(scripts):
-            if script not in otscript2uniscript:
-                continue
-            uniscript = otscript2uniscript[script]
-            lookups_for_this_script = []
-            if uniscript not in lookups:
-                continue
-            if feature.statements:
-                feature.statements.append(ast.Comment(""))
-            # We have something for this script. First add the default
-            # lookups, then the script-specific ones
-            for dflt_script in DFLT_SCRIPTS:
-                if dflt_script in lookups:
-                    lookups_for_this_script.extend(lookups[dflt_script].values())
-            lookups_for_this_script.extend(lookups[uniscript].values())
-            addLookupReferences(feature, lookups_for_this_script, script, langs)
+    def _registerDistLookups(self, feature, lookups):
+        scripts = self.context.scriptGroups["dist"]
+        ltrLookups = lookups.get("LTR")
+        if ltrLookups:
+            for script, langs in scripts.get("LTR", []):
+                ast.addLookupReferences(feature, ltrLookups, script, langs)
+        rtlLookups = lookups.get("RTL")
+        if rtlLookups:
+            for script, langs in scripts.get("RTL", []):
+                ast.addLookupReferences(feature, rtlLookups, script, langs)

--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
@@ -16,7 +16,7 @@ SIDE2_PREFIX = "public.kern2."
 #   src/hb-ot-shape-complex-khmer.cc
 # We derived the list of scripts associated to each dist-enabled shaper from
 # `hb_ot_shape_complex_categorize` in src/hb-ot-shape-complex-private.hh
-DIST_ENABLED_SCRIPTS = set(INDIC_SCRIPTS) | {"Khmr", "Mymr"} | set(USE_SCRIPTS)
+DIST_ENABLED_SCRIPTS = set(INDIC_SCRIPTS) | set(["Khmr", "Mymr"]) | set(USE_SCRIPTS)
 
 RTL_BIDI_TYPES = {"R", "AL"}
 LTR_BIDI_TYPES = {"L", "AN", "EN"}

--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
@@ -1,15 +1,10 @@
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
 
 from fontTools import unicodedata
-from fontTools.feaLib import ast
 
 from ufo2ft.constants import INDIC_SCRIPTS, USE_SCRIPTS
 from ufo2ft.featureWriters import BaseFeatureWriter, ast
 from ufo2ft.util import classifyGlyphs, quantize, unicodeScriptDirection
-
-if TYPE_CHECKING:
-    from typing import Iterator, Literal
 
 SIDE1_PREFIX = "public.kern1."
 SIDE2_PREFIX = "public.kern2."
@@ -27,7 +22,7 @@ RTL_BIDI_TYPES = {"R", "AL"}
 LTR_BIDI_TYPES = {"L", "AN", "EN"}
 
 
-def unicodeBidiType(uv: int) -> Literal["R"] | Literal["L"] | None:
+def unicodeBidiType(uv):
     """Return "R" for characters with RTL direction, or "L" for LTR (whether
     'strong' or 'weak'), or None for neutral direction.
     """
@@ -37,7 +32,8 @@ def unicodeBidiType(uv: int) -> Literal["R"] | Literal["L"] | None:
         return "R"
     elif bidiType in LTR_BIDI_TYPES:
         return "L"
-    return None
+    else:
+        return None
 
 
 class KerningPair:
@@ -52,7 +48,6 @@ class KerningPair:
         else:
             raise AssertionError(side1)
 
-        self.side2: ast.GlyphName | ast.GlyphClassName | ast.GlyphClass
         if isinstance(side2, str):
             self.side2 = ast.GlyphName(side2)
         elif isinstance(side2, ast.GlyphClassDefinition):
@@ -119,7 +114,7 @@ class KernFeatureWriter(BaseFeatureWriter):
         ctx.gdefClasses = self.getGDEFGlyphClasses()
         ctx.kerning = self.getKerningData(font, feaFile, self.getOrderedGlyphSet())
 
-        feaScripts = getScriptLanguageSystems(feaFile)
+        feaScripts = ast.getScriptLanguageSystems(feaFile)
         ctx.scriptGroups = self._groupScriptsByTagAndDirection(feaScripts)
 
         return ctx
@@ -203,10 +198,10 @@ class KernFeatureWriter(BaseFeatureWriter):
     @classmethod
     def getKerningClasses(cls, font, feaFile=None, glyphSet=None):
         side1Groups, side2Groups = cls.getKerningGroups(font, glyphSet)
-        side1Classes = makeGlyphClassDefinitions(
+        side1Classes = ast.makeGlyphClassDefinitions(
             side1Groups, feaFile, stripPrefix="public."
         )
-        side2Classes = makeGlyphClassDefinitions(
+        side2Classes = ast.makeGlyphClassDefinitions(
             side2Groups, feaFile, stripPrefix="public."
         )
         return side1Classes, side2Classes

--- a/Lib/ufo2ft/util.py
+++ b/Lib/ufo2ft/util.py
@@ -281,12 +281,12 @@ def closeGlyphsOverGSUB(gsub, glyphs):
 
 def classifyGlyphs(unicodeFunc, cmap, gsub=None):
     """'unicodeFunc' is a callable that takes a Unicode codepoint and
-    returns a string, or collection of strings, denoting some Unicode
-    property associated with the given character (or None if a character
-    is considered 'neutral'). 'cmap' is a dictionary mapping Unicode
-    codepoints to glyph names. 'gsub' is an (optional) fonttools GSUB
-    table object, used to find all the glyphs that are "reachable" via
-    substitutions from the initial sets of glyphs defined in the cmap.
+    returns a string denoting some Unicode property associated with the
+    given character (or None if a character is considered 'neutral').
+    'cmap' is a dictionary mapping Unicode codepoints to glyph names.
+    'gsub' is an (optional) fonttools GSUB table object, used to find all
+    the glyphs that are "reachable" via substitutions from the initial
+    sets of glyphs defined in the cmap.
 
     Returns a dictionary of glyph sets associated with the given Unicode
     properties.
@@ -294,14 +294,11 @@ def classifyGlyphs(unicodeFunc, cmap, gsub=None):
     glyphSets = {}
     neutralGlyphs = set()
     for uv, glyphName in cmap.items():
-        key_or_keys = unicodeFunc(uv)
-        if key_or_keys is None:
+        key = unicodeFunc(uv)
+        if key is None:
             neutralGlyphs.add(glyphName)
-        elif isinstance(key_or_keys, (list, set)):
-            for key in key_or_keys:
-                glyphSets.setdefault(key, set()).add(glyphName)
         else:
-            glyphSets.setdefault(key_or_keys, set()).add(glyphName)
+            glyphSets.setdefault(key, set()).add(glyphName)
 
     if gsub is not None:
         if neutralGlyphs:

--- a/tests/featureCompiler_test.py
+++ b/tests/featureCompiler_test.py
@@ -231,11 +231,7 @@ class FeatureCompilerTest:
                 foo = ast.FeatureBlock("FOO ")
                 foo.statements.append(
                     ast.SingleSubstStatement(
-                        [ast.GlyphName("a")],
-                        [ast.GlyphName("v")],
-                        prefix="",
-                        suffix="",
-                        forceChain=None,
+                        "a", "v", prefix="", suffix="", forceChain=None
                     )
                 )
                 feaFile.statements.append(foo)

--- a/tests/featureCompiler_test.py
+++ b/tests/featureCompiler_test.py
@@ -327,15 +327,13 @@ class FeatureCompilerTest:
             } liga;
 
 
-            lookup kern_Common {
+            lookup kern_ltr {
                 lookupflag IgnoreMarks;
                 pos a v -40;
-            } kern_Common;
+            } kern_ltr;
 
             feature kern {
-                script DFLT;
-                language dflt;
-                lookup kern_Common;
+                lookup kern_ltr;
             } kern;
             """
         )


### PR DESCRIPTION
This reverts commit bdac61e1e0c347a64ad2cee7d5de725ae9817c00.

We need to test it more thoroughly first.