### PR TITLE
Fix variable anchors when DesignSpace source specifies a layer

### DIFF
--- a/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
@@ -417,9 +417,13 @@ class BaseFeatureWriter:
             y_value = VariableScalar()
             found = False
             for source in designspace.sources:
-                if glyphName not in source.font:
+                if source.layerName is None:
+                    layer = source.font
+                else:
+                    layer = source.font.layers[source.layerName]
+                if glyphName not in layer:
                     continue
-                glyph = source.font[glyphName]
+                glyph = layer[glyphName]
                 for anchor in glyph.anchors:
                     if anchor.name == anchorName:
                         location = get_userspace_location(designspace, source.location)

--- a/tests/data/TestVariableFont-CFF2-cffsubr.ttx
+++ b/tests/data/TestVariableFont-CFF2-cffsubr.ttx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ttFont sfntVersion="OTTO" ttLibVersion="4.44">
+<ttFont sfntVersion="OTTO" ttLibVersion="4.51">
 
   <GlyphOrder>
     <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
@@ -319,8 +319,15 @@
       <Format value="1"/>
       <VarRegionList>
         <!-- RegionAxisCount=1 -->
-        <!-- RegionCount=1 -->
+        <!-- RegionCount=2 -->
         <Region index="0">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.36365"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="1">
           <VarRegionAxis index="0">
             <StartCoord value="0.36365"/>
             <PeakCoord value="1.0"/>
@@ -332,10 +339,11 @@
       <VarData index="0">
         <!-- ItemCount=2 -->
         <NumShorts value="0"/>
-        <!-- VarRegionCount=1 -->
+        <!-- VarRegionCount=2 -->
         <VarRegionIndex index="0" value="0"/>
-        <Item index="0" value="[1]"/>
-        <Item index="1" value="[88]"/>
+        <VarRegionIndex index="1" value="1"/>
+        <Item index="0" value="[11, 88]"/>
+        <Item index="1" value="[89, 1]"/>
       </VarData>
     </VarStore>
   </GDEF>
@@ -398,12 +406,12 @@
                 <YCoordinate value="556"/>
                 <XDeviceTable>
                   <StartSize value="0"/>
-                  <EndSize value="0"/>
+                  <EndSize value="1"/>
                   <DeltaFormat value="32768"/>
                 </XDeviceTable>
                 <YDeviceTable>
                   <StartSize value="0"/>
-                  <EndSize value="1"/>
+                  <EndSize value="0"/>
                   <DeltaFormat value="32768"/>
                 </YDeviceTable>
               </BaseAnchor>

--- a/tests/data/TestVariableFont-CFF2-post3.ttx
+++ b/tests/data/TestVariableFont-CFF2-post3.ttx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ttFont sfntVersion="OTTO" ttLibVersion="4.44">
+<ttFont sfntVersion="OTTO" ttLibVersion="4.51">
 
   <GlyphOrder>
     <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
@@ -302,8 +302,15 @@
       <Format value="1"/>
       <VarRegionList>
         <!-- RegionAxisCount=1 -->
-        <!-- RegionCount=1 -->
+        <!-- RegionCount=2 -->
         <Region index="0">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.36365"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="1">
           <VarRegionAxis index="0">
             <StartCoord value="0.36365"/>
             <PeakCoord value="1.0"/>
@@ -315,10 +322,11 @@
       <VarData index="0">
         <!-- ItemCount=2 -->
         <NumShorts value="0"/>
-        <!-- VarRegionCount=1 -->
+        <!-- VarRegionCount=2 -->
         <VarRegionIndex index="0" value="0"/>
-        <Item index="0" value="[1]"/>
-        <Item index="1" value="[88]"/>
+        <VarRegionIndex index="1" value="1"/>
+        <Item index="0" value="[11, 88]"/>
+        <Item index="1" value="[89, 1]"/>
       </VarData>
     </VarStore>
   </GDEF>
@@ -381,12 +389,12 @@
                 <YCoordinate value="556"/>
                 <XDeviceTable>
                   <StartSize value="0"/>
-                  <EndSize value="0"/>
+                  <EndSize value="1"/>
                   <DeltaFormat value="32768"/>
                 </XDeviceTable>
                 <YDeviceTable>
                   <StartSize value="0"/>
-                  <EndSize value="1"/>
+                  <EndSize value="0"/>
                   <DeltaFormat value="32768"/>
                 </YDeviceTable>
               </BaseAnchor>

--- a/tests/data/TestVariableFont-CFF2-useProductionNames.ttx
+++ b/tests/data/TestVariableFont-CFF2-useProductionNames.ttx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ttFont sfntVersion="OTTO" ttLibVersion="4.44">
+<ttFont sfntVersion="OTTO" ttLibVersion="4.51">
 
   <GlyphOrder>
     <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
@@ -319,8 +319,15 @@
       <Format value="1"/>
       <VarRegionList>
         <!-- RegionAxisCount=1 -->
-        <!-- RegionCount=1 -->
+        <!-- RegionCount=2 -->
         <Region index="0">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.36365"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="1">
           <VarRegionAxis index="0">
             <StartCoord value="0.36365"/>
             <PeakCoord value="1.0"/>
@@ -332,10 +339,11 @@
       <VarData index="0">
         <!-- ItemCount=2 -->
         <NumShorts value="0"/>
-        <!-- VarRegionCount=1 -->
+        <!-- VarRegionCount=2 -->
         <VarRegionIndex index="0" value="0"/>
-        <Item index="0" value="[1]"/>
-        <Item index="1" value="[88]"/>
+        <VarRegionIndex index="1" value="1"/>
+        <Item index="0" value="[11, 88]"/>
+        <Item index="1" value="[89, 1]"/>
       </VarData>
     </VarStore>
   </GDEF>
@@ -398,12 +406,12 @@
                 <YCoordinate value="556"/>
                 <XDeviceTable>
                   <StartSize value="0"/>
-                  <EndSize value="0"/>
+                  <EndSize value="1"/>
                   <DeltaFormat value="32768"/>
                 </XDeviceTable>
                 <YDeviceTable>
                   <StartSize value="0"/>
-                  <EndSize value="1"/>
+                  <EndSize value="0"/>
                   <DeltaFormat value="32768"/>
                 </YDeviceTable>
               </BaseAnchor>

--- a/tests/data/TestVariableFont-CFF2.ttx
+++ b/tests/data/TestVariableFont-CFF2.ttx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ttFont sfntVersion="OTTO" ttLibVersion="4.44">
+<ttFont sfntVersion="OTTO" ttLibVersion="4.51">
 
   <GlyphOrder>
     <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
@@ -316,8 +316,15 @@
       <Format value="1"/>
       <VarRegionList>
         <!-- RegionAxisCount=1 -->
-        <!-- RegionCount=1 -->
+        <!-- RegionCount=2 -->
         <Region index="0">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.36365"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="1">
           <VarRegionAxis index="0">
             <StartCoord value="0.36365"/>
             <PeakCoord value="1.0"/>
@@ -329,10 +336,11 @@
       <VarData index="0">
         <!-- ItemCount=2 -->
         <NumShorts value="0"/>
-        <!-- VarRegionCount=1 -->
+        <!-- VarRegionCount=2 -->
         <VarRegionIndex index="0" value="0"/>
-        <Item index="0" value="[1]"/>
-        <Item index="1" value="[88]"/>
+        <VarRegionIndex index="1" value="1"/>
+        <Item index="0" value="[11, 88]"/>
+        <Item index="1" value="[89, 1]"/>
       </VarData>
     </VarStore>
   </GDEF>
@@ -395,12 +403,12 @@
                 <YCoordinate value="556"/>
                 <XDeviceTable>
                   <StartSize value="0"/>
-                  <EndSize value="0"/>
+                  <EndSize value="1"/>
                   <DeltaFormat value="32768"/>
                 </XDeviceTable>
                 <YDeviceTable>
                   <StartSize value="0"/>
-                  <EndSize value="1"/>
+                  <EndSize value="0"/>
                   <DeltaFormat value="32768"/>
                 </YDeviceTable>
               </BaseAnchor>

--- a/tests/data/TestVariableFont-TTF-post3.ttx
+++ b/tests/data/TestVariableFont-TTF-post3.ttx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.44">
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.51">
 
   <GlyphOrder>
     <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
@@ -305,8 +305,15 @@
       <Format value="1"/>
       <VarRegionList>
         <!-- RegionAxisCount=1 -->
-        <!-- RegionCount=1 -->
+        <!-- RegionCount=2 -->
         <Region index="0">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.36365"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="1">
           <VarRegionAxis index="0">
             <StartCoord value="0.36365"/>
             <PeakCoord value="1.0"/>
@@ -318,10 +325,11 @@
       <VarData index="0">
         <!-- ItemCount=2 -->
         <NumShorts value="0"/>
-        <!-- VarRegionCount=1 -->
+        <!-- VarRegionCount=2 -->
         <VarRegionIndex index="0" value="0"/>
-        <Item index="0" value="[1]"/>
-        <Item index="1" value="[88]"/>
+        <VarRegionIndex index="1" value="1"/>
+        <Item index="0" value="[11, 88]"/>
+        <Item index="1" value="[89, 1]"/>
       </VarData>
     </VarStore>
   </GDEF>
@@ -384,12 +392,12 @@
                 <YCoordinate value="556"/>
                 <XDeviceTable>
                   <StartSize value="0"/>
-                  <EndSize value="0"/>
+                  <EndSize value="1"/>
                   <DeltaFormat value="32768"/>
                 </XDeviceTable>
                 <YDeviceTable>
                   <StartSize value="0"/>
-                  <EndSize value="1"/>
+                  <EndSize value="0"/>
                   <DeltaFormat value="32768"/>
                 </YDeviceTable>
               </BaseAnchor>

--- a/tests/data/TestVariableFont-TTF-useProductionNames.ttx
+++ b/tests/data/TestVariableFont-TTF-useProductionNames.ttx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.44">
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.51">
 
   <GlyphOrder>
     <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
@@ -322,8 +322,15 @@
       <Format value="1"/>
       <VarRegionList>
         <!-- RegionAxisCount=1 -->
-        <!-- RegionCount=1 -->
+        <!-- RegionCount=2 -->
         <Region index="0">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.36365"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="1">
           <VarRegionAxis index="0">
             <StartCoord value="0.36365"/>
             <PeakCoord value="1.0"/>
@@ -335,10 +342,11 @@
       <VarData index="0">
         <!-- ItemCount=2 -->
         <NumShorts value="0"/>
-        <!-- VarRegionCount=1 -->
+        <!-- VarRegionCount=2 -->
         <VarRegionIndex index="0" value="0"/>
-        <Item index="0" value="[1]"/>
-        <Item index="1" value="[88]"/>
+        <VarRegionIndex index="1" value="1"/>
+        <Item index="0" value="[11, 88]"/>
+        <Item index="1" value="[89, 1]"/>
       </VarData>
     </VarStore>
   </GDEF>
@@ -401,12 +409,12 @@
                 <YCoordinate value="556"/>
                 <XDeviceTable>
                   <StartSize value="0"/>
-                  <EndSize value="0"/>
+                  <EndSize value="1"/>
                   <DeltaFormat value="32768"/>
                 </XDeviceTable>
                 <YDeviceTable>
                   <StartSize value="0"/>
-                  <EndSize value="1"/>
+                  <EndSize value="0"/>
                   <DeltaFormat value="32768"/>
                 </YDeviceTable>
               </BaseAnchor>

--- a/tests/data/TestVariableFont-TTF.ttx
+++ b/tests/data/TestVariableFont-TTF.ttx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.44">
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.51">
 
   <GlyphOrder>
     <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
@@ -319,8 +319,15 @@
       <Format value="1"/>
       <VarRegionList>
         <!-- RegionAxisCount=1 -->
-        <!-- RegionCount=1 -->
+        <!-- RegionCount=2 -->
         <Region index="0">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.36365"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="1">
           <VarRegionAxis index="0">
             <StartCoord value="0.36365"/>
             <PeakCoord value="1.0"/>
@@ -332,10 +339,11 @@
       <VarData index="0">
         <!-- ItemCount=2 -->
         <NumShorts value="0"/>
-        <!-- VarRegionCount=1 -->
+        <!-- VarRegionCount=2 -->
         <VarRegionIndex index="0" value="0"/>
-        <Item index="0" value="[1]"/>
-        <Item index="1" value="[88]"/>
+        <VarRegionIndex index="1" value="1"/>
+        <Item index="0" value="[11, 88]"/>
+        <Item index="1" value="[89, 1]"/>
       </VarData>
     </VarStore>
   </GDEF>
@@ -398,12 +406,12 @@
                 <YCoordinate value="556"/>
                 <XDeviceTable>
                   <StartSize value="0"/>
-                  <EndSize value="0"/>
+                  <EndSize value="1"/>
                   <DeltaFormat value="32768"/>
                 </XDeviceTable>
                 <YDeviceTable>
                   <StartSize value="0"/>
-                  <EndSize value="1"/>
+                  <EndSize value="0"/>
                   <DeltaFormat value="32768"/>
                 </YDeviceTable>
               </BaseAnchor>

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -264,7 +264,7 @@ class IntegrationTest:
             feature mark {
                 lookup mark2base {
                     pos base e
-                        <anchor (wght=350:314 wght=450:314 wght=625:315) (wght=350:556 wght=450:556 wght=625:644)> mark @MC_top;
+                        <anchor (wght=350:314 wght=450:403 wght=625:315) (wght=350:556 wght=450:567 wght=625:644)> mark @MC_top;
                 } mark2base;
 
             } mark;


### PR DESCRIPTION
The anchor position was always taken from the default layer, ignoring the specified layerName.