### PR TITLE
Warn on questionable (dis)use of `# Automatic Code`

### DIFF
--- a/Lib/ufo2ft/featureCompiler.py
+++ b/Lib/ufo2ft/featureCompiler.py
@@ -286,15 +286,16 @@ class FeatureCompiler(BaseFeatureCompiler):
             if self.featureWriters:
                 featureFile = parseLayoutFeatures(self.ufo, self.feaIncludeDir)
 
-                warn_about_miscased_insertion_markers(
-                    describe_ufo(self.ufo),
-                    featureFile,
-                    {
-                        feaWriter.insertFeatureMarker
-                        for feaWriter in self.featureWriters
-                        if feaWriter.insertFeatureMarker is not None
-                    },
-                )
+                # Insertion markers are only considered in "skip" mode.
+                if any(writer.mode == "skip" for writer in self.featureWriters):
+                    markers = {
+                        writer.insertFeatureMarker
+                        for writer in self.featureWriters
+                        if writer.insertFeatureMarker is not None
+                    }
+                    warn_about_miscased_insertion_markers(
+                        describe_ufo(self.ufo), featureFile, markers
+                    )
 
                 path = self.ufo.path
                 for writer in self.featureWriters:

--- a/Lib/ufo2ft/featureCompiler.py
+++ b/Lib/ufo2ft/featureCompiler.py
@@ -392,9 +392,10 @@ def warn_about_miscased_insertion_markers(
                     if match_ignore_case and not match_case:
                         logger.warning(
                             "%s: The insertion comment '%s' in the feature file is "
-                            "miscased, ignoring it.",
+                            "miscased (search pattern: %s), ignoring it.",
                             ufo_description,
                             statement,
+                            pattern_case.pattern,
                         )
 
     _inner(feaFile)

--- a/Lib/ufo2ft/featureCompiler.py
+++ b/Lib/ufo2ft/featureCompiler.py
@@ -7,7 +7,6 @@ from collections import OrderedDict
 from inspect import isclass
 from io import StringIO
 from tempfile import NamedTemporaryFile
-from typing import Any
 
 from fontTools import mtiLib
 from fontTools.feaLib.builder import addOpenTypeFeaturesFromString

--- a/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
@@ -80,11 +80,13 @@ class BaseFeatureWriter:
           instantiated from a FeatureCompiler);
         - a set of features (tags) to be generated. If self.mode is "skip",
           these are all the features which are _not_ already present.
+        - a set of all existing features (tags) in the feaFile.
 
         Returns the context namespace instance.
         """
         todo = set(self.features)
         insertComments = None
+        existing = set()
         if self.mode == "skip":
             if self.insertFeatureMarker is not None:
                 insertComments = self.collectInsertMarkers(
@@ -104,6 +106,7 @@ class BaseFeatureWriter:
             compiler=compiler,
             todo=todo,
             insertComments=insertComments,
+            existingFeatures=existing,
         )
 
         return self.context

--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
@@ -204,12 +204,14 @@ class KernFeatureWriter(BaseFeatureWriter):
         ctx.gdefClasses = self.getGDEFGlyphClasses()
         ctx.glyphSet = self.getOrderedGlyphSet()
 
-        # If the font contains kerning, the feaFile contains `kern` or `dist`
-        # feature blocks, but we have no insertion markers (or they were
-        # misspelt and ignored), warn the user that the kerning blocks in the
-        # feaFile take precedence and other kerning is dropped.
+        # Unless we use the legacy append mode (which ignores insertion
+        # markers), if the font contains kerning and the feaFile contains `kern`
+        # or `dist` feature blocks, but we have no insertion markers (or they
+        # were misspelt and ignored), warn the user that the kerning blocks in
+        # the feaFile take precedence and other kerning is dropped.
         if (
-            font.kerning
+            self.mode == "skip"
+            and font.kerning
             and ctx.existingFeatures & self.features
             and not ctx.insertComments
         ):

--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
@@ -11,7 +11,13 @@ from fontTools.unicodedata import script_horizontal_direction
 
 from ufo2ft.constants import COMMON_SCRIPT, INDIC_SCRIPTS, USE_SCRIPTS
 from ufo2ft.featureWriters import BaseFeatureWriter, ast
-from ufo2ft.util import DFLT_SCRIPTS, classifyGlyphs, quantize, unicodeScriptExtensions
+from ufo2ft.util import (
+    DFLT_SCRIPTS,
+    classifyGlyphs,
+    describe_ufo,
+    quantize,
+    unicodeScriptExtensions,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -197,6 +203,21 @@ class KernFeatureWriter(BaseFeatureWriter):
         ctx = super().setContext(font, feaFile, compiler=compiler)
         ctx.gdefClasses = self.getGDEFGlyphClasses()
         ctx.glyphSet = self.getOrderedGlyphSet()
+
+        # If the font contains kerning, the feaFile contains `kern` or `dist`
+        # feature blocks, but we have no insertion markers (or they were
+        # misspelt and ignored), warn the user that the kerning blocks in the
+        # feaFile take precedence and other kerning is dropped.
+        if (
+            font.kerning
+            and ctx.existingFeatures & self.features
+            and not ctx.insertComments
+        ):
+            LOGGER.warning(
+                "%s: font has kerning, but also manually written kerning features "
+                "without an insertion comment. Dropping the former.",
+                describe_ufo(font),
+            )
 
         # Remember which languages are defined for which OT tag, as all
         # generated kerning needs to be registered for the script's `dflt`

--- a/Lib/ufo2ft/util.py
+++ b/Lib/ufo2ft/util.py
@@ -622,5 +622,6 @@ def describe_ufo(ufo: Any) -> str:
         and hasattr(ufo.reader.fs, "root_path")
     ):
         return ufo.reader.fs.root_path
-    else:
+    elif ufo.info.familyName or ufo.info.styleName:
         return f"{ufo.info.familyName} {ufo.info.styleName}"
+    return repr(ufo)

--- a/Lib/ufo2ft/util.py
+++ b/Lib/ufo2ft/util.py
@@ -5,7 +5,7 @@ import logging
 import re
 from copy import deepcopy
 from inspect import currentframe, getfullargspec
-from typing import Mapping, Set
+from typing import Any, Mapping, Set
 
 from fontTools import subset, ttLib, unicodedata
 from fontTools.designspaceLib import DesignSpaceDocument
@@ -612,3 +612,15 @@ def unicodeScriptExtensions(
     defines "Hrkt" as an alias for both scripts.
     """
     return {aliases.get(s, s) for s in unicodedata.script_extension(chr(codepoint))}
+
+
+def describe_ufo(ufo: Any) -> str:
+    """Returns a description of a UFO suitable for logging."""
+    if (
+        hasattr(ufo, "reader")
+        and hasattr(ufo.reader, "fs")
+        and hasattr(ufo.reader.fs, "root_path")
+    ):
+        return ufo.reader.fs.root_path
+    else:
+        return f"{ufo.info.familyName} {ufo.info.styleName}"

--- a/Lib/ufo2ft/util.py
+++ b/Lib/ufo2ft/util.py
@@ -623,5 +623,5 @@ def describe_ufo(ufo: Any) -> str:
     ):
         return ufo.reader.fs.root_path
     elif ufo.info.familyName or ufo.info.styleName:
-        return f"{ufo.info.familyName} {ufo.info.styleName}"
+        return " ".join(n for n in (ufo.info.familyName, ufo.info.styleName) if n)
     return repr(ufo)

--- a/tests/featureWriters/kernFeatureWriter_test.py
+++ b/tests/featureWriters/kernFeatureWriter_test.py
@@ -366,8 +366,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
             )
             font = compiler.compile()
 
-        assert "miscased" in caplog.text
-        assert "Dropping the former" not in caplog.text
+        assert not caplog.text
         assert "GPOS" in font
 
     def test_insert_comment_before_extended(self, FontClass):

--- a/tests/featureWriters/kernFeatureWriter_test.py
+++ b/tests/featureWriters/kernFeatureWriter_test.py
@@ -353,9 +353,22 @@ class KernFeatureWriterTest(FeatureWriterTest):
         # We mis-cased the insertion marker above, so it's ignored and we end up
         # with an empty `kern` block overriding the other kerning in the font
         # source and therefore no `GPOS` table.
-        assert "miscased, ignoring it" in caplog.text
+        assert "miscased" in caplog.text
         assert "Dropping the former" in caplog.text
         assert "GPOS" not in font
+
+        # Append mode ignores insertion markers and so should not log warnings
+        # and have kerning in the final font.
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            compiler = FeatureCompiler(
+                ufo, featureWriters=[KernFeatureWriter(mode="append")]
+            )
+            font = compiler.compile()
+
+        assert "miscased" in caplog.text
+        assert "Dropping the former" not in caplog.text
+        assert "GPOS" in font
 
     def test_insert_comment_before_extended(self, FontClass):
         ufo = FontClass()


### PR DESCRIPTION
1. Warn about mis-cased `# Automatic Code` comments (see #701)
2. Warn if there is no insertion marker but kerning.plist data and a manual kern/dist feature in the fea code (because kerning.plist will be dropped)