### PR TITLE
Kern feature writer: Only use exported glyphs

### DIFF
--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
@@ -386,7 +386,9 @@ class KernFeatureWriter(BaseFeatureWriter):
         lookup = ast.LookupBlock(name)
         if ignoreMarks and self.options.ignoreMarks:
             # We only want to filter the spacing marks
-            marks = set(self.context.gdefClasses.mark or []) & set(self.context.glyphSet.keys())
+            marks = set(self.context.gdefClasses.mark or []) & set(
+                self.context.glyphSet.keys()
+            )
 
             spacing = []
             if marks:

--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
@@ -386,7 +386,8 @@ class KernFeatureWriter(BaseFeatureWriter):
         lookup = ast.LookupBlock(name)
         if ignoreMarks and self.options.ignoreMarks:
             # We only want to filter the spacing marks
-            marks = set(self.context.gdefClasses.mark) & set(self.context.glyphSet.keys())
+            marks = set(self.context.gdefClasses.mark or []) & set(self.context.glyphSet.keys())
+
             spacing = []
             if marks:
                 spacing = [mark for mark in marks if self.context.font[mark].width != 0]

--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
@@ -386,7 +386,7 @@ class KernFeatureWriter(BaseFeatureWriter):
         lookup = ast.LookupBlock(name)
         if ignoreMarks and self.options.ignoreMarks:
             # We only want to filter the spacing marks
-            marks = self.context.gdefClasses.mark
+            marks = set(self.context.gdefClasses.mark) & set(self.context.glyphSet.keys())
             spacing = []
             if marks:
                 spacing = [mark for mark in marks if self.context.font[mark].width != 0]


### PR DESCRIPTION
Noto Sans Balinese isn't compiling today, because some unexpected glyphs are turning up in the generated features file. This turns out to be because of the kern feature writer. This PR makes it only use exported glyphs when forming mark filtering sets.