### PR TITLE
Populate modified in head based on created

### DIFF
--- a/Lib/ufo2ft/fontInfoData.py
+++ b/Lib/ufo2ft/fontInfoData.py
@@ -100,15 +100,28 @@ def dateStringForNow():
 
 
 def openTypeHeadCreatedFallback(info):
-    """
-    Fallback to the environment variable SOURCE_DATE_EPOCH if set, otherwise
-    now.
+    """Return an appropriate timestamp for created in head.
+
+    If SOURCE_DATE_EPOCH is set, it returns the corresponding value. Otherwise,
+    it returns the current timestamp.
     """
     if "SOURCE_DATE_EPOCH" in os.environ:
         t = datetime.utcfromtimestamp(int(os.environ["SOURCE_DATE_EPOCH"]))
         return t.strftime(_date_format)
     else:
         return dateStringForNow()
+
+
+def openTypeHeadModifiedFallback(info):
+    """Return an appropriate timestamp for modified in head.
+
+    If UFO2FT_HEAD_MODIFIED is set to created, it returns the same value as the
+    one in openTypeHeadCreated. Otherwise, it returns the current timestamp.
+    """
+    if os.environ.get("UFO2FT_HEAD_MODIFIED") == "created":
+        return getAttrWithFallback(info, "openTypeHeadCreated")
+    else:
+        return openTypeHeadCreatedFallback(info)
 
 
 # hhea
@@ -436,6 +449,7 @@ specialFallbacks = dict(
     styleMapFamilyName=styleMapFamilyNameFallback,
     styleMapStyleName=styleMapStyleNameFallback,
     openTypeHeadCreated=openTypeHeadCreatedFallback,
+    openTypeHeadModified=openTypeHeadModifiedFallback,
     openTypeHheaAscender=openTypeHheaAscenderFallback,
     openTypeHheaDescender=openTypeHheaDescenderFallback,
     openTypeHheaCaretSlopeRise=openTypeHheaCaretSlopeRiseFallback,

--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -35,7 +35,6 @@ from ufo2ft.constants import (
 )
 from ufo2ft.errors import InvalidFontData
 from ufo2ft.fontInfoData import (
-    dateStringForNow,
     dateStringToTimeValue,
     getAttrWithFallback,
     intListToNum,
@@ -333,7 +332,12 @@ class BaseOutlineCompiler:
             dateStringToTimeValue(getAttrWithFallback(font.info, "openTypeHeadCreated"))
             - mac_epoch_diff
         )
-        head.modified = dateStringToTimeValue(dateStringForNow()) - mac_epoch_diff
+        head.modified = (
+            dateStringToTimeValue(
+                getAttrWithFallback(font.info, "openTypeHeadModified")
+            )
+            - mac_epoch_diff
+        )
 
         # bounding box
         xMin, yMin, xMax, yMax = self.fontBoundingBox

--- a/tests/fontInfoData_test.py
+++ b/tests/fontInfoData_test.py
@@ -156,15 +156,40 @@ class GetAttrWithFallbackTest:
         assert getAttrWithFallback(info, "openTypeHheaCaretSlopeRun") == 200
 
     def test_head_created(self, info):
-        os.environ["SOURCE_DATE_EPOCH"] = "1514485183"
+        current_epoch = "1514485183"
+        current_timestamp = "2017/12/28 18:19:43"
+        os.environ["SOURCE_DATE_EPOCH"] = current_epoch
         try:
-            assert (
-                getAttrWithFallback(info, "openTypeHeadCreated")
-                == "2017/12/28 18:19:43"
-            )
+            actual = getAttrWithFallback(info, "openTypeHeadCreated")
+            assert actual == current_timestamp
         finally:
             del os.environ["SOURCE_DATE_EPOCH"]
-        assert getAttrWithFallback(info, "openTypeHeadCreated") != "2017/12/28 18:19:43"
+        actual = getAttrWithFallback(info, "openTypeHeadCreated")
+        assert actual != current_timestamp
+
+    def test_head_modified(self, info):
+        current_epoch = "1514485183"
+        current_timestamp = "2017/12/28 18:19:43"
+        created_timestamp = "2017/01/01 00:00:00"
+
+        assert info.openTypeHeadCreated is None
+        info.openTypeHeadCreated = created_timestamp
+
+        os.environ["SOURCE_DATE_EPOCH"] = current_epoch
+        try:
+            actual = getAttrWithFallback(info, "openTypeHeadModified")
+            assert actual == current_timestamp
+        finally:
+            del os.environ["SOURCE_DATE_EPOCH"]
+
+        os.environ["SOURCE_DATE_EPOCH"] = current_epoch
+        os.environ["UFO2FT_HEAD_MODIFIED"] = "created"
+        try:
+            actual = getAttrWithFallback(info, "openTypeHeadModified")
+            assert actual == created_timestamp
+        finally:
+            del os.environ["SOURCE_DATE_EPOCH"]
+            del os.environ["UFO2FT_HEAD_MODIFIED"]
 
     def test_empty_info(self, InfoClass):
         info = InfoClass()


### PR DESCRIPTION
In CI/CD pipelines, it is useful to be able to reliably produce the exact same binaries at different points in time. This pull request takes a step in that direction by proposing to treat `modified` similarly to `created`. To elaborate, an imaginary `openTypeHeadModified` is introduced, and it defaults to a fixed value when a certain environment value is set.