### PR TITLE
Old kern writer: register lookups under DFLT, too

### DIFF
--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter2.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter2.py
@@ -526,6 +526,7 @@ class KernFeatureWriter(BaseFeatureWriter):
         # InDesign bugfix: register kerning lookups for all LTR scripts under DFLT
         # so that the basic composer, without a language selected, will still kern.
         # Register LTR lookups if any, otherwise RTL lookups.
+        # See https://github.com/googlefonts/ufo2ft/pull/787.
         dfltLookups = []
         ltrLookups = lookups.get("LTR")
         rtlLookups = lookups.get("RTL")

--- a/tests/featureWriters/kernFeatureWriter2_test.py
+++ b/tests/featureWriters/kernFeatureWriter2_test.py
@@ -694,6 +694,7 @@ class KernFeatureWriterTest(FeatureWriterTest):
 
             feature kern {
                 lookup kern_dflt;
+                lookup kern_ltr;
                 script latn;
                 language dflt;
                 lookup kern_ltr;
@@ -808,6 +809,8 @@ class KernFeatureWriterTest(FeatureWriterTest):
 
             feature kern {
                 lookup kern_dflt;
+                lookup kern_ltr;
+                lookup kern_ltr_marks;
                 script latn;
                 language dflt;
                 lookup kern_ltr;


### PR DESCRIPTION
This ports https://github.com/googlefonts/ufo2ft/pull/787 to the old kern writer.

Contrary to the new writer, here we don't try to register languages for DFLT.