### PR TITLE
allow to disable automatic setting of USE_MY_METRICS glyf component flag

### DIFF
--- a/Lib/ufo2ft/__init__.py
+++ b/Lib/ufo2ft/__init__.py
@@ -223,6 +223,7 @@ compileTTF_args = {
         reverseDirection=True,
         rememberCurveType=True,
         flattenComponents=False,
+        autoUseMyMetrics=True,
     ),
 }
 
@@ -274,6 +275,7 @@ compileInterpolatableTTFs_args = {
         colrLayerReuse=False,
         colrAutoClipBoxes=False,
         extraSubstitutions=None,
+        autoUseMyMetrics=True,
     ),
 }
 
@@ -550,6 +552,7 @@ compileVariableTTF_args = {
         excludeVariationTables=(),
         optimizeGvar=True,
         colrAutoClipBoxes=False,
+        autoUseMyMetrics=True,
     ),
 }
 

--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -1414,6 +1414,30 @@ class OutlineTTFCompiler(BaseOutlineCompiler):
         "prep",
     }
 
+    def __init__(
+        self,
+        font,
+        glyphSet=None,
+        glyphOrder=None,
+        tables=None,
+        notdefGlyph=None,
+        colrLayerReuse=True,
+        colrAutoClipBoxes=True,
+        colrClipBoxQuantization=colrClipBoxQuantization,
+        autoUseMyMetrics=True,
+    ):
+        super().__init__(
+            font,
+            glyphSet=glyphSet,
+            glyphOrder=glyphOrder,
+            tables=tables,
+            notdefGlyph=notdefGlyph,
+            colrLayerReuse=colrLayerReuse,
+            colrAutoClipBoxes=colrAutoClipBoxes,
+            colrClipBoxQuantization=colrClipBoxQuantization,
+        )
+        self.autoUseMyMetrics = autoUseMyMetrics
+
     def compileGlyphs(self):
         """Compile and return the TrueType glyphs for this font."""
         allGlyphs = self.allGlyphs

--- a/tests/outlineCompiler_test.py
+++ b/tests/outlineCompiler_test.py
@@ -119,6 +119,11 @@ class OutlineTTFCompilerTest:
         for component in ttf["glyf"]["romanthree"].components:
             assert not (component.flags & USE_MY_METRICS)
 
+    def test_autoUseMyMetrics_False(self, use_my_metrics_ufo):
+        compiler = OutlineTTFCompiler(use_my_metrics_ufo, autoUseMyMetrics=False)
+        ttf = compiler.compile()
+        assert not (ttf["glyf"]["Iacute"].components[1].flags & USE_MY_METRICS)
+
     def test_autoUseMyMetrics_None(self, use_my_metrics_ufo):
         compiler = OutlineTTFCompiler(use_my_metrics_ufo)
         # setting 'autoUseMyMetrics' attribute to None disables the feature


### PR DESCRIPTION
Setting USE_MY_METRICS (0x0200) the way ufo2ft does (to the component whose base glyph has the same advance width and horizontal positioning as the composite glyph as a whole) is not necessary for fonts that do not have hinted metrics
Having this flag set doesn't hurt either (it's basically no-op for unhinted fonts), thus I don't want to change the default behavior otherwise it will produce spurious diffs.
At least we allow to disable this feature. It will also help us when comparing the output of fontmake-py vs fontmake-rs (which does not implement this unnecessary USE_MY_METRICS flag setting). 

(FWIW Glyphs.app also does not set this flag)