### PR TITLE
Fix issue with sparse masters when .notdef contain cubic curves

### DIFF
--- a/Lib/ufo2ft/__init__.py
+++ b/Lib/ufo2ft/__init__.py
@@ -408,7 +408,7 @@ def compileInterpolatableTTFsFromDS(designSpaceDoc, **kwargs):
     kwargs["skipExportGlyphs"] = designSpaceDoc.lib.get("public.skipExportGlyphs", [])
 
     if kwargs["notdefGlyph"] is None:
-        kwargs["notdefGlyph"] = _getDefaultNotdefGlyph(designSpaceDoc)
+        kwargs["notdefGlyph"] = _getDefaultNotdefGlyph(designSpaceDoc, empty=True)
 
     kwargs["extraSubstitutions"] = defaultdict(set)
     for rule in designSpaceDoc.rules:

--- a/Lib/ufo2ft/util.py
+++ b/Lib/ufo2ft/util.py
@@ -475,7 +475,7 @@ def getDefaultMasterFont(designSpaceDoc):
     return defaultSource.font
 
 
-def _getDefaultNotdefGlyph(designSpaceDoc):
+def _getDefaultNotdefGlyph(designSpaceDoc, empty=False):
     from ufo2ft.errors import InvalidDesignSpaceData
 
     try:
@@ -488,6 +488,18 @@ def _getDefaultNotdefGlyph(designSpaceDoc):
             notdefGlyph = baseUfo[".notdef"]
         except KeyError:
             notdefGlyph = None
+        else:
+            if empty:
+                # create a new empty .notdef glyph with the same width/height
+                # as the default master's .notdef glyph to be use for sparse layer
+                # master TTFs, so that it won't participate in gvar interpolation
+                # TODO(anthrotype): Use sentinel values for width/height to
+                # mark the glyph as non-participating for HVAR if/when fonttools
+                # supports that, https://github.com/googlefonts/ufo2ft/issues/501
+                emptyGlyph = _getNewGlyphFactory(notdefGlyph)(".notdef")
+                emptyGlyph.width = notdefGlyph.width
+                emptyGlyph.height = notdefGlyph.height
+                notdefGlyph = emptyGlyph
     return notdefGlyph
 
 


### PR DESCRIPTION
I first push a reproducer for the issue I raised in https://github.com/googlefonts/ufo2ft/issues/501#issuecomment-1660173297

and then follow up with a fix.

EDIT:

previously we were copying ".notdef" glyph from the default master when a sparse layer didn't contain one already, but if the notdef contains some cubic curves then our own check fails because the .notdef that we inserted in the sparse masters' OutlineCompiler was not passed through cu2qu...
Our intention is to have sparse masters _not_ participate in the interpolation of that particular .notdef glyph so we make it empty (a gid0=.notdef still needs to be there for a valid TTF so we must have it there).
Currently the same trick does not work for CFF2 variable fonts (https://github.com/fonttools/fonttools/issues/3233) but those are fine with cubics in .notdef glyph any way.. For now at least