### PR TITLE
Bucketize Hiragana and Katakana for kern writing purposes

### DIFF
--- a/Lib/ufo2ft/constants.py
+++ b/Lib/ufo2ft/constants.py
@@ -1,3 +1,5 @@
+from types import MappingProxyType
+
 SPARSE_TTF_MASTER_TABLES = frozenset(
     ["glyf", "head", "hmtx", "loca", "maxp", "post", "vmtx"]
 )
@@ -40,7 +42,7 @@ UNICODE_VARIATION_SEQUENCES_KEY = "public.unicodeVariationSequences"
 
 COMMON_SCRIPT = "Zyyy"
 
-UNICODE_SCRIPT_ALIASES = {"Hira": "Hrkt", "Kana": "Hrkt"}
+UNICODE_SCRIPT_ALIASES = MappingProxyType({"Hira": "Hrkt", "Kana": "Hrkt"})
 
 INDIC_SCRIPTS = [
     "Beng",  # Bengali

--- a/Lib/ufo2ft/constants.py
+++ b/Lib/ufo2ft/constants.py
@@ -40,6 +40,8 @@ UNICODE_VARIATION_SEQUENCES_KEY = "public.unicodeVariationSequences"
 
 COMMON_SCRIPT = "Zyyy"
 
+HIRAGANA_KATAKANA_SCRIPTS = {"Hira", "Kana"}
+
 INDIC_SCRIPTS = [
     "Beng",  # Bengali
     "Cham",  # Cham

--- a/Lib/ufo2ft/constants.py
+++ b/Lib/ufo2ft/constants.py
@@ -40,7 +40,7 @@ UNICODE_VARIATION_SEQUENCES_KEY = "public.unicodeVariationSequences"
 
 COMMON_SCRIPT = "Zyyy"
 
-HIRAGANA_KATAKANA_SCRIPTS = {"Hira", "Kana"}
+UNICODE_SCRIPT_ALIASES = {"Hira": "Hrkt", "Kana": "Hrkt"}
 
 INDIC_SCRIPTS = [
     "Beng",  # Bengali

--- a/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 from ufo2ft.constants import OPENTYPE_CATEGORIES_KEY
 from ufo2ft.errors import InvalidFeaturesData
 from ufo2ft.featureWriters import ast
-from ufo2ft.util import bucketizedScriptExtensions
+from ufo2ft.util import unicodeScriptExtensions
 
 INSERT_FEATURE_MARKER = r"\s*# Automatic Code.*"
 
@@ -413,7 +413,7 @@ class BaseFeatureWriter:
             if glyph.name not in glyphSet or glyph.unicodes is None:
                 continue
             for codepoint in glyph.unicodes:
-                scripts = bucketizedScriptExtensions(codepoint)
+                scripts = unicodeScriptExtensions(codepoint)
                 if len(scripts) == 1:
                     single_scripts.update(scripts)
 

--- a/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
@@ -2,11 +2,10 @@ import logging
 from collections import OrderedDict, namedtuple
 from types import SimpleNamespace
 
-from fontTools import unicodedata
-
 from ufo2ft.constants import OPENTYPE_CATEGORIES_KEY
 from ufo2ft.errors import InvalidFeaturesData
 from ufo2ft.featureWriters import ast
+from ufo2ft.util import bucketizedScriptExtensions
 
 INSERT_FEATURE_MARKER = r"\s*# Automatic Code.*"
 
@@ -414,7 +413,7 @@ class BaseFeatureWriter:
             if glyph.name not in glyphSet or glyph.unicodes is None:
                 continue
             for codepoint in glyph.unicodes:
-                scripts = unicodedata.script_extension(chr(codepoint))
+                scripts = bucketizedScriptExtensions(codepoint)
                 if len(scripts) == 1:
                     single_scripts.update(scripts)
 

--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
@@ -11,7 +11,12 @@ from fontTools.unicodedata import script_horizontal_direction
 
 from ufo2ft.constants import COMMON_SCRIPT, INDIC_SCRIPTS, USE_SCRIPTS
 from ufo2ft.featureWriters import BaseFeatureWriter, ast
-from ufo2ft.util import DFLT_SCRIPTS, classifyGlyphs, quantize
+from ufo2ft.util import (
+    DFLT_SCRIPTS,
+    bucketizedScriptExtensions,
+    classifyGlyphs,
+    quantize,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -357,7 +362,7 @@ class KernFeatureWriter(BaseFeatureWriter):
             # anyway.
             return {COMMON_SCRIPT}
         else:
-            script_extension = unicodedata.script_extension(chr(uv))
+            script_extension = bucketizedScriptExtensions(uv)
             return script_extension & (self.context.knownScripts | DFLT_SCRIPTS)
 
     def _makeKerningLookups(self):

--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
@@ -135,6 +135,9 @@ class KernFeatureWriter(BaseFeatureWriter):
           pairs that would mix RTL and LTR glyphs, which will not occur in
           applications. Unicode BiDi classes L, AN and EN are considered L, R
           and AL are considered R.
+    * Note: the glyph script determination has the quirk of declaring "Hira" and
+      "Kana" scripts as "Hrkt" so that they are considered one script and can be
+      kerned against each other.
     * Get the kerning groups from the UFO and filter out glyphs not in the
       glyphset and empty groups. Remember which group a glyph is a member of,
       for kern1 and kern2, so we can later reconstruct per-script groups.

--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
@@ -11,12 +11,7 @@ from fontTools.unicodedata import script_horizontal_direction
 
 from ufo2ft.constants import COMMON_SCRIPT, INDIC_SCRIPTS, USE_SCRIPTS
 from ufo2ft.featureWriters import BaseFeatureWriter, ast
-from ufo2ft.util import (
-    DFLT_SCRIPTS,
-    bucketizedScriptExtensions,
-    classifyGlyphs,
-    quantize,
-)
+from ufo2ft.util import DFLT_SCRIPTS, classifyGlyphs, quantize, unicodeScriptExtensions
 
 LOGGER = logging.getLogger(__name__)
 
@@ -365,7 +360,7 @@ class KernFeatureWriter(BaseFeatureWriter):
             # anyway.
             return {COMMON_SCRIPT}
         else:
-            script_extension = bucketizedScriptExtensions(uv)
+            script_extension = unicodeScriptExtensions(uv)
             return script_extension & (self.context.knownScripts | DFLT_SCRIPTS)
 
     def _makeKerningLookups(self):

--- a/Lib/ufo2ft/featureWriters/markFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/markFeatureWriter.py
@@ -4,11 +4,15 @@ from collections import OrderedDict, defaultdict
 from functools import partial
 
 from fontTools.misc.fixedTools import otRound
-from fontTools.unicodedata import script_extension
 
 from ufo2ft.constants import INDIC_SCRIPTS, USE_SCRIPTS
 from ufo2ft.featureWriters import BaseFeatureWriter, ast
-from ufo2ft.util import classifyGlyphs, quantize, unicodeInScripts
+from ufo2ft.util import (
+    classifyGlyphs,
+    quantize,
+    unicodeInScripts,
+    unicodeScriptExtensions,
+)
 
 
 class AbstractMarkPos:
@@ -867,7 +871,7 @@ class MarkFeatureWriter(BaseFeatureWriter):
             unicodeIsAbvm = partial(unicodeInScripts, scripts=scriptsUsingAbvm)
 
             def unicodeIsNotAbvm(uv):
-                return bool(script_extension(chr(uv)) - self.scriptsUsingAbvm)
+                return bool(unicodeScriptExtensions(uv) - self.scriptsUsingAbvm)
 
             if any(unicodeIsAbvm(uv) for uv in cmap):
                 # If there are any characters from Indic/USE/Khmer scripts in

--- a/Lib/ufo2ft/util.py
+++ b/Lib/ufo2ft/util.py
@@ -602,7 +602,7 @@ def getMaxComponentDepth(glyph, glyphSet, maxComponentDepth=0):
 
 
 def unicodeScriptExtensions(
-    codepoint: int, aliases: Mapping[str, str] | None = None
+    codepoint: int, aliases: Mapping[str, str] = UNICODE_SCRIPT_ALIASES
 ) -> set[str]:
     """Returns the Unicode script extensions for a codepoint, optionally
     aliasing some scripts.
@@ -611,6 +611,4 @@ def unicodeScriptExtensions(
     is being able to kern Hiragana and Katakana against each other, Unicode
     defines "Hrkt" as an alias for both scripts.
     """
-    if aliases is None:
-        aliases = UNICODE_SCRIPT_ALIASES
     return {aliases.get(s, s) for s in unicodedata.script_extension(chr(codepoint))}

--- a/Lib/ufo2ft/util.py
+++ b/Lib/ufo2ft/util.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import importlib
 import logging
 import re
@@ -12,6 +14,8 @@ from fontTools.misc.fixedTools import otRound
 from fontTools.misc.transform import Identity, Transform
 from fontTools.pens.reverseContourPen import ReverseContourPen
 from fontTools.pens.transformPen import TransformPen
+
+from ufo2ft.constants import HIRAGANA_KATAKANA_SCRIPTS
 
 logger = logging.getLogger(__name__)
 
@@ -595,3 +599,18 @@ def getMaxComponentDepth(glyph, glyphSet, maxComponentDepth=0):
         maxComponentDepth = max(maxComponentDepth, componentDepth)
 
     return maxComponentDepth
+
+
+def bucketizedScriptExtensions(codepoint: int) -> set[str]:
+    """Returns the Unicode script extensions for a codepoint, combining some
+    scripts into the same bucket.
+
+    This allows lookups to contain more than one script. The most prominent case
+    is being able to kern Hiragana and Katakana against each other, Unicode
+    defines "Hrkt" as an alias for both scripts.
+    """
+    scripts = unicodedata.script_extension(chr(codepoint))
+    if HIRAGANA_KATAKANA_SCRIPTS & scripts:
+        scripts -= HIRAGANA_KATAKANA_SCRIPTS
+        scripts.add("Hrkt")  # Hrkt is an alias for Hira and Kata.
+    return scripts

--- a/tests/featureWriters/kernFeatureWriter_test.py
+++ b/tests/featureWriters/kernFeatureWriter_test.py
@@ -4,11 +4,11 @@ from textwrap import dedent
 import pytest
 from fontTools import unicodedata
 
-from ufo2ft.constants import HIRAGANA_KATAKANA_SCRIPTS
+from ufo2ft.constants import UNICODE_SCRIPT_ALIASES
 from ufo2ft.errors import InvalidFeaturesData
 from ufo2ft.featureCompiler import parseLayoutFeatures
 from ufo2ft.featureWriters import KernFeatureWriter, ast
-from ufo2ft.util import DFLT_SCRIPTS, bucketizedScriptExtensions
+from ufo2ft.util import DFLT_SCRIPTS, unicodeScriptExtensions
 
 from . import FeatureWriterTest
 
@@ -1652,7 +1652,7 @@ def test_kern_mixed_bidis(caplog, FontClass):
     assert "<one-ar alef-ar 8> with ambiguous direction" in caplog.text
 
 
-def bucketizedScript(codepoint: int) -> str:
+def unicodeScript(codepoint: int) -> str:
     """Returns the Unicode script for a codepoint, combining some
     scripts into the same bucket.
 
@@ -1660,12 +1660,10 @@ def bucketizedScript(codepoint: int) -> str:
     is being able to kern Hiragana and Katakana against each other, Unicode
     defines "Hrkt" as an alias for both scripts.
 
-    Note: Keep in sync with bucketizedScriptExtensions!
+    Note: Keep in sync with unicodeScriptExtensions!
     """
     script = unicodedata.script(chr(codepoint))
-    if script in HIRAGANA_KATAKANA_SCRIPTS:
-        return "Hrkt"
-    return script
+    return UNICODE_SCRIPT_ALIASES.get(script, script)
 
 
 def test_kern_zyyy_zinh(FontClass):
@@ -1673,8 +1671,8 @@ def test_kern_zyyy_zinh(FontClass):
     disjoint set of explicit script extensions end up in the correct lookups."""
     glyphs = {}
     for i in range(0, 0x110000, 0x10):
-        script = bucketizedScript(i)
-        script_extension = bucketizedScriptExtensions(i)
+        script = unicodeScript(i)
+        script_extension = unicodeScriptExtensions(i)
         if script not in script_extension:
             assert script in DFLT_SCRIPTS
             name = f"uni{i:04X}"


### PR DESCRIPTION
I missed this special case before; Hiragana and Katakana are expected to be kernable against each other and apps commonly support this. They seem to be the only two scripts that are aliased together under the ISO 15924 name "Hrkt" and which map to the OT tag "kana". Keeping them separate would result in two `script kana;` blocks in the kern feature and therefore common glyphs being kerned twice.