### PR TITLE
use upem as default caretSlopeRise for both upright/oblique fonts

### DIFF
--- a/Lib/ufo2ft/fontInfoData.py
+++ b/Lib/ufo2ft/fontInfoData.py
@@ -133,9 +133,9 @@ def openTypeHheaDescenderFallback(info):
 def openTypeHheaCaretSlopeRiseFallback(info):
     """
     Fallback to *openTypeHheaCaretSlopeRise*. If the italicAngle is zero,
-    return 1. If italicAngle is non-zero, compute the slope rise from the
+    return UPEM. If italicAngle is non-zero, compute the slope rise from the
     complementary openTypeHheaCaretSlopeRun, if the latter is defined.
-    Else, default to an arbitrary fixed reference point (1000).
+    Else, default to the font's UPEM.
     """
     italicAngle = getAttrWithFallback(info, "italicAngle")
     if italicAngle != 0:
@@ -145,9 +145,7 @@ def openTypeHheaCaretSlopeRiseFallback(info):
         ):
             slopeRun = info.openTypeHheaCaretSlopeRun
             return otRound(slopeRun / math.tan(math.radians(-italicAngle)))
-        else:
-            return 1000  # just an arbitrary non-zero reference point
-    return 1
+    return getAttrWithFallback(info, "unitsPerEm")
 
 
 def openTypeHheaCaretSlopeRunFallback(info):

--- a/tests/data/DSv5/MutatorSansVariable_Weight-CFF2.ttx
+++ b/tests/data/DSv5/MutatorSansVariable_Weight-CFF2.ttx
@@ -41,7 +41,7 @@
     <minLeftSideBearing value="0"/>
     <minRightSideBearing value="-10"/>
     <xMaxExtent value="450"/>
-    <caretSlopeRise value="1"/>
+    <caretSlopeRise value="1000"/>
     <caretSlopeRun value="0"/>
     <caretOffset value="0"/>
     <reserved0 value="0"/>

--- a/tests/data/DSv5/MutatorSansVariable_Weight-TTF.ttx
+++ b/tests/data/DSv5/MutatorSansVariable_Weight-TTF.ttx
@@ -41,7 +41,7 @@
     <minLeftSideBearing value="0"/>
     <minRightSideBearing value="-10"/>
     <xMaxExtent value="450"/>
-    <caretSlopeRise value="1"/>
+    <caretSlopeRise value="1000"/>
     <caretSlopeRun value="0"/>
     <caretOffset value="0"/>
     <reserved0 value="0"/>

--- a/tests/data/DSv5/MutatorSansVariable_Weight_Width-CFF2.ttx
+++ b/tests/data/DSv5/MutatorSansVariable_Weight_Width-CFF2.ttx
@@ -41,7 +41,7 @@
     <minLeftSideBearing value="0"/>
     <minRightSideBearing value="-10"/>
     <xMaxExtent value="450"/>
-    <caretSlopeRise value="1"/>
+    <caretSlopeRise value="1000"/>
     <caretSlopeRun value="0"/>
     <caretOffset value="0"/>
     <reserved0 value="0"/>

--- a/tests/data/DSv5/MutatorSansVariable_Weight_Width-TTF.ttx
+++ b/tests/data/DSv5/MutatorSansVariable_Weight_Width-TTF.ttx
@@ -41,7 +41,7 @@
     <minLeftSideBearing value="0"/>
     <minRightSideBearing value="-10"/>
     <xMaxExtent value="450"/>
-    <caretSlopeRise value="1"/>
+    <caretSlopeRise value="1000"/>
     <caretSlopeRun value="0"/>
     <caretOffset value="0"/>
     <reserved0 value="0"/>

--- a/tests/data/DSv5/MutatorSansVariable_Width-CFF2.ttx
+++ b/tests/data/DSv5/MutatorSansVariable_Width-CFF2.ttx
@@ -41,7 +41,7 @@
     <minLeftSideBearing value="0"/>
     <minRightSideBearing value="-10"/>
     <xMaxExtent value="450"/>
-    <caretSlopeRise value="1"/>
+    <caretSlopeRise value="1000"/>
     <caretSlopeRun value="0"/>
     <caretOffset value="0"/>
     <reserved0 value="0"/>

--- a/tests/data/DSv5/MutatorSansVariable_Width-TTF.ttx
+++ b/tests/data/DSv5/MutatorSansVariable_Width-TTF.ttx
@@ -41,7 +41,7 @@
     <minLeftSideBearing value="0"/>
     <minRightSideBearing value="-10"/>
     <xMaxExtent value="450"/>
-    <caretSlopeRise value="1"/>
+    <caretSlopeRise value="1000"/>
     <caretSlopeRun value="0"/>
     <caretOffset value="0"/>
     <reserved0 value="0"/>

--- a/tests/data/DSv5/MutatorSerifVariable_Width-CFF2.ttx
+++ b/tests/data/DSv5/MutatorSerifVariable_Width-CFF2.ttx
@@ -41,7 +41,7 @@
     <minLeftSideBearing value="-70"/>
     <minRightSideBearing value="-80"/>
     <xMaxExtent value="450"/>
-    <caretSlopeRise value="1"/>
+    <caretSlopeRise value="1000"/>
     <caretSlopeRun value="0"/>
     <caretOffset value="0"/>
     <reserved0 value="0"/>

--- a/tests/data/DSv5/MutatorSerifVariable_Width-TTF.ttx
+++ b/tests/data/DSv5/MutatorSerifVariable_Width-TTF.ttx
@@ -41,7 +41,7 @@
     <minLeftSideBearing value="-70"/>
     <minRightSideBearing value="-80"/>
     <xMaxExtent value="450"/>
-    <caretSlopeRise value="1"/>
+    <caretSlopeRise value="1000"/>
     <caretSlopeRun value="0"/>
     <caretOffset value="0"/>
     <reserved0 value="0"/>

--- a/tests/data/TestVariableFont-CFF2-cffsubr.ttx
+++ b/tests/data/TestVariableFont-CFF2-cffsubr.ttx
@@ -41,7 +41,7 @@
     <minLeftSideBearing value="-37"/>
     <minRightSideBearing value="-50"/>
     <xMaxExtent value="582"/>
-    <caretSlopeRise value="1"/>
+    <caretSlopeRise value="1000"/>
     <caretSlopeRun value="0"/>
     <caretOffset value="0"/>
     <reserved0 value="0"/>

--- a/tests/data/TestVariableFont-CFF2-post3.ttx
+++ b/tests/data/TestVariableFont-CFF2-post3.ttx
@@ -41,7 +41,7 @@
     <minLeftSideBearing value="-37"/>
     <minRightSideBearing value="-50"/>
     <xMaxExtent value="582"/>
-    <caretSlopeRise value="1"/>
+    <caretSlopeRise value="1000"/>
     <caretSlopeRun value="0"/>
     <caretOffset value="0"/>
     <reserved0 value="0"/>

--- a/tests/data/TestVariableFont-CFF2-useProductionNames.ttx
+++ b/tests/data/TestVariableFont-CFF2-useProductionNames.ttx
@@ -41,7 +41,7 @@
     <minLeftSideBearing value="-37"/>
     <minRightSideBearing value="-50"/>
     <xMaxExtent value="582"/>
-    <caretSlopeRise value="1"/>
+    <caretSlopeRise value="1000"/>
     <caretSlopeRun value="0"/>
     <caretOffset value="0"/>
     <reserved0 value="0"/>

--- a/tests/data/TestVariableFont-CFF2.ttx
+++ b/tests/data/TestVariableFont-CFF2.ttx
@@ -41,7 +41,7 @@
     <minLeftSideBearing value="-37"/>
     <minRightSideBearing value="-50"/>
     <xMaxExtent value="582"/>
-    <caretSlopeRise value="1"/>
+    <caretSlopeRise value="1000"/>
     <caretSlopeRun value="0"/>
     <caretOffset value="0"/>
     <reserved0 value="0"/>

--- a/tests/data/TestVariableFont-TTF-post3.ttx
+++ b/tests/data/TestVariableFont-TTF-post3.ttx
@@ -41,7 +41,7 @@
     <minLeftSideBearing value="-37"/>
     <minRightSideBearing value="-50"/>
     <xMaxExtent value="582"/>
-    <caretSlopeRise value="1"/>
+    <caretSlopeRise value="1000"/>
     <caretSlopeRun value="0"/>
     <caretOffset value="0"/>
     <reserved0 value="0"/>

--- a/tests/data/TestVariableFont-TTF-useProductionNames.ttx
+++ b/tests/data/TestVariableFont-TTF-useProductionNames.ttx
@@ -41,7 +41,7 @@
     <minLeftSideBearing value="-37"/>
     <minRightSideBearing value="-50"/>
     <xMaxExtent value="582"/>
-    <caretSlopeRise value="1"/>
+    <caretSlopeRise value="1000"/>
     <caretSlopeRun value="0"/>
     <caretOffset value="0"/>
     <reserved0 value="0"/>

--- a/tests/data/TestVariableFont-TTF.ttx
+++ b/tests/data/TestVariableFont-TTF.ttx
@@ -41,7 +41,7 @@
     <minLeftSideBearing value="-37"/>
     <minRightSideBearing value="-50"/>
     <xMaxExtent value="582"/>
-    <caretSlopeRise value="1"/>
+    <caretSlopeRise value="1000"/>
     <caretSlopeRun value="0"/>
     <caretOffset value="0"/>
     <reserved0 value="0"/>

--- a/tests/fontInfoData_test.py
+++ b/tests/fontInfoData_test.py
@@ -133,7 +133,7 @@ class GetAttrWithFallbackTest:
         assert getAttrWithFallback(info, "openTypeOS2WinDescent") == 250
 
     def test_caret_slope(self, info):
-        assert getAttrWithFallback(info, "openTypeHheaCaretSlopeRise") == 1
+        assert getAttrWithFallback(info, "openTypeHheaCaretSlopeRise") == 1000
         assert getAttrWithFallback(info, "openTypeHheaCaretSlopeRun") == 0
 
         info.italicAngle = -12


### PR DESCRIPTION
... so that if masters have different italicAngles only their slope run is allowed to vary, whereas the rise stays fixed

Fixes https://github.com/googlefonts/ufo2ft/issues/804

This will produce a lot of diff noise for nothing downstream, but I think it's for good