### PR TITLE
Register lookups for all defined languages

### DIFF
--- a/Lib/ufo2ft/featureWriters/ast.py
+++ b/Lib/ufo2ft/featureWriters/ast.py
@@ -20,15 +20,16 @@ for name in getattr(ast, "__all__", dir(ast)):
 del sys, self, name
 
 
-def getScriptLanguageSystems(feaFile):
+def getScriptLanguageSystems(feaFile, excludeDflt=True):
     """Return dictionary keyed by Unicode script code containing lists of
-    (OT_SCRIPT_TAG, [OT_LANGUAGE_TAG, ...]) tuples (excluding "DFLT").
+    (OT_SCRIPT_TAG, [OT_LANGUAGE_TAG, ...]) tuples (excluding "DFLT" by default,
+    unless excludeDflt is False).
     """
     languagesByScript = collections.OrderedDict()
     for ls in [
         st for st in feaFile.statements if isinstance(st, ast.LanguageSystemStatement)
     ]:
-        if ls.script == "DFLT":
+        if ls.script == "DFLT" and excludeDflt:
             continue
         languagesByScript.setdefault(ls.script, []).append(ls.language)
 

--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
@@ -204,9 +204,7 @@ class KernFeatureWriter(BaseFeatureWriter):
         # setting any language for a script would deactivate kerning.
         feaScripts = ast.getScriptLanguageSystems(feaFile, excludeDflt=False)
         ctx.feaScripts = {
-            # NOTE: Lower otTag because it's sourced verbatim from the feature
-            # file, except if it's "DFLT", because that one is special.
-            (otTag.lower() if otTag != "DFLT" else otTag): languages
+            otTag: languages
             for _, languageSystems in feaScripts.items()
             for otTag, languages in languageSystems
         }

--- a/tests/featureWriters/kernFeatureWriter_test.py
+++ b/tests/featureWriters/kernFeatureWriter_test.py
@@ -777,11 +777,13 @@ class KernFeatureWriterTest(FeatureWriterTest):
                 language dflt;
                 lookup kern_Default;
                 lookup kern_Arab;
+                language URD;
 
                 script latn;
                 language dflt;
                 lookup kern_Default;
                 lookup kern_Latn;
+                language TRK;
             } kern;
             """
         )
@@ -901,12 +903,14 @@ class KernFeatureWriterTest(FeatureWriterTest):
                 lookup kern_Default;
                 lookup kern_Arab;
                 lookup kern_Arab_marks;
+                language URD;
 
                 script latn;
                 language dflt;
                 lookup kern_Default;
                 lookup kern_Latn;
                 lookup kern_Latn_marks;
+                language TRK;
             } kern;
             """
         )
@@ -988,6 +992,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
                 language dflt;
                 lookup kern_Arab;
                 lookup kern_Arab_marks;
+                language ARA;
             } kern;
             """
         )

--- a/tests/featureWriters/kernFeatureWriter_test.py
+++ b/tests/featureWriters/kernFeatureWriter_test.py
@@ -2000,11 +2000,10 @@ def test_dflt_language(FontClass):
     glyphs = {"a": ord("a"), "comma": ord(",")}
     groups = {}
     kerning = {("a", "a"): 1, ("comma", "comma"): 2}
-    # NOTE the deliberatly different casings for `latn`.
     features = """
             languagesystem DFLT dflt;
             languagesystem DFLT ZND;
-            languagesystem Latn dflt;
+            languagesystem latn dflt;
             languagesystem latn ANG;
     """
     ufo = makeUFO(FontClass, glyphs, groups, kerning, features)

--- a/tests/featureWriters/kernFeatureWriter_test.py
+++ b/tests/featureWriters/kernFeatureWriter_test.py
@@ -1993,6 +1993,52 @@ def test_hyphenated_duplicates(FontClass):
     )
 
 
+def test_dflt_language(FontClass):
+    """Check that languages defined for the special DFLT script are registered
+    as well."""
+
+    glyphs = {"a": ord("a"), "comma": ord(",")}
+    groups = {}
+    kerning = {("a", "a"): 1, ("comma", "comma"): 2}
+    # NOTE the deliberatly different casings for `latn`.
+    features = """
+            languagesystem DFLT dflt;
+            languagesystem DFLT ZND;
+            languagesystem Latn dflt;
+            languagesystem latn ANG;
+    """
+    ufo = makeUFO(FontClass, glyphs, groups, kerning, features)
+
+    newFeatures = KernFeatureWriterTest.writeFeatures(ufo)
+
+    assert dedent(str(newFeatures)) == dedent(
+        """
+        lookup kern_Latn {
+            lookupflag IgnoreMarks;
+            pos a a 1;
+        } kern_Latn;
+
+        lookup kern_Default {
+            lookupflag IgnoreMarks;
+            pos comma comma 2;
+        } kern_Default;
+
+        feature kern {
+            script DFLT;
+            language dflt;
+            lookup kern_Default;
+            language ZND;
+
+            script latn;
+            language dflt;
+            lookup kern_Default;
+            lookup kern_Latn;
+            language ANG;
+        } kern;
+        """
+    )
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
Closes https://github.com/googlefonts/ufo2ft/issues/699.

I'm not sure about:

1. Should we also consider languages defined for `DFLT`? The spec technically allows this but I don't know if it's a valid use case?
2. If the designer defined a language for e.g. the OT tag `tml2`, should it also be inserted for `taml`?