### PR TITLE
Rename dottedCircleFilter module

### DIFF
--- a/Lib/ufo2ft/filters/__init__.py
+++ b/Lib/ufo2ft/filters/__init__.py
@@ -48,7 +48,9 @@ def getFilterClass(filterName, pkg="ufo2ft.filters"):
     moduleName = filterName[0].lower() + filterName[1:]
     module = importlib.import_module(".".join([pkg, moduleName]))
     # if filter name is 'Foo Bar', the class should be called 'FooBarFilter'
-    className = filterName[0].upper() + filterName[1:] + "Filter"
+    className = filterName[0].upper() + filterName[1:]
+    if not className.endswith("Filter"):
+        className += "Filter"
     return getattr(module, className)
 
 

--- a/Lib/ufo2ft/filters/__init__.py
+++ b/Lib/ufo2ft/filters/__init__.py
@@ -9,7 +9,7 @@ from .base import BaseFilter
 from .cubicToQuadratic import CubicToQuadraticFilter
 from .decomposeComponents import DecomposeComponentsFilter
 from .decomposeTransformedComponents import DecomposeTransformedComponentsFilter
-from .dottedCircleFilter import DottedCircleFilter
+from .dottedCircle import DottedCircleFilter
 from .explodeColorLayerGlyphs import ExplodeColorLayerGlyphsFilter
 from .flattenComponents import FlattenComponentsFilter
 from .propagateAnchors import PropagateAnchorsFilter

--- a/Lib/ufo2ft/filters/dottedCircle.py
+++ b/Lib/ufo2ft/filters/dottedCircle.py
@@ -25,7 +25,7 @@ or in the ``lib.plist`` file of a UFO::
     <array>
       <dict>
         <key>name</key>
-        <string>DottedCircleFilter</string>
+        <string>dottedCircle</string>
         <key>pre</key>
         <true/>
       </dict>

--- a/Lib/ufo2ft/filters/dottedCircleFilter.py
+++ b/Lib/ufo2ft/filters/dottedCircleFilter.py
@@ -1,0 +1,21 @@
+"""NOTE: This is a redirection stub, because the original module was misnamed.
+
+It ended in "Filter", which messed with the assumptions in ``getFilterClass``.
+Make an alias for the class here to steer the importer in the right
+direction.
+"""
+
+import logging
+
+from .dottedCircle import DottedCircleFilter
+
+LOGGER = logging.getLogger(__name__)
+
+
+class DottedCircleFilterFilter(DottedCircleFilter):
+    def __init__(self, *args, **kwargs):
+        LOGGER.warning(
+            "Please update your filter name from `DottedCircleFilter` to "
+            "`dottedCircle`."
+        )
+        super().__init__(*args, **kwargs)

--- a/Lib/ufo2ft/filters/dottedCircleFilter.py
+++ b/Lib/ufo2ft/filters/dottedCircleFilter.py
@@ -5,17 +5,17 @@ Make an alias for the class here to steer the importer in the right
 direction.
 """
 
-import logging
+import warnings
 
 from .dottedCircle import DottedCircleFilter
-
-LOGGER = logging.getLogger(__name__)
 
 
 class DottedCircleFilterFilter(DottedCircleFilter):
     def __init__(self, *args, **kwargs):
-        LOGGER.warning(
+        warnings.warn(
             "Please update your filter name from `DottedCircleFilter` to "
-            "`dottedCircle`."
+            "`dottedCircle`.",
+            UserWarning,
+            stacklevel=1,
         )
         super().__init__(*args, **kwargs)

--- a/Lib/ufo2ft/filters/dottedCircleFilter.py
+++ b/Lib/ufo2ft/filters/dottedCircleFilter.py
@@ -1,21 +1,12 @@
-"""NOTE: This is a redirection stub, because the original module was misnamed.
-
-It ended in "Filter", which messed with the assumptions in ``getFilterClass``.
-Make an alias for the class here to steer the importer in the right
-direction.
-"""
+"""This is a redirection stub, because the original module was
+misnamed."""
 
 import warnings
 
-from .dottedCircle import DottedCircleFilter
+from .dottedCircle import DottedCircleFilter  # noqa
 
-
-class DottedCircleFilterFilter(DottedCircleFilter):
-    def __init__(self, *args, **kwargs):
-        warnings.warn(
-            "Please update your filter name from `DottedCircleFilter` to "
-            "`dottedCircle`.",
-            UserWarning,
-            stacklevel=1,
-        )
-        super().__init__(*args, **kwargs)
+warnings.warn(
+    "Please update your filter name from `DottedCircleFilter` to " "`dottedCircle`.",
+    UserWarning,
+    stacklevel=1,
+)

--- a/Lib/ufo2ft/filters/dottedCircleFilter.py
+++ b/Lib/ufo2ft/filters/dottedCircleFilter.py
@@ -6,7 +6,7 @@ import warnings
 from .dottedCircle import DottedCircleFilter  # noqa
 
 warnings.warn(
-    "Please update your filter name from `DottedCircleFilter` to " "`dottedCircle`.",
+    "The dottedCircleFilter module is deprecated, please import dottedCircle instead.",
     UserWarning,
     stacklevel=1,
 )

--- a/tests/filters/dottedCircle_test.py
+++ b/tests/filters/dottedCircle_test.py
@@ -1,4 +1,4 @@
-import logging
+import pytest
 
 from ufo2ft.filters import loadFilters
 from ufo2ft.filters.dottedCircle import DottedCircleFilter
@@ -56,7 +56,7 @@ def test_empty_font(FontClass):
     assert "uni25CC" in modified
 
 
-def test_empty_font_deprecated(FontClass, caplog):
+def test_empty_font_deprecated(FontClass):
     """Check that the module redirection works."""
 
     font = FontClass()
@@ -64,9 +64,8 @@ def test_empty_font_deprecated(FontClass, caplog):
         {"name": "DottedCircleFilter", "pre": True}
     ]
 
-    with caplog.at_level(logging.WARNING):
+    with pytest.warns(UserWarning, match="Please update .*"):
         pre_filters, _ = loadFilters(font)
-    assert "Please update" in caplog.text
     (philter,) = pre_filters
     glyphset = _GlyphSet.from_layer(font)
 

--- a/tests/filters/dottedCircle_test.py
+++ b/tests/filters/dottedCircle_test.py
@@ -1,4 +1,7 @@
-from ufo2ft.filters.dottedCircleFilter import DottedCircleFilter
+import logging
+
+from ufo2ft.filters import loadFilters
+from ufo2ft.filters.dottedCircle import DottedCircleFilter
 from ufo2ft.util import _GlyphSet
 
 
@@ -45,6 +48,25 @@ def test_empty_font(FontClass):
     ]
 
     pre_filters, _ = loadFilters(font)
+    (philter,) = pre_filters
+    glyphset = _GlyphSet.from_layer(font)
+
+    modified = philter(font, glyphset)
+
+    assert "uni25CC" in modified
+
+
+def test_empty_font_deprecated(FontClass, caplog):
+    """Check that the module redirection works."""
+
+    font = FontClass()
+    font.lib["com.github.googlei18n.ufo2ft.filters"] = [
+        {"name": "DottedCircleFilter", "pre": True}
+    ]
+
+    with caplog.at_level(logging.WARNING):
+        pre_filters, _ = loadFilters(font)
+    assert "Please update" in caplog.text
     (philter,) = pre_filters
     glyphset = _GlyphSet.from_layer(font)
 

--- a/tests/filters/dottedCircle_test.py
+++ b/tests/filters/dottedCircle_test.py
@@ -40,7 +40,12 @@ def test_empty_font(FontClass):
     appropriate."""
 
     font = FontClass()
-    philter = DottedCircleFilter()
+    font.lib["com.github.googlei18n.ufo2ft.filters"] = [
+        {"name": "dottedCircle", "pre": True}
+    ]
+
+    pre_filters, _ = loadFilters(font)
+    (philter,) = pre_filters
     glyphset = _GlyphSet.from_layer(font)
 
     modified = philter(font, glyphset)

--- a/tests/filters/dottedCircle_test.py
+++ b/tests/filters/dottedCircle_test.py
@@ -56,6 +56,7 @@ def test_empty_font(FontClass):
     assert "uni25CC" in modified
 
 
+@pytest.mark.filterwarnings("ignore:Please update")
 def test_empty_font_deprecated(FontClass):
     """Check that the module redirection works."""
 
@@ -64,8 +65,7 @@ def test_empty_font_deprecated(FontClass):
         {"name": "DottedCircleFilter", "pre": True}
     ]
 
-    with pytest.warns(UserWarning, match="Please update .*"):
-        pre_filters, _ = loadFilters(font)
+    pre_filters, _ = loadFilters(font)
     (philter,) = pre_filters
     glyphset = _GlyphSet.from_layer(font)
 

--- a/tests/filters/filters_test.py
+++ b/tests/filters/filters_test.py
@@ -41,6 +41,8 @@ def test_getFilterClass():
     assert getFilterClass("fooBar") == FooBarFilter
     with pytest.raises(ImportError):
         getFilterClass("Baz")
+    with pytest.raises(ImportError):
+        getFilterClass("FooBarFilter")
 
     with _TempModule("myfilters"), _TempModule("myfilters.fooBar") as temp_module:
         with pytest.raises(AttributeError):


### PR DESCRIPTION
https://github.com/googlefonts/ufo2ft/pull/715 was wrong actually and broke main. I decided to rename the filter module instead and put in a redirection stub.

Closes https://github.com/googlefonts/ufo2ft/issues/707.