### PR TITLE
Add LTR script kerning to DFLT for InDesign default composer

### DIFF
--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
@@ -581,14 +581,17 @@ class KernFeatureWriter(BaseFeatureWriter):
 
         # InDesign bugfix: register kerning lookups for all LTR scripts under DFLT
         # so that the basic composer, without a language selected, will still kern.
+        # Register LTR lookups if any, otherwise RTL lookups.
         if isKernBlock:
-            for script in sorted(lookups):
-                if (
-                    script_horizontal_direction(script, "LTR") == "LTR"
-                    and script not in DIST_ENABLED_SCRIPTS
-                    and script != COMMON_SCRIPT
-                ):
-                    dfltLookups.extend(lookups[script].values())
+            lookupsLTR: list[ast.LookupBlock] = []
+            lookupsRTL: list[ast.LookupBlock] = []
+            for script, scriptLookups in sorted(lookups.items()):
+                if script != COMMON_SCRIPT and script not in DIST_ENABLED_SCRIPTS:
+                    if script_horizontal_direction(script, "LTR") == "LTR":
+                        lookupsLTR.extend(scriptLookups.values())
+                    elif script_horizontal_direction(script, "LTR") == "RTL":
+                        lookupsRTL.extend(scriptLookups.values())
+            dfltLookups.extend(lookupsLTR or lookupsRTL)
 
         if dfltLookups:
             languages = feaLanguagesByScript.get("DFLT", ["dflt"])

--- a/tests/data/TestFont-CFF-compreffor.ttx
+++ b/tests/data/TestFont-CFF-compreffor.ttx
@@ -390,8 +390,19 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=1 -->
+      <!-- ScriptCount=2 -->
       <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
         <ScriptTag value="latn"/>
         <Script>
           <DefaultLangSys>

--- a/tests/data/TestFont-CFF.ttx
+++ b/tests/data/TestFont-CFF.ttx
@@ -406,8 +406,19 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=1 -->
+      <!-- ScriptCount=2 -->
       <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
         <ScriptTag value="latn"/>
         <Script>
           <DefaultLangSys>

--- a/tests/data/TestFont-CFF2-cffsubr.ttx
+++ b/tests/data/TestFont-CFF2-cffsubr.ttx
@@ -412,8 +412,19 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=1 -->
+      <!-- ScriptCount=2 -->
       <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
         <ScriptTag value="latn"/>
         <Script>
           <DefaultLangSys>

--- a/tests/data/TestFont-CFF2-post3.ttx
+++ b/tests/data/TestFont-CFF2-post3.ttx
@@ -387,8 +387,19 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=1 -->
+      <!-- ScriptCount=2 -->
       <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
         <ScriptTag value="latn"/>
         <Script>
           <DefaultLangSys>

--- a/tests/data/TestFont-NoOptimize-CFF.ttx
+++ b/tests/data/TestFont-NoOptimize-CFF.ttx
@@ -409,8 +409,19 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=1 -->
+      <!-- ScriptCount=2 -->
       <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
         <ScriptTag value="latn"/>
         <Script>
           <DefaultLangSys>

--- a/tests/data/TestFont-NoOptimize-CFF2.ttx
+++ b/tests/data/TestFont-NoOptimize-CFF2.ttx
@@ -421,8 +421,19 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=1 -->
+      <!-- ScriptCount=2 -->
       <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
         <ScriptTag value="latn"/>
         <Script>
           <DefaultLangSys>

--- a/tests/data/TestFont-NoOverlaps-CFF-pathops.ttx
+++ b/tests/data/TestFont-NoOverlaps-CFF-pathops.ttx
@@ -401,8 +401,19 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=1 -->
+      <!-- ScriptCount=2 -->
       <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
         <ScriptTag value="latn"/>
         <Script>
           <DefaultLangSys>

--- a/tests/data/TestFont-NoOverlaps-CFF.ttx
+++ b/tests/data/TestFont-NoOverlaps-CFF.ttx
@@ -398,8 +398,19 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=1 -->
+      <!-- ScriptCount=2 -->
       <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
         <ScriptTag value="latn"/>
         <Script>
           <DefaultLangSys>

--- a/tests/data/TestFont-NoOverlaps-TTF-pathops.ttx
+++ b/tests/data/TestFont-NoOverlaps-TTF-pathops.ttx
@@ -485,8 +485,19 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=1 -->
+      <!-- ScriptCount=2 -->
       <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
         <ScriptTag value="latn"/>
         <Script>
           <DefaultLangSys>

--- a/tests/data/TestFont-NoOverlaps-TTF.ttx
+++ b/tests/data/TestFont-NoOverlaps-TTF.ttx
@@ -485,8 +485,19 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=1 -->
+      <!-- ScriptCount=2 -->
       <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
         <ScriptTag value="latn"/>
         <Script>
           <DefaultLangSys>

--- a/tests/data/TestFont-Specialized-CFF.ttx
+++ b/tests/data/TestFont-Specialized-CFF.ttx
@@ -387,8 +387,19 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=1 -->
+      <!-- ScriptCount=2 -->
       <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
         <ScriptTag value="latn"/>
         <Script>
           <DefaultLangSys>

--- a/tests/data/TestFont-Specialized-CFF2.ttx
+++ b/tests/data/TestFont-Specialized-CFF2.ttx
@@ -399,8 +399,19 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=1 -->
+      <!-- ScriptCount=2 -->
       <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
         <ScriptTag value="latn"/>
         <Script>
           <DefaultLangSys>

--- a/tests/data/TestFont-TTF-post3.ttx
+++ b/tests/data/TestFont-TTF-post3.ttx
@@ -458,8 +458,19 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=1 -->
+      <!-- ScriptCount=2 -->
       <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
         <ScriptTag value="latn"/>
         <Script>
           <DefaultLangSys>

--- a/tests/data/TestFont.ttx
+++ b/tests/data/TestFont.ttx
@@ -483,8 +483,19 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=1 -->
+      <!-- ScriptCount=2 -->
       <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
         <ScriptTag value="latn"/>
         <Script>
           <DefaultLangSys>

--- a/tests/featureWriters/kernFeatureWriter_test.py
+++ b/tests/featureWriters/kernFeatureWriter_test.py
@@ -576,6 +576,10 @@ class KernFeatureWriterTest(FeatureWriterTest):
             } kern_Arab;
 
             feature kern {
+                script DFLT;
+                language dflt;
+                lookup kern_Arab;
+
                 script arab;
                 language dflt;
                 lookup kern_Arab;
@@ -602,6 +606,11 @@ class KernFeatureWriterTest(FeatureWriterTest):
             } kern_Thaa;
 
             feature kern {
+                script DFLT;
+                language dflt;
+                lookup kern_Arab;
+                lookup kern_Thaa;
+
                 script arab;
                 language dflt;
                 lookup kern_Arab;
@@ -624,6 +633,10 @@ class KernFeatureWriterTest(FeatureWriterTest):
             } kern_Thaa;
 
             feature kern {
+                script DFLT;
+                language dflt;
+                lookup kern_Thaa;
+
                 script thaa;
                 language dflt;
                 lookup kern_Thaa;
@@ -1043,6 +1056,11 @@ class KernFeatureWriterTest(FeatureWriterTest):
             } kern_Arab_marks;
 
             feature kern {
+                script DFLT;
+                language dflt;
+                lookup kern_Arab;
+                lookup kern_Arab_marks;
+
                 script arab;
                 language dflt;
                 lookup kern_Arab;
@@ -1284,6 +1302,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
                 script DFLT;
                 language dflt;
                 lookup kern_Default;
+                lookup kern_Hebr;
 
                 script hebr;
                 language dflt;
@@ -1677,6 +1696,11 @@ def test_kern_multi_script(FontClass):
         } kern_Nkoo;
 
         feature kern {
+            script DFLT;
+            language dflt;
+            lookup kern_Arab;
+            lookup kern_Nkoo;
+
             script arab;
             language dflt;
             lookup kern_Arab;

--- a/tests/featureWriters/kernFeatureWriter_test.py
+++ b/tests/featureWriters/kernFeatureWriter_test.py
@@ -154,7 +154,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
 
         # default is ignoreMarks=True
         feaFile = self.writeFeatures(font)
-        assert str(feaFile) == dedent(
+        assert dedent(str(feaFile)) == dedent(
             """\
             lookup kern_Latn {
                 lookupflag IgnoreMarks;
@@ -166,6 +166,11 @@ class KernFeatureWriterTest(FeatureWriterTest):
             } kern_Latn_marks;
 
             feature kern {
+                script DFLT;
+                language dflt;
+                lookup kern_Latn;
+                lookup kern_Latn_marks;
+                
                 script latn;
                 language dflt;
                 lookup kern_Latn;
@@ -175,7 +180,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
         )
 
         feaFile = self.writeFeatures(font, ignoreMarks=False)
-        assert str(feaFile) == dedent(
+        assert dedent(str(feaFile)) == dedent(
             """\
             lookup kern_Latn {
                 pos A acutecomb -55;
@@ -183,6 +188,10 @@ class KernFeatureWriterTest(FeatureWriterTest):
             } kern_Latn;
 
             feature kern {
+                script DFLT;
+                language dflt;
+                lookup kern_Latn;
+                
                 script latn;
                 language dflt;
                 lookup kern_Latn;
@@ -664,6 +673,10 @@ class KernFeatureWriterTest(FeatureWriterTest):
             } kern_Latn;
 
             feature kern {
+                script DFLT;
+                language dflt;
+                lookup kern_Latn;
+
                 script latn;
                 language dflt;
                 lookup kern_Latn;
@@ -713,6 +726,10 @@ class KernFeatureWriterTest(FeatureWriterTest):
             } kern_Latn;
 
             feature kern {
+                script DFLT;
+                language dflt;
+                lookup kern_Latn;
+
                 script latn;
                 language dflt;
                 lookup kern_Latn;
@@ -807,6 +824,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
                 script DFLT;
                 language dflt;
                 lookup kern_Default;
+                lookup kern_Latn;
 
                 script arab;
                 language dflt;
@@ -932,6 +950,8 @@ class KernFeatureWriterTest(FeatureWriterTest):
                 script DFLT;
                 language dflt;
                 lookup kern_Default;
+                lookup kern_Latn;
+                lookup kern_Latn_marks;
 
                 script arab;
                 language dflt;
@@ -1052,6 +1072,10 @@ class KernFeatureWriterTest(FeatureWriterTest):
             } kern_Latn;
 
             feature kern {
+                script DFLT;
+                language dflt;
+                lookup kern_Latn;
+ 
                 script arab;
                 language dflt;
                 lookup kern_Arab;
@@ -1397,6 +1421,7 @@ def test_kern_split_multi_glyph_class(FontClass):
             script DFLT;
             language dflt;
             lookup kern_Default;
+            lookup kern_Latn;
 
             script latn;
             language dflt;
@@ -1480,6 +1505,11 @@ def test_kern_split_and_drop(FontClass, caplog):
         } kern_Orya;
 
         feature kern {
+            script DFLT;
+            language dflt;
+            lookup kern_Grek;
+            lookup kern_Latn;
+
             script grek;
             language dflt;
             lookup kern_Grek;
@@ -1538,6 +1568,10 @@ def test_kern_split_and_drop_mixed(caplog, FontClass):
         } kern_Latn;
 
         feature kern {
+            script DFLT;
+            language dflt;
+            lookup kern_Latn;
+
             script latn;
             language dflt;
             lookup kern_Latn;
@@ -1575,6 +1609,10 @@ def test_kern_split_and_mix_common(FontClass):
         } kern_Nkoo;
 
         feature kern {
+            script DFLT;
+            language dflt;
+            lookup kern_Latn;
+
             script latn;
             language dflt;
             lookup kern_Latn;
@@ -1707,6 +1745,7 @@ def test_kern_mixed_bidis(caplog, FontClass):
             script DFLT;
             language dflt;
             lookup kern_Default;
+            lookup kern_Latn;
 
             script arab;
             language dflt;
@@ -1825,6 +1864,9 @@ def test_kern_zyyy_zinh(FontClass):
             script DFLT;
             language dflt;
             lookup kern_Default;
+            lookup kern_Grek;
+            lookup kern_Hani;
+            lookup kern_Hrkt;
 
             script grek;
             language dflt;
@@ -1903,6 +1945,7 @@ def test_kern_hira_kana_hrkt(FontClass):
             script DFLT;
             language dflt;
             lookup kern_Default;
+            lookup kern_Hrkt;
 
             script kana;
             language dflt;
@@ -2164,6 +2207,7 @@ def test_dflt_language(FontClass):
             script DFLT;
             language dflt;
             lookup kern_Default;
+            lookup kern_Latn;
             language ZND;
 
             script latn;


### PR DESCRIPTION
Hello, this is an Adobe-specific "fix" for the following situation: in InDesign, using the default paragraph composer (not World-ready), and having no language selected, InDesign will not bother detecting the actual script of the text runs, and use the appropriate kerning; instead it sticks to only what is registered in the DFLT script.

With the split by script kerning, there's very little kerning under DFLT and it looks as though the font is unkerned.

In this PR I'm registering all the LTR script lookups under DFLT, so that InDesign applies that kerning even when no language is selected. The idea is that for RTL scripts you need to switch to the "good" composer anyway, so no need to bother.