### PR TITLE
Reorder class definitions in feature writers

### DIFF
--- a/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
@@ -234,23 +234,21 @@ class BaseFeatureWriter:
             statements.insert(index, feature)
             indices.append(index)
 
-        # Write classDefs, anchorsDefs, markClassDefs, lookups at earliest
-        # opportunity.
-        others = []
         minindex = min(indices)
+        if lookups:
+            feaFile.statements = statements = (
+                statements[:minindex] + lookups + statements[minindex:]
+            )
+
+        # Write classDefs, anchorsDefs, markClassDefs, lookups at
+        # the very top of the feature file.
+        others = []
         for defs in [classDefs, anchorDefs, markClassDefs]:
             if defs:
                 others.extend(defs)
                 others.append(ast.Comment(""))
-        # Insert lookups
-        if lookups:
-            if minindex > 0 and not others:
-                others.append(ast.Comment(""))
-            others.extend(lookups)
-        if others:
-            feaFile.statements = statements = (
-                statements[:minindex] + others + statements[minindex:]
-            )
+
+        feaFile.statements = statements = others + statements
 
     @staticmethod
     def collectInsertMarkers(feaFile, insertFeatureMarker, featureTags):

--- a/tests/featureWriters/__init__.py
+++ b/tests/featureWriters/__init__.py
@@ -13,8 +13,12 @@ class FeatureWriterTest:
         """
         writer = cls.FeatureWriter(**kwargs)
         feaFile = parseLayoutFeatures(ufo)
-        n = len(feaFile.statements)
+        old_statements = [st.asFea() for st in feaFile.statements]
+
         if writer.write(ufo, feaFile):
             new = ast.FeatureFile()
-            new.statements = feaFile.statements[n:]
+
+            for statement in feaFile.statements:
+                if statement.asFea() not in old_statements:
+                    new.statements.append(statement)
             return new

--- a/tests/featureWriters/kernFeatureWriter2_test.py
+++ b/tests/featureWriters/kernFeatureWriter2_test.py
@@ -147,7 +147,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
         # default is ignoreMarks=True
         feaFile = self.writeFeatures(font)
         assert str(feaFile) == dedent(
-            """
+            """\
             lookup kern_ltr {
                 lookupflag IgnoreMarks;
                 pos B C -30;
@@ -166,7 +166,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
 
         feaFile = self.writeFeatures(font, ignoreMarks=False)
         assert str(feaFile) == dedent(
-            """
+            """\
             lookup kern_ltr {
                 pos A acutecomb -55;
                 pos B C -30;
@@ -198,7 +198,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
         # default is ignoreMarks=True
         feaFile = self.writeFeatures(font)
         assert str(feaFile) == dedent(
-            """
+            """\
             lookup kern_ltr_marks {
                 pos A acutecomb -55;
             } kern_ltr_marks;
@@ -301,7 +301,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
         # test append mode ignores insert marker
         generated = self.writeFeatures(ufo, mode="append")
         assert str(generated) == dedent(
-            """
+            """\
             lookup kern_ltr {
                 lookupflag IgnoreMarks;
                 pos seven six 25;
@@ -384,7 +384,6 @@ class KernFeatureWriterTest(FeatureWriterTest):
                 #
             } kern;
 
-
             lookup kern_ltr {
                 lookupflag IgnoreMarks;
                 pos seven six 25;
@@ -401,7 +400,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
         # test append mode ignores insert marker
         generated = self.writeFeatures(ufo, mode="append")
         assert str(generated) == dedent(
-            """
+            """\
             lookup kern_ltr {
                 lookupflag IgnoreMarks;
                 pos seven six 25;
@@ -444,7 +443,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
         # test append mode ignores insert marker
         generated = self.writeFeatures(ufo, mode="append")
         assert str(generated) == dedent(
-            """
+            """\
             lookup kern_ltr {
                 lookupflag IgnoreMarks;
                 pos seven six 25;
@@ -476,7 +475,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
         generated = self.writeFeatures(ufo)
 
         assert str(generated) == dedent(
-            """
+            """\
             lookup kern_rtl {
                 lookupflag IgnoreMarks;
                 pos four-ar seven-ar -30;
@@ -906,7 +905,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
         generated = self.writeFeatures(ufo)
 
         assert str(generated) == dedent(
-            """
+            """\
             lookup kern_ltr {
                 lookupflag IgnoreMarks;
                 pos A V -40;
@@ -933,7 +932,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
         generated = self.writeFeatures(ufo)
 
         assert str(generated) == dedent(
-            """
+            """\
             lookup kern_ltr {
                 lookupflag IgnoreMarks;
                 pos A V -40;
@@ -1025,7 +1024,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
         generated = self.writeFeatures(ufo)
 
         assert str(generated) == dedent(
-            """
+            """\
             lookup kern_rtl {
                 lookupflag IgnoreMarks;
                 pos u10A1E u10A06 <117 0 117 0>;
@@ -1153,7 +1152,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
         generated = self.writeFeatures(ufo)
 
         assert str(generated) == dedent(
-            """
+            """\
             lookup kern_dflt {
                 lookupflag IgnoreMarks;
                 pos seven four -25;

--- a/tests/featureWriters/kernFeatureWriter_test.py
+++ b/tests/featureWriters/kernFeatureWriter_test.py
@@ -155,7 +155,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
         # default is ignoreMarks=True
         feaFile = self.writeFeatures(font)
         assert str(feaFile) == dedent(
-            """
+            """\
             lookup kern_Latn {
                 lookupflag IgnoreMarks;
                 pos B C -30;
@@ -176,7 +176,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
 
         feaFile = self.writeFeatures(font, ignoreMarks=False)
         assert str(feaFile) == dedent(
-            """
+            """\
             lookup kern_Latn {
                 pos A acutecomb -55;
                 pos B C -30;
@@ -210,7 +210,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
         # default is ignoreMarks=True
         feaFile = self.writeFeatures(font)
         assert str(feaFile) == dedent(
-            """
+            """\
             lookup kern_Default_marks {
                 pos A acutecomb -55;
             } kern_Default_marks;
@@ -250,7 +250,6 @@ class KernFeatureWriterTest(FeatureWriterTest):
 
         expected = existing + dedent(
             """
-
             lookup kern_Default {
                 lookupflag IgnoreMarks;
                 pos seven six 25;
@@ -319,7 +318,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
         # test append mode ignores insert marker
         generated = self.writeFeatures(ufo, mode="append")
         assert str(generated) == dedent(
-            """
+            """\
             lookup kern_Default {
                 lookupflag IgnoreMarks;
                 pos seven six 25;
@@ -406,7 +405,6 @@ class KernFeatureWriterTest(FeatureWriterTest):
                 #
             } kern;
 
-
             lookup kern_Default {
                 lookupflag IgnoreMarks;
                 pos seven six 25;
@@ -425,7 +423,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
         # test append mode ignores insert marker
         generated = self.writeFeatures(ufo, mode="append")
         assert str(generated) == dedent(
-            """
+            """\
             lookup kern_Default {
                 lookupflag IgnoreMarks;
                 pos seven six 25;
@@ -470,7 +468,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
         # test append mode ignores insert marker
         generated = self.writeFeatures(ufo, mode="append")
         assert str(generated) == dedent(
-            """
+            """\
             lookup kern_Default {
                 lookupflag IgnoreMarks;
                 pos seven six 25;
@@ -547,7 +545,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
         generated = self.writeFeatures(ufo)
 
         assert dedent(str(generated)) == dedent(
-            """
+            """\
             lookup kern_Arab {
                 lookupflag IgnoreMarks;
                 pos four-ar seven-ar -30;
@@ -574,7 +572,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
         generated = self.writeFeatures(ufo)
 
         assert dedent(str(generated)) == dedent(
-            """
+            """\
             lookup kern_Thaa {
                 lookupflag IgnoreMarks;
                 pos four-ar seven-ar -30;
@@ -1091,7 +1089,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
         generated = self.writeFeatures(ufo)
 
         assert str(generated) == dedent(
-            """
+            """\
             lookup kern_Khar {
                 lookupflag IgnoreMarks;
                 pos u10A1E u10A06 <117 0 117 0>;
@@ -1211,7 +1209,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
         generated = self.writeFeatures(ufo)
 
         assert dedent(str(generated)) == dedent(
-            """
+            """\
             lookup kern_Hebr {
                 lookupflag IgnoreMarks;
                 pos yod-hb bet-hb <-100 0 -100 0>;
@@ -2115,7 +2113,7 @@ def test_dflt_language(FontClass):
     newFeatures = KernFeatureWriterTest.writeFeatures(ufo)
 
     assert dedent(str(newFeatures)) == dedent(
-        """
+        """\
         lookup kern_Latn {
             lookupflag IgnoreMarks;
             pos a a 1;

--- a/tests/featureWriters/markFeatureWriter_test.py
+++ b/tests/featureWriters/markFeatureWriter_test.py
@@ -282,9 +282,9 @@ class MarkFeatureWriterTest(FeatureWriterTest):
 
         assert str(feaFile) == dedent(
             """\
-            markClass acutecomb <anchor 100 200> @MC_top;
             markClass tildecomb <anchor 100 200> @MC_top;
 
+            markClass acutecomb <anchor 100 200> @MC_top;
             feature mark {
                 lookup mark2base {
                     pos base a
@@ -377,6 +377,8 @@ class MarkFeatureWriterTest(FeatureWriterTest):
 
         assert str(feaFile) == dedent(
             """\
+            markClass tildecomb <anchor 100 200> @MC_top;
+
             markClass acutecomb <anchor 100 200> @MC_top;
             feature mark {
                 lookup mark1 {
@@ -387,8 +389,6 @@ class MarkFeatureWriterTest(FeatureWriterTest):
                 #
                 #
             } mark;
-
-            markClass tildecomb <anchor 100 200> @MC_top;
 
             feature mark {
                 lookup mark2base {


### PR DESCRIPTION
This fixes one of the issues in #506 - that is, when the mark feature writer is run more than once (for example, for `abvm` and then for `mark`), the mark class definitions that it emits can end up after the lookups which use those definitions, causing the font to fail to compile. Instead of trying to carefully work out where to place the definitions, we simply put them at the top of the feature file.

This also rewrites the feature writer test class to detect new statements wherever they occur in the feature file, not simply statements which have been appended.