### PR TITLE
Fix DeprecationWarning: datetime.datetime.utcfromtimestamp()

### DIFF
--- a/Lib/ufo2ft/fontInfoData.py
+++ b/Lib/ufo2ft/fontInfoData.py
@@ -17,7 +17,7 @@ import math
 import os
 import time
 import unicodedata
-from datetime import datetime
+from datetime import datetime, timezone
 
 from fontTools import ufoLib
 from fontTools.misc.fixedTools import otRound
@@ -104,7 +104,7 @@ def openTypeHeadCreatedFallback(info):
     now.
     """
     if "SOURCE_DATE_EPOCH" in os.environ:
-        t = datetime.utcfromtimestamp(int(os.environ["SOURCE_DATE_EPOCH"]))
+        t = datetime.fromtimestamp(int(os.environ["SOURCE_DATE_EPOCH"]), timezone.utc)
         return t.strftime(_date_format)
     else:
         return dateStringForNow()


### PR DESCRIPTION
```
tests/fontInfoData_test.py::GetAttrWithFallbackTest::test_head_created[ufoLib2]
  /Users/clupo/oss/ufo2ft/Lib/ufo2ft/fontInfoData.py:107: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
```