### PR TITLE
Overwrite output when using ufoLib2

### DIFF
--- a/Lib/ufo2ft/featureWriters/__main__.py
+++ b/Lib/ufo2ft/featureWriters/__main__.py
@@ -41,4 +41,7 @@ compiler.writeFeatures(buf)
 ufo.features.text = buf.getvalue()
 
 logger.info("Written on %s" % args.output)
-ufo.save(args.output)
+try:
+    ufo.save(args.output, overwrite=True)
+except TypeError:
+    ufo.save(args.output)

--- a/Lib/ufo2ft/filters/__main__.py
+++ b/Lib/ufo2ft/filters/__main__.py
@@ -56,4 +56,7 @@ for filtername in args.filters:
     f(ufo)
 
 logger.info("Written on %s" % args.output)
-ufo.save(args.output)
+try:
+    ufo.save(args.output, overwrite=True)
+except TypeError:
+    ufo.save(args.output)


### PR DESCRIPTION
ufoLib2 balks at overwriting existing UFOs unless you tell it to.