### PR TITLE
[FlattenComponents] Don't throw weird errors when components are missing

### DIFF
--- a/Lib/ufo2ft/filters/flattenComponents.py
+++ b/Lib/ufo2ft/filters/flattenComponents.py
@@ -21,7 +21,11 @@ class FlattenComponentsFilter(BaseFilter):
             return flattened
         pen = glyph.getPen()
         for comp in list(glyph.components):
-            flattened_tuples = _flattenComponent(self.context.glyphSet, comp)
+            flattened_tuples = _flattenComponent(
+                self.context.glyphSet, comp, found_in=glyph
+            )
+            if not flattened_tuples:
+                continue
             if flattened_tuples[0] != (comp.baseGlyph, comp.transformation):
                 flattened = True
             glyph.removeComponent(comp)
@@ -32,8 +36,14 @@ class FlattenComponentsFilter(BaseFilter):
         return flattened
 
 
-def _flattenComponent(glyphSet, component):
+def _flattenComponent(glyphSet, component, found_in):
     """Returns a list of tuples (baseGlyph, transform) of nested component."""
+    if component.baseGlyph not in glyphSet:
+        logger.warning(
+            "Could not find component '%s' used in '%s'"
+            % (component.baseGlyph, found_in.name)
+        )
+        return []
 
     glyph = glyphSet[component.baseGlyph]
     # Any contour will cause components to be decomposed
@@ -43,7 +53,7 @@ def _flattenComponent(glyphSet, component):
 
     all_flattened_components = []
     for nested in glyph.components:
-        flattened_components = _flattenComponent(glyphSet, nested)
+        flattened_components = _flattenComponent(glyphSet, nested, found_in=glyph)
         for i, (name, tr) in enumerate(flattened_components):
             flat_tr = Transform(*component.transformation)
             flat_tr = flat_tr.translate(tr.dx, tr.dy)

--- a/Lib/ufo2ft/filters/flattenComponents.py
+++ b/Lib/ufo2ft/filters/flattenComponents.py
@@ -24,8 +24,6 @@ class FlattenComponentsFilter(BaseFilter):
             flattened_tuples = _flattenComponent(
                 self.context.glyphSet, comp, found_in=glyph
             )
-            if not flattened_tuples:
-                continue
             if flattened_tuples[0] != (comp.baseGlyph, comp.transformation):
                 flattened = True
             glyph.removeComponent(comp)
@@ -39,11 +37,10 @@ class FlattenComponentsFilter(BaseFilter):
 def _flattenComponent(glyphSet, component, found_in):
     """Returns a list of tuples (baseGlyph, transform) of nested component."""
     if component.baseGlyph not in glyphSet:
-        logger.warning(
+        raise ValueError(
             "Could not find component '%s' used in '%s'"
             % (component.baseGlyph, found_in.name)
         )
-        return []
 
     glyph = glyphSet[component.baseGlyph]
     # Any contour will cause components to be decomposed

--- a/Lib/ufo2ft/filters/flattenComponents.py
+++ b/Lib/ufo2ft/filters/flattenComponents.py
@@ -38,8 +38,7 @@ def _flattenComponent(glyphSet, component, found_in):
     """Returns a list of tuples (baseGlyph, transform) of nested component."""
     if component.baseGlyph not in glyphSet:
         raise ValueError(
-            "Could not find component '%s' used in '%s'"
-            % (component.baseGlyph, found_in.name)
+            f"Could not find component '{component.baseGlyph}' used in '{found_in.name}'"
         )
 
     glyph = glyphSet[component.baseGlyph]


### PR DESCRIPTION
If I use fontmake on a Glyphs file which contains components with missing base glyphs, I get errors like this:

```
INFO:ufo2ft.filters:Running FlattenComponentsFilter on GoogleSans_Persian-Regular
fontmake: Error: In 'master_ufo/XXX-Regular.designspace': Generating fonts from Designspace failed: 'flig2'
```

(Side note: there are many cases where fontmake eats the original exception like this, and produces weird and inscrutable errors. We should hunt down all of them.)

With this PR, the font compiles with warnings:

```
WARNING:ufo2ft.filters.flattenComponents:Could not find component 'flig2' used in 'f_f'
```