### PR TITLE
Deal with "Filter" suffix of filter names

### DIFF
--- a/Lib/ufo2ft/filters/__init__.py
+++ b/Lib/ufo2ft/filters/__init__.py
@@ -45,6 +45,8 @@ def getFilterClass(filterName, pkg="ufo2ft.filters"):
     # TODO add support for third-party plugin discovery?
     # if filter name is 'Foo Bar', the module should be called 'fooBar'
     filterName = filterName.replace(" ", "")
+    if filterName.endswith("Filter"):
+        filterName = filterName[: -len("Filter")]
     moduleName = filterName[0].lower() + filterName[1:]
     module = importlib.import_module(".".join([pkg, moduleName]))
     # if filter name is 'Foo Bar', the class should be called 'FooBarFilter'

--- a/tests/filters/dottedCircle_test.py
+++ b/tests/filters/dottedCircle_test.py
@@ -1,5 +1,6 @@
 from ufo2ft.filters.dottedCircleFilter import DottedCircleFilter
 from ufo2ft.util import _GlyphSet
+from ufo2ft.filters import loadFilters
 
 
 def test_dotted_circle_filter(FontClass, datadir):
@@ -40,7 +41,12 @@ def test_empty_font(FontClass):
     appropriate."""
 
     font = FontClass()
-    philter = DottedCircleFilter()
+    font.lib["com.github.googlei18n.ufo2ft.filters"] = [
+        {"name": "DottedCircleFilter", "pre": True}
+    ]
+
+    pre_filters, _ = loadFilters(font)
+    (philter,) = pre_filters
     glyphset = _GlyphSet.from_layer(font)
 
     modified = philter(font, glyphset)

--- a/tests/filters/filters_test.py
+++ b/tests/filters/filters_test.py
@@ -38,6 +38,7 @@ def fooBar():
 def test_getFilterClass():
     assert getFilterClass("Foo Bar") == FooBarFilter
     assert getFilterClass("FooBar") == FooBarFilter
+    assert getFilterClass("FooBarFilter") == FooBarFilter
     assert getFilterClass("fooBar") == FooBarFilter
     with pytest.raises(ImportError):
         getFilterClass("Baz")


### PR DESCRIPTION
Deal with the fact that the `DottedCircleFilter` class is misnamed by stripping the "Filter" when searching for the module.

Closes https://github.com/googlefonts/ufo2ft/issues/707