### PR TITLE
iterClassDefinitions() should find nested class definitions

### DIFF
--- a/Lib/ufo2ft/featureWriters/ast.py
+++ b/Lib/ufo2ft/featureWriters/ast.py
@@ -79,11 +79,19 @@ def iterClassDefinitions(feaFile, featureTag=None):
         for s in feaFile.statements:
             if isinstance(s, ast.GlyphClassDefinition):
                 yield s
+            elif isinstance(s, ast.LookupBlock):
+                for ns in s.statements:
+                    if isinstance(ns, ast.GlyphClassDefinition):
+                        yield ns
     # then iterate over per-feature class definitions
     for fea in iterFeatureBlocks(feaFile, tag=featureTag):
         for s in fea.statements:
             if isinstance(s, ast.GlyphClassDefinition):
                 yield s
+            elif isinstance(s, ast.LookupBlock):
+                for ns in s.statements:
+                    if isinstance(ns, ast.GlyphClassDefinition):
+                        yield ns
 
 
 LOOKUP_FLAGS = {

--- a/Lib/ufo2ft/featureWriters/ast.py
+++ b/Lib/ufo2ft/featureWriters/ast.py
@@ -73,25 +73,12 @@ def findTable(feaLib, tag):
             return statement
 
 
-def iterClassDefinitions(feaFile, featureTag=None):
-    if featureTag is None:
-        # start from top-level class definitions
-        for s in feaFile.statements:
-            if isinstance(s, ast.GlyphClassDefinition):
-                yield s
-            elif isinstance(s, ast.LookupBlock):
-                for ns in s.statements:
-                    if isinstance(ns, ast.GlyphClassDefinition):
-                        yield ns
-    # then iterate over per-feature class definitions
-    for fea in iterFeatureBlocks(feaFile, tag=featureTag):
-        for s in fea.statements:
-            if isinstance(s, ast.GlyphClassDefinition):
-                yield s
-            elif isinstance(s, ast.LookupBlock):
-                for ns in s.statements:
-                    if isinstance(ns, ast.GlyphClassDefinition):
-                        yield ns
+def iterClassDefinitions(feaFile):
+    for s in feaFile.statements:
+        if isinstance(s, ast.GlyphClassDefinition):
+            yield s
+        elif isinstance(s, (ast.Block)):
+            yield from iterClassDefinitions(s)
 
 
 LOOKUP_FLAGS = {

--- a/tests/featureWriters/ast_test.py
+++ b/tests/featureWriters/ast_test.py
@@ -1,5 +1,7 @@
 from io import StringIO
+
 from fontTools.feaLib.parser import Parser
+
 from ufo2ft.featureWriters import ast
 
 

--- a/tests/featureWriters/ast_test.py
+++ b/tests/featureWriters/ast_test.py
@@ -1,0 +1,34 @@
+from io import StringIO
+from fontTools.feaLib.parser import Parser
+from ufo2ft.featureWriters import ast
+
+
+def test_iterClassDefinitions():
+    text = """
+    @TopLevelClass = [a b c];
+
+    lookup test_lookup {
+        @LookupLevelClass = [d e f];
+    } test_lookup;
+
+    feature test {
+        @FeatureLevelClass = [g h i];
+
+        lookup test_nested_lookup {
+            @NestedLookupLevelClass = [j k l];
+        } test_nested_lookup;
+    } test;
+    """
+    glyph_names = "a b c d e f g h i j k l".split()
+    feature_file = StringIO(text)
+    p = Parser(feature_file, glyph_names)
+    doc = p.parse()
+    class_defs = ast.iterClassDefinitions(doc)
+    result = [cd.name for cd in class_defs]
+    expected = [
+        "TopLevelClass",
+        "LookupLevelClass",
+        "FeatureLevelClass",
+        "NestedLookupLevelClass",
+    ]
+    assert result == expected


### PR DESCRIPTION
https://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html#2.g.ii
> Glyph class assignments can appear anywhere in the feature file. A glyph class name may be used in the feature file only after its definition.

Glyph class definitions can be top-level, inside a feature blocks but also inside a lookup block or inside lookup block itself inside a feature block. I guess other blocks like cvparameters or table would not make sense.