### PR TITLE
Document insertion marker in BaseFeatureWriter

### DIFF
--- a/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
@@ -42,6 +42,11 @@ class BaseFeatureWriter:
     The `options` class attribute contains a mapping of option
     names with their default values. These can be overridden on an
     instance by passing keyword arguments to the constructor.
+
+    Combining manually written and automatically generated feature code 
+    can be achieved by using the `# Automatic Code` insertion marker 
+    inside the feature code. Automatically generated code for the 
+    respective feature is added in that spot.
     """
 
     tableTag = None


### PR DESCRIPTION
I couldn't find any proper mention of how to use the insertion marker in the repo so I added a minimal documentation in the BaseFeatureWriter docstring. It seems only [this issue](https://github.com/googlefonts/ufo2ft/issues/351#issuecomment-796598457) really mentions the method and strings, and in the code there are only tests that reference the string. `BaseFeatureWriter` has the `INSERT_FEATURE_MARKER` so I figured that's where the "documentation" should reside as well. Feel free to expand or re-word, but please add some mention of this use somewhere :)