### PR TITLE
Make sparse layers without .notdef not participate in gvar/CFF2/HVAR

### DIFF
--- a/Lib/ufo2ft/__init__.py
+++ b/Lib/ufo2ft/__init__.py
@@ -24,7 +24,7 @@ from ufo2ft.preProcessor import (
     TTFPreProcessor,
 )
 from ufo2ft.util import (
-    _getDefaultNotdefGlyph,
+    _notdefGlyphFallback,
     colrClipBoxQuantization,
     ensure_all_sources_have_names,
     init_kwargs,
@@ -408,7 +408,7 @@ def compileInterpolatableTTFsFromDS(designSpaceDoc, **kwargs):
     kwargs["skipExportGlyphs"] = designSpaceDoc.lib.get("public.skipExportGlyphs", [])
 
     if kwargs["notdefGlyph"] is None:
-        kwargs["notdefGlyph"] = _getDefaultNotdefGlyph(designSpaceDoc, empty=True)
+        kwargs["notdefGlyph"] = _notdefGlyphFallback(designSpaceDoc)
 
     kwargs["extraSubstitutions"] = defaultdict(set)
     for rule in designSpaceDoc.rules:
@@ -479,7 +479,7 @@ def compileInterpolatableOTFsFromDS(designSpaceDoc, **kwargs):
     kwargs["skipExportGlyphs"] = designSpaceDoc.lib.get("public.skipExportGlyphs", [])
 
     if kwargs["notdefGlyph"] is None:
-        kwargs["notdefGlyph"] = _getDefaultNotdefGlyph(designSpaceDoc)
+        kwargs["notdefGlyph"] = _notdefGlyphFallback(designSpaceDoc)
 
     kwargs["extraSubstitutions"] = defaultdict(set)
     for rule in designSpaceDoc.rules:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fonttools[lxml,ufo]==4.40.0
+fonttools[lxml,ufo]==4.42.0
 defcon==0.10.2
 compreffor==0.5.3
 booleanOperations==0.9.0

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     setup_requires=pytest_runner + wheel + ["setuptools_scm"],
     tests_require=["pytest>=2.8"],
     install_requires=[
-        "fonttools[ufo]>=4.40.0",
+        "fonttools[ufo]>=4.42.0",
         "cffsubr>=0.2.8",
         "booleanOperations>=0.9.0",
     ],

--- a/tests/data/TestVariableFont-CFF2-cffsubr.ttx
+++ b/tests/data/TestVariableFont-CFF2-cffsubr.ttx
@@ -471,20 +471,20 @@
         <Region index="0">
           <VarRegionAxis index="0">
             <StartCoord value="0.0"/>
-            <PeakCoord value="0.36365"/>
+            <PeakCoord value="1.0"/>
             <EndCoord value="1.0"/>
           </VarRegionAxis>
         </Region>
         <Region index="1">
           <VarRegionAxis index="0">
-            <StartCoord value="0.36365"/>
-            <PeakCoord value="1.0"/>
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.36365"/>
             <EndCoord value="1.0"/>
           </VarRegionAxis>
         </Region>
         <Region index="2">
           <VarRegionAxis index="0">
-            <StartCoord value="0.0"/>
+            <StartCoord value="0.36365"/>
             <PeakCoord value="1.0"/>
             <EndCoord value="1.0"/>
           </VarRegionAxis>

--- a/tests/data/TestVariableFont-CFF2-post3.ttx
+++ b/tests/data/TestVariableFont-CFF2-post3.ttx
@@ -448,20 +448,20 @@
         <Region index="0">
           <VarRegionAxis index="0">
             <StartCoord value="0.0"/>
-            <PeakCoord value="0.36365"/>
+            <PeakCoord value="1.0"/>
             <EndCoord value="1.0"/>
           </VarRegionAxis>
         </Region>
         <Region index="1">
           <VarRegionAxis index="0">
-            <StartCoord value="0.36365"/>
-            <PeakCoord value="1.0"/>
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.36365"/>
             <EndCoord value="1.0"/>
           </VarRegionAxis>
         </Region>
         <Region index="2">
           <VarRegionAxis index="0">
-            <StartCoord value="0.0"/>
+            <StartCoord value="0.36365"/>
             <PeakCoord value="1.0"/>
             <EndCoord value="1.0"/>
           </VarRegionAxis>

--- a/tests/data/TestVariableFont-CFF2-sparse-notdefGlyph.ttx
+++ b/tests/data/TestVariableFont-CFF2-sparse-notdefGlyph.ttx
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <CFF2>
+    <major value="2"/>
+    <minor value="0"/>
+    <CFFFont name="CFF2Font">
+      <FontMatrix value="0.001 0 0 0.001 0 0"/>
+      <FDArray>
+        <FontDict index="0">
+          <Private>
+            <BlueScale value="0.039625"/>
+            <BlueShift value="7"/>
+            <BlueFuzz value="1"/>
+            <LanguageGroup value="0"/>
+            <ExpansionFactor value="0.06"/>
+          </Private>
+        </FontDict>
+      </FDArray>
+      <CharStrings>
+        <CharString name=".notdef">
+          50 -250 rmoveto
+          400 1000 -400 hlineto
+          50 -950 rmoveto
+          900 300 -900 vlineto
+          100 500 1 blend
+          200 rmoveto
+          278 -112 222 -138 -138 -112 -222 -278 277 -112 223 -138 -138 -112 -223 -277 8 blend
+          vhcurveto
+        </CharString>
+        <CharString name="a">
+          468 -1 rmoveto
+          -21 435 -233 70 -205 -76 27 -91 -56 1 blend
+          172 60 155 -40 -59 2 2 blend
+          3 -360 56 1 blend
+          rlineto
+          12 266 59 -2 2 blend
+          rmoveto
+          -352 -23 3 -218 139 -34 221 83 -6 63 -222 -60 -75 52 15 40 13 37 -21 5 blend
+          2 46 294 35 -78 -30 2 blend
+          rlineto
+        </CharString>
+        <CharString name="dotabovecomb">
+          -21 597 -8 28 2 blend
+          rmoveto
+          -16 -94 78 -2 9 88 -19 -48 44 7 -4 29 6 blend
+          rlineto
+        </CharString>
+        <CharString name="e">
+          1 vsindex
+          127 228 -1 70 -25 1 2 blend
+          rmoveto
+          449 -2 1 -45 -2 -2 2 blend
+          -5 79 -255 208 -276 -252 148 -279 338 63 -17 84 -280 -54 -82 188 170 153 163 -124 -355 6 27 0 0 -27 0 36 0 -29 0 -34 0 31 0 -1 0 2 0 -45 -2 13 28 100 37 0 13 0 -2 55 -40 -54 -32 -86 -30 -57 -85 -60 34 57 84 146 -5 0 21 blend
+          rlineto
+        </CharString>
+        <CharString name="edotabove">
+          127 228 70 1 2 blend
+          rmoveto
+          449 -2 -45 -2 2 blend
+          -5 79 -255 208 -276 -252 148 -279 338 63 -17 84 -27 36 -29 -34 31 -1 2 -45 13 100 10 blend
+          -280 -54 -82 188 170 153 163 -124 -355 55 -54 -86 -57 -60 57 146 7 blend
+          6 rlineto
+          167 395 -84 118 2 blend
+          rmoveto
+          -16 -94 78 -2 9 88 -19 -48 44 7 -4 29 6 blend
+          rlineto
+        </CharString>
+        <CharString name="s">
+          559 459 rmoveto
+          -235 71 -286 -187 389 -188 -145 -79 -229 98 -28 -91 279 -96 278 187 -369 192 113 76 -22 55 -58 -61 19 49 34 9 9 -56 -2 -41 46 12 29 24 -57 -31 18 blend
+          213 -66 rlineto
+        </CharString>
+      </CharStrings>
+      <VarStore Format="1">
+        <Format value="1"/>
+        <VarRegionList>
+          <!-- RegionAxisCount=1 -->
+          <!-- RegionCount=3 -->
+          <Region index="0">
+            <VarRegionAxis index="0">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
+            </VarRegionAxis>
+          </Region>
+          <Region index="1">
+            <VarRegionAxis index="0">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.36365"/>
+              <EndCoord value="1.0"/>
+            </VarRegionAxis>
+          </Region>
+          <Region index="2">
+            <VarRegionAxis index="0">
+              <StartCoord value="0.36365"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
+            </VarRegionAxis>
+          </Region>
+        </VarRegionList>
+        <!-- VarDataCount=2 -->
+        <VarData index="0">
+          <!-- ItemCount=0 -->
+          <NumShorts value="0"/>
+          <!-- VarRegionCount=1 -->
+          <VarRegionIndex index="0" value="0"/>
+        </VarData>
+        <VarData index="1">
+          <!-- ItemCount=0 -->
+          <NumShorts value="0"/>
+          <!-- VarRegionCount=2 -->
+          <VarRegionIndex index="0" value="1"/>
+          <VarRegionIndex index="1" value="2"/>
+        </VarData>
+      </VarStore>
+    </CFFFont>
+
+    <GlobalSubrs>
+      <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+    </GlobalSubrs>
+  </CFF2>
+
+  <hmtx>
+    <mtx name=".notdef" width="500" lsb="0"/>
+    <mtx name="a" width="600" lsb="9"/>
+    <mtx name="dotabovecomb" width="0" lsb="-37"/>
+    <mtx name="e" width="600" lsb="40"/>
+    <mtx name="edotabove" width="600" lsb="40"/>
+    <mtx name="s" width="600" lsb="25"/>
+  </hmtx>
+
+  <HVAR>
+    <Version value="0x00010000"/>
+    <VarStore Format="1">
+      <Format value="1"/>
+      <VarRegionList>
+        <!-- RegionAxisCount=1 -->
+        <!-- RegionCount=3 -->
+        <Region index="0">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="1">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.36365"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="2">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.36365"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+      </VarRegionList>
+      <!-- VarDataCount=1 -->
+      <VarData index="0">
+        <!-- ItemCount=2 -->
+        <NumShorts value="1"/>
+        <!-- VarRegionCount=1 -->
+        <VarRegionIndex index="0" value="0"/>
+        <Item index="0" value="[0]"/>
+        <Item index="1" value="[500]"/>
+      </VarData>
+    </VarStore>
+    <AdvWidthMap>
+      <Map glyph=".notdef" outer="0" inner="1"/>
+      <Map glyph="a" outer="0" inner="0"/>
+      <Map glyph="dotabovecomb" outer="0" inner="0"/>
+      <Map glyph="e" outer="0" inner="0"/>
+      <Map glyph="edotabove" outer="0" inner="0"/>
+      <Map glyph="s" outer="0" inner="0"/>
+    </AdvWidthMap>
+  </HVAR>
+
+</ttFont>

--- a/tests/data/TestVariableFont-CFF2-useProductionNames.ttx
+++ b/tests/data/TestVariableFont-CFF2-useProductionNames.ttx
@@ -465,20 +465,20 @@
         <Region index="0">
           <VarRegionAxis index="0">
             <StartCoord value="0.0"/>
-            <PeakCoord value="0.36365"/>
+            <PeakCoord value="1.0"/>
             <EndCoord value="1.0"/>
           </VarRegionAxis>
         </Region>
         <Region index="1">
           <VarRegionAxis index="0">
-            <StartCoord value="0.36365"/>
-            <PeakCoord value="1.0"/>
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.36365"/>
             <EndCoord value="1.0"/>
           </VarRegionAxis>
         </Region>
         <Region index="2">
           <VarRegionAxis index="0">
-            <StartCoord value="0.0"/>
+            <StartCoord value="0.36365"/>
             <PeakCoord value="1.0"/>
             <EndCoord value="1.0"/>
           </VarRegionAxis>

--- a/tests/data/TestVariableFont-CFF2.ttx
+++ b/tests/data/TestVariableFont-CFF2.ttx
@@ -462,20 +462,20 @@
         <Region index="0">
           <VarRegionAxis index="0">
             <StartCoord value="0.0"/>
-            <PeakCoord value="0.36365"/>
+            <PeakCoord value="1.0"/>
             <EndCoord value="1.0"/>
           </VarRegionAxis>
         </Region>
         <Region index="1">
           <VarRegionAxis index="0">
-            <StartCoord value="0.36365"/>
-            <PeakCoord value="1.0"/>
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.36365"/>
             <EndCoord value="1.0"/>
           </VarRegionAxis>
         </Region>
         <Region index="2">
           <VarRegionAxis index="0">
-            <StartCoord value="0.0"/>
+            <StartCoord value="0.36365"/>
             <PeakCoord value="1.0"/>
             <EndCoord value="1.0"/>
           </VarRegionAxis>

--- a/tests/data/TestVariableFont-TTF-post3.ttx
+++ b/tests/data/TestVariableFont-TTF-post3.ttx
@@ -451,20 +451,20 @@
         <Region index="0">
           <VarRegionAxis index="0">
             <StartCoord value="0.0"/>
-            <PeakCoord value="0.36365"/>
+            <PeakCoord value="1.0"/>
             <EndCoord value="1.0"/>
           </VarRegionAxis>
         </Region>
         <Region index="1">
           <VarRegionAxis index="0">
-            <StartCoord value="0.36365"/>
-            <PeakCoord value="1.0"/>
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.36365"/>
             <EndCoord value="1.0"/>
           </VarRegionAxis>
         </Region>
         <Region index="2">
           <VarRegionAxis index="0">
-            <StartCoord value="0.0"/>
+            <StartCoord value="0.36365"/>
             <PeakCoord value="1.0"/>
             <EndCoord value="1.0"/>
           </VarRegionAxis>

--- a/tests/data/TestVariableFont-TTF-useProductionNames.ttx
+++ b/tests/data/TestVariableFont-TTF-useProductionNames.ttx
@@ -468,20 +468,20 @@
         <Region index="0">
           <VarRegionAxis index="0">
             <StartCoord value="0.0"/>
-            <PeakCoord value="0.36365"/>
+            <PeakCoord value="1.0"/>
             <EndCoord value="1.0"/>
           </VarRegionAxis>
         </Region>
         <Region index="1">
           <VarRegionAxis index="0">
-            <StartCoord value="0.36365"/>
-            <PeakCoord value="1.0"/>
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.36365"/>
             <EndCoord value="1.0"/>
           </VarRegionAxis>
         </Region>
         <Region index="2">
           <VarRegionAxis index="0">
-            <StartCoord value="0.0"/>
+            <StartCoord value="0.36365"/>
             <PeakCoord value="1.0"/>
             <EndCoord value="1.0"/>
           </VarRegionAxis>

--- a/tests/data/TestVariableFont-TTF.ttx
+++ b/tests/data/TestVariableFont-TTF.ttx
@@ -465,20 +465,20 @@
         <Region index="0">
           <VarRegionAxis index="0">
             <StartCoord value="0.0"/>
-            <PeakCoord value="0.36365"/>
+            <PeakCoord value="1.0"/>
             <EndCoord value="1.0"/>
           </VarRegionAxis>
         </Region>
         <Region index="1">
           <VarRegionAxis index="0">
-            <StartCoord value="0.36365"/>
-            <PeakCoord value="1.0"/>
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.36365"/>
             <EndCoord value="1.0"/>
           </VarRegionAxis>
         </Region>
         <Region index="2">
           <VarRegionAxis index="0">
-            <StartCoord value="0.0"/>
+            <StartCoord value="0.36365"/>
             <PeakCoord value="1.0"/>
             <EndCoord value="1.0"/>
           </VarRegionAxis>

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -515,6 +515,23 @@ class IntegrationTest:
         # varLib only warns: https://github.com/fonttools/fonttools/issues/2572
         assert ".notdef" in vf["gvar"].variations
 
+    def test_compileVariableCFF2_sparse_notdefGlyph(self, designspace):
+        # test that sparse layer without .notdef does not participate in computation
+        # of CFF2 and HVAR deltas for the .notdef glypht
+        for src_idx, transform in ((0, (1, 0, 0, 1, 0, 0)), (2, (2, 0, 0, 2, 0, 0))):
+            notdef = designspace.sources[src_idx].font[".notdef"]
+            self.drawCurvedContour(notdef, transform)
+        designspace.sources[2].font[".notdef"].width *= 2
+        assert ".notdef" not in designspace.sources[1].font.layers["Medium"]
+
+        vf = compileVariableCFF2(designspace)
+
+        expectTTX(
+            vf,
+            "TestVariableFont-CFF2-sparse-notdefGlyph.ttx",
+            tables=["CFF2", "hmtx", "HVAR"],
+        )
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main(sys.argv))


### PR DESCRIPTION
requires fonttools >= 4.42
https://github.com/fonttools/fonttools/pull/3235

Fixes https://github.com/googlefonts/ufo2ft/issues/501