### PR TITLE
instructionCompiler: don't log about .notdef missing

### DIFF
--- a/Lib/ufo2ft/instructionCompiler.py
+++ b/Lib/ufo2ft/instructionCompiler.py
@@ -109,11 +109,13 @@ class InstructionCompiler:
         """Compile the glyph instructions from the UFO glyph `name` to bytecode
         and add it to `ttGlyph`."""
         if name not in self.ufo:
-            # Skip glyphs that are not in the UFO, e.g. '.notdef'
-            logger.info(
-                f"Skipping compilation of instructions for glyph '{name}' because it "
-                "is not in the input UFO."
-            )
+            # Skip glyphs that are not in the UFO; no need to inform about '.notdef'
+            # since that glyph is often auto-generated
+            if name != ".notdef":
+                logger.info(
+                    f"Skipping compilation of instructions for glyph '{name}' because it "
+                    "is not in the input UFO."
+                )
             return
 
         glyph = self.ufo[name]

--- a/tests/instructionCompiler_test.py
+++ b/tests/instructionCompiler_test.py
@@ -281,11 +281,18 @@ class InstructionCompilerTest:
 
     def test_compileGlyphInstructions_missing_glyph(self, caplog):
         # The method logs an info when trying to compile a glyph which is
-        # missing in the UFO, e.g. '.notdef'
+        # missing in the UFO
         ic = InstructionCompiler(dict(), None)
         with caplog.at_level(logging.INFO, logger="ufo2ft.instructionCompiler"):
             ic.compileGlyphInstructions(None, "A")
         assert "Skipping compilation of instructions for glyph 'A'" in caplog.text
+        # ... except for '.notdef' which is frequently generated
+        with caplog.at_level(logging.INFO, logger="ufo2ft.instructionCompiler"):
+            ic.compileGlyphInstructions(None, ".notdef")
+        assert (
+            "Skipping compilation of instructions for glyph '.notdef'"
+            not in caplog.text
+        )
 
     # _compile_tt_glyph_program
 


### PR DESCRIPTION
I keep seing logging messages like this coming from ufo2ft.instructionCompiler

```
INFO:ufo2ft.instructionCompiler:Skipping compilation of instructions for glyph '.notdef' because it is not in the input UFO.
```

this is just noise and may also be confusing for the user. ".notdef" glyph is very often automatically generated by ufo2ft, in which case obviously it's because it is missing from the source UFOs, and so there's no need for the instructionCompiler to be chatty about it.