### PR TITLE
Fix InDesign default composer kerning when mixing two scripts with a language selected

### DIFF
--- a/tests/featureWriters/kernFeatureWriter_test.py
+++ b/tests/featureWriters/kernFeatureWriter_test.py
@@ -1532,9 +1532,11 @@ def test_kern_split_and_drop(FontClass, caplog):
             script grek;
             language dflt;
             lookup kern_Grek;
+            lookup kern_Latn;
 
             script latn;
             language dflt;
+            lookup kern_Grek;
             lookup kern_Latn;
         } kern;
 
@@ -1896,15 +1898,21 @@ def test_kern_zyyy_zinh(FontClass):
             language dflt;
             lookup kern_Default;
             lookup kern_Grek;
+            lookup kern_Hani;
+            lookup kern_Hrkt;
 
             script hani;
             language dflt;
             lookup kern_Default;
+            lookup kern_Grek;
             lookup kern_Hani;
+            lookup kern_Hrkt;
 
             script kana;
             language dflt;
             lookup kern_Default;
+            lookup kern_Grek;
+            lookup kern_Hani;
             lookup kern_Hrkt;
         } kern;
 


### PR DESCRIPTION
Picture explanation of the issue:

![image](https://github.com/googlefonts/ufo2ft/assets/3616772/1414ac75-acfc-44ee-8716-77a93700ee66)

It seems that the default composer prefers to trust the Language setting of the text, as opposed to segmenting the text into per-script runs, and only applies features registered in the script of the selected language? Just guessing, no idea how it really works.

It's sort of a regression from previous ufo2ft without kern splitting, because then all LTR kerning was together in one big lookup anyway.

This one feels a bit like walking backwards from the nice split-by-script kerning, but in the spirit of having fonts that work out of box even in sub-optimal settings, we're planning to use this fix anyway.

This could maybe go behind a flag? It's kind of garbage