### PR TITLE
Use atan instead of tan to calculate triangle legs

### DIFF
--- a/Lib/ufo2ft/fontInfoData.py
+++ b/Lib/ufo2ft/fontInfoData.py
@@ -144,7 +144,7 @@ def openTypeHheaCaretSlopeRiseFallback(info):
             and info.openTypeHheaCaretSlopeRun is not None
         ):
             slopeRun = info.openTypeHheaCaretSlopeRun
-            return otRound(slopeRun / math.tan(math.radians(-italicAngle)))
+            return otRound(slopeRun / math.atan(math.radians(-italicAngle)))
         else:
             return 1000  # just an arbitrary non-zero reference point
     return 1
@@ -159,7 +159,7 @@ def openTypeHheaCaretSlopeRunFallback(info):
     italicAngle = getAttrWithFallback(info, "italicAngle")
     if italicAngle != 0:
         slopeRise = getAttrWithFallback(info, "openTypeHheaCaretSlopeRise")
-        return otRound(math.tan(math.radians(-italicAngle)) * slopeRise)
+        return otRound(math.atan(math.radians(-italicAngle)) * slopeRise)
     return 0
 
 

--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -583,7 +583,7 @@ class BaseOutlineCompiler:
 
         def adjustOffset(offset, angle):
             """Adjust Y offset based on italic angle, to get X offset."""
-            return offset * math.tan(math.radians(-angle)) if angle else 0
+            return offset * math.atan(math.radians(-angle)) if angle else 0
 
         v = getAttrWithFallback(font.info, "openTypeOS2SubscriptXSize")
         if v is None:

--- a/tests/fontInfoData_test.py
+++ b/tests/fontInfoData_test.py
@@ -138,16 +138,16 @@ class GetAttrWithFallbackTest:
 
         info.italicAngle = -12
         assert getAttrWithFallback(info, "openTypeHheaCaretSlopeRise") == 1000
-        assert getAttrWithFallback(info, "openTypeHheaCaretSlopeRun") == 213
+        assert getAttrWithFallback(info, "openTypeHheaCaretSlopeRun") == 206
 
         info.italicAngle = 12
         assert getAttrWithFallback(info, "openTypeHheaCaretSlopeRise") == 1000
-        assert getAttrWithFallback(info, "openTypeHheaCaretSlopeRun") == -213
+        assert getAttrWithFallback(info, "openTypeHheaCaretSlopeRun") == -206
 
         info.openTypeHheaCaretSlopeRise = 2048
         assert info.openTypeHheaCaretSlopeRun is None
         assert getAttrWithFallback(info, "openTypeHheaCaretSlopeRise") == 2048
-        assert getAttrWithFallback(info, "openTypeHheaCaretSlopeRun") == -435
+        assert getAttrWithFallback(info, "openTypeHheaCaretSlopeRun") == -422
 
         info.openTypeHheaCaretSlopeRise = None
         info.openTypeHheaCaretSlopeRun = 200

--- a/tests/fontInfoData_test.py
+++ b/tests/fontInfoData_test.py
@@ -147,7 +147,7 @@ class GetAttrWithFallbackTest:
         info.openTypeHheaCaretSlopeRise = 2048
         assert info.openTypeHheaCaretSlopeRun is None
         assert getAttrWithFallback(info, "openTypeHheaCaretSlopeRise") == 2048
-        assert getAttrWithFallback(info, "openTypeHheaCaretSlopeRun") == -422
+        assert getAttrWithFallback(info, "openTypeHheaCaretSlopeRun") == -423
 
         info.openTypeHheaCaretSlopeRise = None
         info.openTypeHheaCaretSlopeRun = 200

--- a/tests/fontInfoData_test.py
+++ b/tests/fontInfoData_test.py
@@ -152,7 +152,7 @@ class GetAttrWithFallbackTest:
         info.openTypeHheaCaretSlopeRise = None
         info.openTypeHheaCaretSlopeRun = 200
         assert info.openTypeHheaCaretSlopeRise is None
-        assert getAttrWithFallback(info, "openTypeHheaCaretSlopeRise") == -941
+        assert getAttrWithFallback(info, "openTypeHheaCaretSlopeRise") == -969
         assert getAttrWithFallback(info, "openTypeHheaCaretSlopeRun") == 200
 
     def test_head_created(self, info):

--- a/tests/fontInfoData_test.py
+++ b/tests/fontInfoData_test.py
@@ -150,10 +150,10 @@ class GetAttrWithFallbackTest:
         assert getAttrWithFallback(info, "openTypeHheaCaretSlopeRun") == -423
 
         info.openTypeHheaCaretSlopeRise = None
-        info.openTypeHheaCaretSlopeRun = 200
+        info.openTypeHheaCaretSlopeRun = -206
         assert info.openTypeHheaCaretSlopeRise is None
-        assert getAttrWithFallback(info, "openTypeHheaCaretSlopeRise") == -969
-        assert getAttrWithFallback(info, "openTypeHheaCaretSlopeRun") == 200
+        assert getAttrWithFallback(info, "openTypeHheaCaretSlopeRise") == 998 # rounding error, expected 1000
+        assert getAttrWithFallback(info, "openTypeHheaCaretSlopeRun") == -206
 
     def test_head_created(self, info):
         os.environ["SOURCE_DATE_EPOCH"] = "1514485183"


### PR DESCRIPTION
As discussed in https://github.com/googlefonts/ufo2ft/issues/703, this PR fixes the triangle leg calculation formula from tan() to atan().