### PR TITLE
Improve mark writer for character used in multiple scripts

### DIFF
--- a/tests/featureWriters/markFeatureWriter_test.py
+++ b/tests/featureWriters/markFeatureWriter_test.py
@@ -887,6 +887,15 @@ class MarkFeatureWriterTest(FeatureWriterTest):
                 } blwm_mark2base;
 
             } blwm;
+
+            feature mark {
+                lookup mark2base {
+                    pos base kashida-ar
+                        <anchor 100 -100> mark @MC_bottom
+                        <anchor 100 100> mark @MC_top;
+                } mark2base;
+
+            } mark;
             """  # noqa: B950
         )
 

--- a/tests/featureWriters/markFeatureWriter_test.py
+++ b/tests/featureWriters/markFeatureWriter_test.py
@@ -824,6 +824,86 @@ class MarkFeatureWriterTest(FeatureWriterTest):
             """  # noqa: B950
         )
 
+    def test_shared_script_char(self, FontClass):
+        ufo = FontClass()
+        ufo.info.unitsPerEm = 1000
+
+        dottedCircle = ufo.newGlyph("kashida-ar")
+        dottedCircle.unicode = 0x0640
+        dottedCircle.anchors = [
+            {"name": "top", "x": 100, "y": 100},
+            {"name": "bottom", "x": 100, "y": -100},
+        ]
+
+        nukta = ufo.newGlyph("fatha-ar")
+        nukta.unicode = 0x064E
+        nukta.appendAnchor({"name": "_top", "x": 0, "y": 0})
+
+        nukta = ufo.newGlyph("kasra-ar")
+        nukta.unicode = 0x0650
+        nukta.appendAnchor({"name": "_bottom", "x": 0, "y": 547})
+
+        ufo.features.text = dedent(
+            """\
+            languagesystem DFLT dflt;
+            languagesystem arab dflt;
+            """
+        )
+        generated = self.writeFeatures(ufo)
+
+        assert str(generated) == dedent(
+            """\
+            markClass kasra-ar <anchor 0 547> @MC_bottom;
+            markClass fatha-ar <anchor 0 0> @MC_top;
+
+            feature mark {
+                lookup mark2base {
+                    pos base kashida-ar
+                        <anchor 100 -100> mark @MC_bottom
+                        <anchor 100 100> mark @MC_top;
+                } mark2base;
+
+            } mark;
+            """  # noqa: B950
+        )
+
+        expected = dedent(
+            """\
+            markClass kasra-ar <anchor 0 547> @MC_bottom;
+            markClass fatha-ar <anchor 0 0> @MC_top;
+
+            feature abvm {
+                lookup abvm_mark2base {
+                    pos base kashida-ar
+                        <anchor 100 100> mark @MC_top;
+                } abvm_mark2base;
+
+            } abvm;
+
+            feature blwm {
+                lookup blwm_mark2base {
+                    pos base kashida-ar
+                        <anchor 100 -100> mark @MC_bottom;
+                } blwm_mark2base;
+
+            } blwm;
+            """  # noqa: B950
+        )
+
+        ufo.features.text = ""
+        generated = self.writeFeatures(ufo)
+        assert str(generated) == expected
+
+        ufo.features.text = dedent(
+            """\
+            languagesystem DFLT dflt;
+            languagesystem arab dflt;
+            languagesystem adlm dflt;
+            """
+        )
+        generated = self.writeFeatures(ufo)
+        assert str(generated) == expected
+
     def test_all_features(self, testufo):
         ufo = testufo
         ufo.info.unitsPerEm = 1000
@@ -889,6 +969,12 @@ class MarkFeatureWriterTest(FeatureWriterTest):
             "foo_bar_baz",
             "bar_foo",
         ]
+        ufo.features.text = dedent(
+            """\
+            languagesystem DFLT dflt;
+            languagesystem taml dflt;
+            """
+        )
         generated = self.writeFeatures(testufo)
 
         assert str(generated) == dedent(


### PR DESCRIPTION
If a character is used in multiple scripts, and on of these scripts uses e.g. USE shaper, the mark writer will write its anchors in abvm/blwm features exclusively. This breaks the mark attachment if the shaper of the indented script does not enable abvm/blwm features.

This is a partial fix, by looking into the language systems declared in the feature file and filtering out abvm scripts not in them.

Part of https://github.com/googlefonts/ufo2ft/issues/579