### PR TITLE
Insert empty lookups for interpolation

### DIFF
--- a/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
@@ -67,6 +67,25 @@ class BaseFeatureWriter:
         logger = ".".join([self.__class__.__module__, self.__class__.__name__])
         self.log = logging.getLogger(logger)
 
+    def preWrite(self, font, feaFile, compiler=None) -> Any:
+        """Prepare data for the preMerge step, if needed.
+
+        Return the data in question.
+
+        The default is to return None and then do nothing in the preMerge().
+        """
+        return None
+
+    def preMerge(
+        self,
+        default_source: Any,
+        other_sources: list[Any],
+        fonts: list[TTFont],
+        preMergeDatas: list[Any],
+    ) -> list[Any]:
+        """Align the contents of preMergeDatas from a global point of view."""
+        return preMergeDatas
+
     def setContext(self, font, feaFile, compiler=None):
         """Populate a temporary `self.context` namespace, which is reset
         after each new call to `_write` method.

--- a/Lib/ufo2ft/plan_for_interpolatable_feature_compiler.md
+++ b/Lib/ufo2ft/plan_for_interpolatable_feature_compiler.md
@@ -1,0 +1,16 @@
+Before:
+- feature compiler
+  - for each UFO:
+    - makes a feature file from UFO's feature.fea
+    - calls each feature writer which grows the contents of the feature file
+    - compiles the feature file to OT stuff and puts into TTF
+
+
+After:
+- feature compiler
+  - for each UFO:
+    - asks each feature writer to prepare data (not necessarily feature code) for each UFO. Feature writers can look at existing feature file from the UFO but cannot change it yet
+- runs each feature writer's preMerge step
+  - for each UFO:
+    - calls each feature writer which grows the contents of the feature file 
+    - compiles the feature file to OT stuff


### PR DESCRIPTION
See https://github.com/fonttools/fonttools/pull/3073.

I need to think about what information to provide to feature writers again. Currently, I pass a dict of feature writer name to list of lookups it wrote to the writer, to mimic what's done on the default source. Problem: that might be too little information. Lookups also need to be registered in feature blocks, so I'd need to pass these in as well (is the lookup registered for kern or dist?). Maybe I need to approach this differently and instead walk the fea AST before it gets compiled, and insert new empty AST nodes? But then I again need to know precisely what to insert where. Or combine the appraoches to see which writer authored which lookup, and then walk the default AST and copy the nodes I need and clear out their statements, so I can copy them to the other sources if need be?

For information, we want to implementing the bottom part of this diagram:

![image](https://user-images.githubusercontent.com/3616772/231184138-69f7db76-e5df-4dc4-9acc-f23b4e7d9a2e.png)
