### PR TITLE
Fix include dir detection in current dir

### DIFF
--- a/Lib/ufo2ft/featureCompiler.py
+++ b/Lib/ufo2ft/featureCompiler.py
@@ -47,7 +47,7 @@ def parseLayoutFeatures(font, includeDir=None):
         # the include directory to the parent of the UFO.
         ufoPath = os.path.normpath(ufoPath)
         buf.name = os.path.join(ufoPath, "features.fea")
-        includeDir = os.path.dirname(ufoPath)
+        includeDir = os.path.dirname(ufoPath) or "."
     glyphNames = set(font.keys())
     includeDir = os.path.normpath(includeDir) if includeDir else None
     try:

--- a/tests/featureCompiler_test.py
+++ b/tests/featureCompiler_test.py
@@ -15,8 +15,6 @@ from ufo2ft.featureWriters import (
     ast,
 )
 
-from .testSupport import pushd
-
 
 class ParseLayoutFeaturesTest:
     def test_include(self, FontClass, tmpdir):
@@ -40,14 +38,16 @@ class ParseLayoutFeaturesTest:
 
         assert "# hello world" in str(fea)
 
-    def test_include_no_ufo_path(self, FontClass, tmpdir):
+    def test_include_no_ufo_path(self, FontClass, tmpdir, monkeypatch):
         ufo = FontClass()
         ufo.features.text = dedent(
             """\
             include(test.fea)
             """
         )
-        with pushd(str(tmpdir)):
+        with monkeypatch.context() as context:
+            context.chdir(str(tmpdir))
+            ufo.save("Test.ufo")
             with pytest.raises(IncludedFeaNotFound):
                 parseLayoutFeatures(ufo)
 

--- a/tests/featureCompiler_test.py
+++ b/tests/featureCompiler_test.py
@@ -100,6 +100,18 @@ class ParseLayoutFeaturesTest:
 
         assert "# hello world" in str(fea)
 
+    def test_include_dir_cwd(self, FontClass, tmp_path, monkeypatch):
+        (tmp_path / "test.fea").write_text("# hello world", encoding="utf-8")
+        ufo = FontClass()
+        ufo.features.text = "include(test.fea)"
+
+        with monkeypatch.context() as context:
+            context.chdir(tmp_path)
+            ufo.save("Test.ufo")
+            fea = parseLayoutFeatures(ufo)
+
+        assert "# hello world" in str(fea)
+
 
 class DummyFeatureWriter:
     tableTag = "GPOS"

--- a/tests/testSupport.py
+++ b/tests/testSupport.py
@@ -1,5 +1,3 @@
-import contextlib
-import os
 import sys
 import types
 
@@ -28,13 +26,3 @@ class _TempModule:
         else:
             del sys.modules[self.mod_name]
         self._saved_module = []
-
-
-@contextlib.contextmanager
-def pushd(target):
-    saved = os.getcwd()
-    os.chdir(target)
-    try:
-        yield saved
-    finally:
-        os.chdir(saved)


### PR DESCRIPTION
`os.path.dirname("a.ufo")` returns an empty string instead of `"."`, breaking the include dir logic.