### PR TITLE
set OVERLAP_SIMPLE when public.truetype.overlap key set on simple glyph

### DIFF
--- a/Lib/ufo2ft/filters/__main__.py
+++ b/Lib/ufo2ft/filters/__main__.py
@@ -34,8 +34,6 @@ if not args.output:
 
 ufo = loader(args.ufo)
 
-include = None
-
 if args.include:
     include_set = set(args.include.split(","))
 
@@ -47,6 +45,9 @@ elif args.exclude:
 
     def include(g):
         return g.name not in exclude_set
+
+else:
+    include = None
 
 
 for filtername in args.filters:

--- a/Lib/ufo2ft/instructionCompiler.py
+++ b/Lib/ufo2ft/instructionCompiler.py
@@ -11,6 +11,7 @@ from fontTools.ttLib.tables._g_l_y_f import (
     OVERLAP_COMPOUND,
     ROUND_XY_TO_GRID,
     USE_MY_METRICS,
+    flagOverlapSimple,
 )
 
 from ufo2ft.constants import (
@@ -121,6 +122,8 @@ class InstructionCompiler:
             self._compile_tt_glyph_program(glyph, ttGlyph, ttdata)
         if ttGlyph.isComposite():
             self._set_composite_flags(glyph, ttGlyph)
+        else:
+            self._set_simple_flags(glyph, ttGlyph)
 
     def _compile_tt_glyph_program(
         self, glyph: Glyph, ttglyph: TTGlyph, ttdata: dict
@@ -252,6 +255,19 @@ class InstructionCompiler:
         # we try to automatically set it
         if not lib_contains_use_my_metrics_key:
             self.autoUseMyMetrics(ttglyph, glyph.name)
+
+    def _set_simple_flags(self, glyph: Glyph, ttglyph: TTGlyph) -> None:
+        # Set simple glyph flags
+
+        if ttglyph.numberOfContours < 1 or not ttglyph.flags:
+            return
+
+        # Set OVERLAP_SIMPLE
+        if TRUETYPE_OVERLAP_KEY in glyph.lib:
+            if glyph.lib[TRUETYPE_OVERLAP_KEY]:
+                ttglyph.flags[0] |= flagOverlapSimple
+            else:
+                ttglyph.flags[0] &= ~flagOverlapSimple
 
     def update_maxp(self) -> None:
         """Update the maxp table with relevant values from the UFO and compiled

--- a/tests/instructionCompiler_test.py
+++ b/tests/instructionCompiler_test.py
@@ -7,6 +7,7 @@ from fontTools.ttLib.tables._g_l_y_f import (
     OVERLAP_COMPOUND,
     ROUND_XY_TO_GRID,
     USE_MY_METRICS,
+    flagOverlapSimple,
 )
 from fontTools.ttLib.ttFont import TTFont
 
@@ -583,6 +584,23 @@ class InstructionCompilerTest:
             ic._set_composite_flags(glyph=glyph, ttglyph=ttglyph)
 
         assert "Number of components differ" in caplog.text
+
+    @pytest.mark.parametrize("overlap", [None, False, True])
+    def test_set_simple_flags(self, quadufo, quadfont, overlap):
+        ic = InstructionCompiler(quadufo, quadfont)
+        name = "a"
+
+        glyph = quadufo[name]
+        if overlap is not None:
+            glyph.lib = {"public.truetype.overlap": overlap}
+        ttglyph = quadfont["glyf"][name]
+
+        ic._set_simple_flags(glyph=glyph, ttglyph=ttglyph)
+
+        if overlap:
+            assert ttglyph.flags[0] & flagOverlapSimple
+        else:
+            assert not ttglyph.flags[0] & flagOverlapSimple
 
     # update_maxp
 


### PR DESCRIPTION
It turns out we were only reading the UFO `public.truetype.overlap` key for composite glyphs, but not also for simple contour glyphs.
This PRs adds support for that as well.

Fixes/supersedes Fixes https://github.com/googlefonts/ufo2ft/pull/615

https://unifiedfontobject.org/versions/ufo3/glyphs/glif/#publictruetypeoverlap

/cc @jenskutilek @m4rc1e 