### PR TITLE
Go halfway back to the old kern writer

### DIFF
--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter2.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter2.py
@@ -552,7 +552,13 @@ def get_variable_kerning_pairs(
         if default_location not in value.values:
             value.values[default_location] = 0
         value = collapse_varscalar(value)
-        result.append(KerningPair(side1, side2, value))
+        pair = KerningPair(side1, side2, value)
+        # Ignore zero-valued class kern pairs. They are the most general
+        # kerns, so they don't override anything else like glyph kerns would
+        # and zero is the default.
+        if pair.firstIsClass and pair.secondIsClass and pair.value == 0:
+            continue
+        result.append(pair)
 
     return result
 

--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter2.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter2.py
@@ -610,22 +610,20 @@ def split_base_and_mark_pairs(
         if pair.firstIsClass:
             side1Bases = tuple(glyph for glyph in pair.side1 if glyph not in marks)
             side1Marks = tuple(glyph for glyph in pair.side1 if glyph in marks)
+        elif pair.side1 in marks:
+            side1Marks = pair.side1
         else:
-            if pair.side1 in marks:
-                side1Marks = pair.side1
-            else:
-                side1Bases = pair.side1
+            side1Bases = pair.side1
 
         side2Bases: tuple[str, ...] | str | None = None
         side2Marks: tuple[str, ...] | str | None = None
         if pair.secondIsClass:
             side2Bases = tuple(glyph for glyph in pair.side2 if glyph not in marks)
             side2Marks = tuple(glyph for glyph in pair.side2 if glyph in marks)
+        elif pair.side2 in marks:
+            side2Marks = pair.side2
         else:
-            if pair.side2 in marks:
-                side2Marks = pair.side2
-            else:
-                side2Bases = pair.side2
+            side2Bases = pair.side2
 
         if side1Bases and side2Bases:  # base-to-base
             basePairs.append(KerningPair(side1Bases, side2Bases, value=pair.value))

--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter2.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter2.py
@@ -1,3 +1,29 @@
+"""Alternative implementation of KernFeatureWriter.
+
+This behaves like the primary kern feature writer, with the important difference
+of grouping kerning data into lookups by kerning direction, not script, like the
+feature writer in ufo2ft v2.30 and older did.
+
+The original idea for the primary splitter was to generate smaller, easier to
+pack lookups for each script exclusively, as cross-script kerning dos not work
+in browsers. However, other applications may allow it, e.g. Adobe's InDesign.
+Subsequently, it was modified to clump together lookups that cross-reference
+each other's scripts, negating the size advantages if you design fonts with
+cross-script kerning for designer ease.
+
+As a special edge case, InDesign's default text shaper does not properly itemize
+text runs, meaning it may group different scripts into the same run unless the
+user specifically marks some text as being a specific script or language. To
+make all kerning reachable in that case, it must be put into a single broad LTR,
+RTL or neutral direction lookup instead of finer script clusters. That will make
+it work in all cases, including when there is no cross-script kerning to fuse
+different lookups together.
+
+Testing showed that size benefits are clawed back with the use of the HarfBuzz
+repacker (during compilation) and GPOS compression (after compilation) at
+acceptable speed.
+"""
+
 from __future__ import annotations
 
 import enum

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,3 +3,4 @@ pytest
 black
 isort
 flake8-bugbear
+syrupy

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,3 +24,5 @@ filterwarnings:
 	ignore:tostring:DeprecationWarning
 	ignore:fromstring:DeprecationWarning
 	ignore:.*bytes:DeprecationWarning:fs.base
+	ignore::DeprecationWarning:fs
+	ignore::DeprecationWarning:pkg_resources

--- a/tests/featureWriters/__snapshots__/kernFeatureWriter2_test.ambr
+++ b/tests/featureWriters/__snapshots__/kernFeatureWriter2_test.ambr
@@ -1,0 +1,1136 @@
+# serializer version: 1
+# name: test_ambiguous_direction_pair
+  '''
+  lookup kern_ltr {
+      lookupflag IgnoreMarks;
+      pos bar bar 1;
+  } kern_ltr;
+  
+  lookup kern_rtl {
+      lookupflag IgnoreMarks;
+      pos bar bar 1;
+  } kern_rtl;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_ltr;
+      
+      script arab;
+      language dflt;
+      lookup kern_rtl;
+      
+      script hebr;
+      language dflt;
+      lookup kern_rtl;
+      
+      script latn;
+      language dflt;
+      lookup kern_ltr;
+  } kern;
+  
+  '''
+# ---
+# name: test_arabic_numerals
+  '''
+  lookup kern_rtl {
+      lookupflag IgnoreMarks;
+      pos four-ar seven-ar -30;
+  } kern_rtl;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_rtl;
+  } kern;
+  
+  '''
+# ---
+# name: test_arabic_numerals.1
+  '''
+  lookup kern_rtl {
+      lookupflag IgnoreMarks;
+      pos four-ar seven-ar -30;
+  } kern_rtl;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_rtl;
+      
+      script arab;
+      language dflt;
+      lookup kern_rtl;
+  } kern;
+  
+  '''
+# ---
+# name: test_arabic_numerals.2
+  '''
+  lookup kern_rtl {
+      lookupflag IgnoreMarks;
+      pos four-ar seven-ar -30;
+  } kern_rtl;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_rtl;
+      
+      script arab;
+      language dflt;
+      lookup kern_rtl;
+      
+      script thaa;
+      language dflt;
+      lookup kern_rtl;
+  } kern;
+  
+  '''
+# ---
+# name: test_arabic_numerals.3
+  '''
+  lookup kern_rtl {
+      lookupflag IgnoreMarks;
+      pos four-ar seven-ar -30;
+  } kern_rtl;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_rtl;
+      
+      script thaa;
+      language dflt;
+      lookup kern_rtl;
+  } kern;
+  
+  '''
+# ---
+# name: test_defining_classdefs
+  '''
+  @kern1.dflt.ssatelugu.alt = [ss-telugu.alt];
+  @kern1.ltr.shatelugu.below = [sha-telugu.below];
+  @kern1.ltr.ssatelugu.alt = [ssa-telugu.alt];
+  @kern2.ltr.katelugu.below = [ka-telugu.below];
+  @kern2.ltr.rVocalicMatratelugu = [rVocalicMatra-telugu];
+  
+  lookup kern_dflt {
+      lookupflag IgnoreMarks;
+      enum pos @kern1.dflt.ssatelugu.alt sha-telugu.below 150;
+  } kern_dflt;
+  
+  lookup kern_ltr {
+      lookupflag IgnoreMarks;
+      enum pos @kern1.ltr.ssatelugu.alt sha-telugu.below 150;
+      pos @kern1.ltr.shatelugu.below @kern2.ltr.katelugu.below 20;
+      pos @kern1.dflt.ssatelugu.alt @kern2.ltr.katelugu.below 60;
+      pos @kern1.ltr.ssatelugu.alt @kern2.ltr.katelugu.below 60;
+  } kern_ltr;
+  
+  lookup kern_ltr_marks {
+      pos @kern1.dflt.ssatelugu.alt @kern2.ltr.rVocalicMatratelugu 180;
+      pos @kern1.ltr.ssatelugu.alt @kern2.ltr.rVocalicMatratelugu 180;
+  } kern_ltr_marks;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_dflt;
+      lookup kern_ltr;
+      lookup kern_ltr_marks;
+  } kern;
+  
+  feature dist {
+      script tel2;
+      language dflt;
+      lookup kern_dflt;
+      lookup kern_ltr;
+      lookup kern_ltr_marks;
+      
+      script telu;
+      language dflt;
+      lookup kern_dflt;
+      lookup kern_ltr;
+      lookup kern_ltr_marks;
+  } dist;
+  
+  '''
+# ---
+# name: test_dflt_language
+  '''
+  lookup kern_dflt {
+      lookupflag IgnoreMarks;
+      pos comma comma 2;
+  } kern_dflt;
+  
+  lookup kern_ltr {
+      lookupflag IgnoreMarks;
+      pos a a 1;
+  } kern_ltr;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_dflt;
+      lookup kern_ltr;
+      language ZND;
+      
+      script latn;
+      language dflt;
+      lookup kern_dflt;
+      lookup kern_ltr;
+      language ANG;
+  } kern;
+  
+  '''
+# ---
+# name: test_dist_LTR
+  '''
+  @kern1.ltr.KND_aaMatra_R = [aaMatra_kannada];
+  @kern2.ltr.KND_ailength_L = [aaMatra_kannada];
+  
+  lookup kern_ltr {
+      lookupflag IgnoreMarks;
+      pos @kern1.ltr.KND_aaMatra_R @kern2.ltr.KND_ailength_L 34;
+  } kern_ltr;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_ltr;
+      
+      script latn;
+      language dflt;
+      lookup kern_ltr;
+  } kern;
+  
+  feature dist {
+      script knd2;
+      language dflt;
+      lookup kern_ltr;
+      
+      script knda;
+      language dflt;
+      lookup kern_ltr;
+  } dist;
+  
+  '''
+# ---
+# name: test_dist_LTR_and_RTL
+  '''
+  @kern1.ltr.KND_aaMatra_R = [aaMatra_kannada];
+  @kern2.ltr.KND_ailength_L = [aaMatra_kannada];
+  
+  lookup kern_ltr {
+      lookupflag IgnoreMarks;
+      pos @kern1.ltr.KND_aaMatra_R @kern2.ltr.KND_ailength_L 34;
+  } kern_ltr;
+  
+  lookup kern_rtl {
+      lookupflag IgnoreMarks;
+      pos u10A1E u10A06 <117 0 117 0>;
+  } kern_rtl;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_ltr;
+  } kern;
+  
+  feature dist {
+      script khar;
+      language dflt;
+      lookup kern_rtl;
+      
+      script knd2;
+      language dflt;
+      lookup kern_ltr;
+      
+      script knda;
+      language dflt;
+      lookup kern_ltr;
+  } dist;
+  
+  '''
+# ---
+# name: test_dist_RTL
+  '''
+  lookup kern_rtl {
+      lookupflag IgnoreMarks;
+      pos u10A1E u10A06 <117 0 117 0>;
+  } kern_rtl;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_rtl;
+      
+      script arab;
+      language dflt;
+      lookup kern_rtl;
+  } kern;
+  
+  feature dist {
+      script khar;
+      language dflt;
+      lookup kern_rtl;
+  } dist;
+  
+  '''
+# ---
+# name: test_hyphenated_duplicates
+  '''
+  @kern1.dflt.hyphen = [comma];
+  @kern1.dflt.hyphen_1 = [period];
+  
+  lookup kern_dflt {
+      lookupflag IgnoreMarks;
+      enum pos @kern1.dflt.hyphen comma 1;
+      enum pos @kern1.dflt.hyphen_1 period 2;
+  } kern_dflt;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_dflt;
+  } kern;
+  
+  '''
+# ---
+# name: test_ignoreMarks
+  '''
+  lookup kern_dflt {
+      lookupflag IgnoreMarks;
+      pos four six -55;
+      pos one six -30;
+  } kern_dflt;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_dflt;
+  } kern;
+  
+  '''
+# ---
+# name: test_ignoreMarks.1
+  '''
+  lookup kern_dflt {
+      pos four six -55;
+      pos one six -30;
+  } kern_dflt;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_dflt;
+  } kern;
+  
+  '''
+# ---
+# name: test_insert_comment_after
+  '''
+  feature kern {
+      pos one four' -50 six;
+      #
+      #
+  } kern;
+  
+  lookup kern_dflt {
+      lookupflag IgnoreMarks;
+      pos seven six 25;
+  } kern_dflt;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_dflt;
+  } kern;
+  
+  '''
+# ---
+# name: test_insert_comment_after.1
+  '''
+  lookup kern_dflt {
+      lookupflag IgnoreMarks;
+      pos seven six 25;
+  } kern_dflt;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_dflt;
+  } kern;
+  
+  '''
+# ---
+# name: test_insert_comment_before
+  '''
+  lookup kern_dflt {
+      lookupflag IgnoreMarks;
+      pos seven six 25;
+  } kern_dflt;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_dflt;
+  } kern;
+  
+  feature kern {
+      #
+      #
+      pos one four' -50 six;
+  } kern;
+  
+  '''
+# ---
+# name: test_insert_comment_before.1
+  '''
+  lookup kern_dflt {
+      lookupflag IgnoreMarks;
+      pos seven six 25;
+  } kern_dflt;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_dflt;
+  } kern;
+  
+  '''
+# ---
+# name: test_insert_comment_before_extended
+  '''
+  lookup kern_dflt {
+      lookupflag IgnoreMarks;
+      pos seven six 25;
+  } kern_dflt;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_dflt;
+  } kern;
+  
+  feature kern {
+      #
+      #
+      pos one four' -50 six;
+  } kern;
+  
+  '''
+# ---
+# name: test_insert_comment_middle
+  '''
+  lookup kern_dflt {
+      lookupflag IgnoreMarks;
+      pos seven six 25;
+  } kern_dflt;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_dflt;
+  } kern;
+  
+  '''
+# ---
+# name: test_kern_LTR_and_RTL
+  '''
+  @kern1.ltr.A = [A Aacute];
+  @kern1.rtl.reh = [reh-ar reh-ar.fina zain-ar];
+  @kern2.rtl.alef = [alef-ar alef-ar.isol];
+  
+  lookup kern_dflt {
+      pos seven four -25;
+  } kern_dflt;
+  
+  lookup kern_ltr {
+      enum pos @kern1.ltr.A V -40;
+  } kern_ltr;
+  
+  lookup kern_rtl {
+      pos four-ar seven-ar -30;
+      pos reh-ar.fina lam-ar.init <-80 0 -80 0>;
+      pos @kern1.rtl.reh @kern2.rtl.alef <-100 0 -100 0>;
+  } kern_rtl;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_dflt;
+      lookup kern_ltr;
+      
+      script arab;
+      language dflt;
+      lookup kern_dflt;
+      lookup kern_rtl;
+      language URD;
+      
+      script latn;
+      language dflt;
+      lookup kern_dflt;
+      lookup kern_ltr;
+      language TRK;
+  } kern;
+  
+  '''
+# ---
+# name: test_kern_LTR_and_RTL_with_marks
+  '''
+  @kern1.ltr.A = [A Aacute];
+  @kern1.rtl.reh = [reh-ar reh-ar.fina zain-ar];
+  @kern2.rtl.alef = [alef-ar alef-ar.isol];
+  
+  lookup kern_dflt {
+      lookupflag IgnoreMarks;
+      pos seven four -25;
+  } kern_dflt;
+  
+  lookup kern_ltr {
+      lookupflag IgnoreMarks;
+      enum pos @kern1.ltr.A V -40;
+  } kern_ltr;
+  
+  lookup kern_ltr_marks {
+      pos V acutecomb 70;
+  } kern_ltr_marks;
+  
+  lookup kern_rtl {
+      lookupflag IgnoreMarks;
+      pos four-ar seven-ar -30;
+      pos reh-ar.fina lam-ar.init <-80 0 -80 0>;
+      pos @kern1.rtl.reh @kern2.rtl.alef <-100 0 -100 0>;
+  } kern_rtl;
+  
+  lookup kern_rtl_marks {
+      pos reh-ar fatha-ar <80 0 80 0>;
+  } kern_rtl_marks;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_dflt;
+      lookup kern_ltr;
+      lookup kern_ltr_marks;
+      
+      script arab;
+      language dflt;
+      lookup kern_dflt;
+      lookup kern_rtl;
+      lookup kern_rtl_marks;
+      language URD;
+      
+      script latn;
+      language dflt;
+      lookup kern_dflt;
+      lookup kern_ltr;
+      lookup kern_ltr_marks;
+      language TRK;
+  } kern;
+  
+  '''
+# ---
+# name: test_kern_RTL_and_DFLT_numbers
+  '''
+  lookup kern_dflt {
+      lookupflag IgnoreMarks;
+      pos seven four -25;
+  } kern_dflt;
+  
+  lookup kern_rtl {
+      lookupflag IgnoreMarks;
+      pos yod-hb bet-hb <-100 0 -100 0>;
+  } kern_rtl;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_dflt;
+      lookup kern_rtl;
+      
+      script hebr;
+      language dflt;
+      lookup kern_dflt;
+      lookup kern_rtl;
+  } kern;
+  
+  '''
+# ---
+# name: test_kern_RTL_with_marks
+  '''
+  @kern1.rtl.reh = [reh-ar reh-ar.fina zain-ar];
+  @kern2.rtl.alef = [alef-ar alef-ar.isol];
+  
+  lookup kern_rtl {
+      lookupflag IgnoreMarks;
+      pos reh-ar.fina lam-ar.init <-80 0 -80 0>;
+      pos @kern1.rtl.reh @kern2.rtl.alef <-100 0 -100 0>;
+  } kern_rtl;
+  
+  lookup kern_rtl_marks {
+      pos reh-ar fatha-ar <80 0 80 0>;
+  } kern_rtl_marks;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_rtl;
+      lookup kern_rtl_marks;
+      
+      script arab;
+      language dflt;
+      lookup kern_rtl;
+      lookup kern_rtl_marks;
+      language ARA;
+  } kern;
+  
+  '''
+# ---
+# name: test_kern_hira_kana_hrkt
+  '''
+  lookup kern_dflt {
+      lookupflag IgnoreMarks;
+      pos period period 5;
+  } kern_dflt;
+  
+  lookup kern_ltr {
+      lookupflag IgnoreMarks;
+      pos a-hira a-hira 1;
+      pos a-hira a-kana 2;
+      pos a-hira period 6;
+      pos a-kana a-hira 3;
+      pos a-kana a-kana 4;
+      pos a-kana period 8;
+      pos period a-hira 7;
+      pos period a-kana 9;
+  } kern_ltr;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_dflt;
+      lookup kern_ltr;
+      
+      script kana;
+      language dflt;
+      lookup kern_dflt;
+      lookup kern_ltr;
+  } kern;
+  
+  '''
+# ---
+# name: test_kern_independent_of_languagesystem[same]
+  '''
+  lookup kern_ltr {
+      lookupflag IgnoreMarks;
+      pos A V -40;
+  } kern_ltr;
+  
+  lookup kern_rtl {
+      lookupflag IgnoreMarks;
+      pos reh-ar alef-ar <-100 0 -100 0>;
+  } kern_rtl;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_ltr;
+      
+      script arab;
+      language dflt;
+      lookup kern_rtl;
+      
+      script latn;
+      language dflt;
+      lookup kern_ltr;
+  } kern;
+  
+  '''
+# ---
+# name: test_kern_mixed_bidis
+  '''
+  lookup kern_dflt {
+      lookupflag IgnoreMarks;
+      pos comma comma -1;
+  } kern_dflt;
+  
+  lookup kern_ltr {
+      lookupflag IgnoreMarks;
+      pos a a 1;
+      pos a comma 2;
+      pos comma a 3;
+  } kern_ltr;
+  
+  lookup kern_rtl {
+      lookupflag IgnoreMarks;
+      pos alef-ar alef-ar <4 0 4 0>;
+      pos alef-ar comma-ar <5 0 5 0>;
+      pos comma-ar alef-ar <6 0 6 0>;
+      pos comma-ar one-adlam <12 0 12 0>;
+      pos one-adlam comma-ar <11 0 11 0>;
+      pos one-adlam one-adlam <10 0 10 0>;
+      pos one-ar one-ar 9;
+  } kern_rtl;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_dflt;
+      lookup kern_ltr;
+      
+      script arab;
+      language dflt;
+      lookup kern_dflt;
+      lookup kern_rtl;
+      
+      script latn;
+      language dflt;
+      lookup kern_dflt;
+      lookup kern_ltr;
+  } kern;
+  
+  feature dist {
+      script adlm;
+      language dflt;
+      lookup kern_dflt;
+      lookup kern_rtl;
+  } dist;
+  
+  '''
+# ---
+# name: test_kern_split_and_drop
+  '''
+  @kern1.ltr.bar = [a-cy];
+  @kern1.ltr.bar_1 = [period];
+  @kern1.ltr.foo = [a a-orya alpha];
+  @kern2.ltr.bar = [a-cy];
+  @kern2.ltr.bar_1 = [period];
+  @kern2.ltr.foo = [a a-orya alpha];
+  
+  lookup kern_ltr {
+      lookupflag IgnoreMarks;
+      pos @kern1.ltr.foo @kern2.ltr.bar 20;
+      pos @kern1.ltr.foo @kern2.ltr.bar_1 20;
+      pos @kern1.ltr.bar @kern2.ltr.foo 20;
+      pos @kern1.ltr.bar_1 @kern2.ltr.foo 20;
+  } kern_ltr;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_ltr;
+      
+      script cyrl;
+      language dflt;
+      lookup kern_ltr;
+      
+      script grek;
+      language dflt;
+      lookup kern_ltr;
+      
+      script latn;
+      language dflt;
+      lookup kern_ltr;
+  } kern;
+  
+  feature dist {
+      script ory2;
+      language dflt;
+      lookup kern_ltr;
+      
+      script orya;
+      language dflt;
+      lookup kern_ltr;
+  } dist;
+  
+  '''
+# ---
+# name: test_kern_split_and_drop_mixed
+  '''
+  @kern1.ltr.foo = [V W];
+  @kern2.ltr.foo = [W];
+  
+  lookup kern_ltr {
+      lookupflag IgnoreMarks;
+      pos @kern1.ltr.foo @kern2.ltr.foo -20;
+  } kern_ltr;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_ltr;
+      
+      script latn;
+      language dflt;
+      lookup kern_ltr;
+  } kern;
+  
+  '''
+# ---
+# name: test_kern_split_multi_glyph_class[same]
+  '''
+  @kern1.dflt.foo = [period];
+  @kern1.ltr.foo = [a];
+  @kern2.dflt.foo = [period];
+  @kern2.ltr.foo = [b];
+  
+  lookup kern_dflt {
+      lookupflag IgnoreMarks;
+      pos period period 9;
+      enum pos period @kern2.dflt.foo 13;
+      enum pos @kern1.dflt.foo period 11;
+      pos @kern1.dflt.foo @kern2.dflt.foo 14;
+  } kern_dflt;
+  
+  lookup kern_ltr {
+      lookupflag IgnoreMarks;
+      pos a a 1;
+      pos a b 2;
+      pos a period 3;
+      pos b a 4;
+      pos b b 5;
+      pos b period 6;
+      pos period a 7;
+      pos period b 8;
+      enum pos a @kern2.ltr.foo 12;
+      enum pos a @kern2.dflt.foo 12;
+      enum pos period @kern2.ltr.foo 13;
+      enum pos @kern1.ltr.foo b 10;
+      enum pos @kern1.ltr.foo period 11;
+      enum pos @kern1.dflt.foo b 10;
+      pos @kern1.ltr.foo @kern2.ltr.foo 14;
+      pos @kern1.ltr.foo @kern2.dflt.foo 14;
+      pos @kern1.dflt.foo @kern2.ltr.foo 14;
+  } kern_ltr;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_dflt;
+      lookup kern_ltr;
+      
+      script latn;
+      language dflt;
+      lookup kern_dflt;
+      lookup kern_ltr;
+  } kern;
+  
+  '''
+# ---
+# name: test_kern_uniqueness
+  '''
+  @kern1.ltr.questiondown = [questiondown];
+  @kern2.ltr.y = [y];
+  
+  lookup kern_ltr {
+      lookupflag IgnoreMarks;
+      pos questiondown y 35;
+      enum pos questiondown @kern2.ltr.y -35;
+      enum pos @kern1.ltr.questiondown y 35;
+      pos @kern1.ltr.questiondown @kern2.ltr.y 15;
+  } kern_ltr;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_ltr;
+      
+      script latn;
+      language dflt;
+      lookup kern_ltr;
+  } kern;
+  
+  '''
+# ---
+# name: test_kern_zyyy_zinh
+  '''
+  lookup kern_dflt {
+      lookupflag IgnoreMarks;
+      pos uni0640 uni0640 0;
+      pos uni0650 uni0650 1;
+      pos uni0670 uni0670 2;
+      pos uni10100 uni10100 30;
+      pos uni10110 uni10110 31;
+      pos uni10120 uni10120 32;
+      pos uni10130 uni10130 33;
+      pos uni102E0 uni102E0 34;
+      pos uni102F0 uni102F0 35;
+      pos uni1BCA0 uni1BCA0 36;
+      pos uni1CD0 uni1CD0 3;
+      pos uni1CE0 uni1CE0 4;
+      pos uni1CF0 uni1CF0 5;
+      pos uni1D360 uni1D360 37;
+      pos uni1D370 uni1D370 38;
+      pos uni1DC0 uni1DC0 6;
+      pos uni1F250 uni1F250 39;
+      pos uni20F0 uni20F0 7;
+      pos uni3010 uni3010 8;
+      pos uni3030 uni3030 9;
+      pos uni30A0 uni30A0 10;
+      pos uni3190 uni3190 11;
+      pos uni31C0 uni31C0 12;
+      pos uni31D0 uni31D0 13;
+      pos uni31E0 uni31E0 14;
+      pos uni3220 uni3220 15;
+      pos uni3230 uni3230 16;
+      pos uni3240 uni3240 17;
+      pos uni3280 uni3280 18;
+      pos uni3290 uni3290 19;
+      pos uni32A0 uni32A0 20;
+      pos uni32B0 uni32B0 21;
+      pos uni32C0 uni32C0 22;
+      pos uni3360 uni3360 23;
+      pos uni3370 uni3370 24;
+      pos uni33E0 uni33E0 25;
+      pos uni33F0 uni33F0 26;
+      pos uniA700 uniA700 27;
+      pos uniA830 uniA830 28;
+      pos uniFF70 uniFF70 29;
+  } kern_dflt;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_dflt;
+      
+      script grek;
+      language dflt;
+      lookup kern_dflt;
+      
+      script hani;
+      language dflt;
+      lookup kern_dflt;
+      
+      script kana;
+      language dflt;
+      lookup kern_dflt;
+  } kern;
+  
+  feature dist {
+      script dev2;
+      language dflt;
+      lookup kern_dflt;
+      
+      script deva;
+      language dflt;
+      lookup kern_dflt;
+      
+      script dupl;
+      language dflt;
+      lookup kern_dflt;
+  } dist;
+  
+  '''
+# ---
+# name: test_mark_base_kerning
+  '''
+  @kern1.ltr.etamil = [va-tamil];
+  @kern1.ltr.etamil_1 = [aulengthmark-tamil];
+  @kern2.ltr.etamil = [va-tamil];
+  @kern2.ltr.etamil_1 = [aulengthmark-tamil];
+  
+  lookup kern_ltr {
+      lookupflag IgnoreMarks;
+      pos aa-tamil va-tamil -20;
+      pos va-tamil aa-tamil -20;
+      enum pos aa-tamil @kern2.ltr.etamil -35;
+      enum pos @kern1.ltr.etamil aa-tamil -35;
+      pos @kern1.ltr.etamil @kern2.ltr.etamil -100;
+  } kern_ltr;
+  
+  lookup kern_ltr_marks {
+      pos aulengthmark-tamil aulengthmark-tamil -200;
+      enum pos aa-tamil @kern2.ltr.etamil_1 -35;
+      enum pos @kern1.ltr.etamil_1 aa-tamil -35;
+      pos @kern1.ltr.etamil_1 @kern2.ltr.etamil_1 -100;
+      pos @kern1.ltr.etamil_1 @kern2.ltr.etamil -100;
+      pos @kern1.ltr.etamil @kern2.ltr.etamil_1 -100;
+  } kern_ltr_marks;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_ltr;
+      lookup kern_ltr_marks;
+  } kern;
+  
+  feature dist {
+      script tml2;
+      language dflt;
+      lookup kern_ltr;
+      lookup kern_ltr_marks;
+      
+      script taml;
+      language dflt;
+      lookup kern_ltr;
+      lookup kern_ltr_marks;
+  } dist;
+  
+  '''
+# ---
+# name: test_mark_to_base_kern
+  '''
+  lookup kern_ltr {
+      lookupflag IgnoreMarks;
+      pos B C -30;
+  } kern_ltr;
+  
+  lookup kern_ltr_marks {
+      pos A acutecomb -55;
+  } kern_ltr_marks;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_ltr;
+      lookup kern_ltr_marks;
+      
+      script latn;
+      language dflt;
+      lookup kern_ltr;
+      lookup kern_ltr_marks;
+  } kern;
+  
+  '''
+# ---
+# name: test_mark_to_base_kern.1
+  '''
+  lookup kern_ltr {
+      pos A acutecomb -55;
+      pos B C -30;
+  } kern_ltr;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_ltr;
+      
+      script latn;
+      language dflt;
+      lookup kern_ltr;
+  } kern;
+  
+  '''
+# ---
+# name: test_mark_to_base_only
+  '''
+  lookup kern_dflt_marks {
+      pos A acutecomb -55;
+  } kern_dflt_marks;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_dflt_marks;
+  } kern;
+  
+  '''
+# ---
+# name: test_mode.1
+  '''
+  feature kern {
+      pos one four' -50 six;
+  } kern;
+  
+  lookup kern_dflt {
+      lookupflag IgnoreMarks;
+      pos seven six 25;
+  } kern_dflt;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_dflt;
+  } kern;
+  
+  '''
+# ---
+# name: test_mode[existing]
+  '''
+  feature kern {
+      pos one four' -50 six;
+  } kern;
+  
+  '''
+# ---
+# name: test_quantize
+  '''
+  lookup kern_dflt {
+      lookupflag IgnoreMarks;
+      pos four six -55;
+      pos one six -25;
+  } kern_dflt;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_dflt;
+  } kern;
+  
+  '''
+# ---
+# name: test_skip_spacing_marks
+  '''
+  lookup kern_ltr {
+      @MFS_kern_ltr = [highspacingdot-deva];
+      lookupflag UseMarkFilteringSet @MFS_kern_ltr;
+      pos ka-deva ra-deva -250;
+      pos ra-deva ka-deva -250;
+  } kern_ltr;
+  
+  lookup kern_ltr_marks {
+      pos highspacingdot-deva ka-deva -200;
+      pos ka-deva highspacingdot-deva -150;
+  } kern_ltr_marks;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_ltr;
+      lookup kern_ltr_marks;
+  } kern;
+  
+  feature dist {
+      script dev2;
+      language dflt;
+      lookup kern_ltr;
+      lookup kern_ltr_marks;
+      
+      script deva;
+      language dflt;
+      lookup kern_ltr;
+      lookup kern_ltr_marks;
+  } dist;
+  
+  '''
+# ---
+# name: test_skip_zero_class_kerns
+  '''
+  @kern1.ltr.baz = [E F];
+  @kern1.ltr.foo = [A B];
+  @kern2.ltr.bar = [C D];
+  
+  lookup kern_ltr {
+      lookupflag IgnoreMarks;
+      pos G H -5;
+      enum pos A @kern2.ltr.bar 5;
+      enum pos @kern1.ltr.foo D 15;
+      pos @kern1.ltr.foo @kern2.ltr.bar 10;
+      pos @kern1.ltr.baz @kern2.ltr.bar -10;
+  } kern_ltr;
+  
+  feature kern {
+      script DFLT;
+      language dflt;
+      lookup kern_ltr;
+      
+      script latn;
+      language dflt;
+      lookup kern_ltr;
+  } kern;
+  
+  '''
+# ---

--- a/tests/featureWriters/kernFeatureWriter2_test.py
+++ b/tests/featureWriters/kernFeatureWriter2_test.py
@@ -1,21 +1,57 @@
 import logging
-from textwrap import dedent
 
+import fontTools.feaLib.ast as fea_ast
 import pytest
+from fontTools import unicodedata
+from syrupy.extensions.amber import AmberSnapshotExtension
+from syrupy.location import PyTestLocation
+from syrupy.types import SnapshotIndex
 
+from ufo2ft.constants import UNICODE_SCRIPT_ALIASES
 from ufo2ft.errors import InvalidFeaturesData
-from ufo2ft.featureCompiler import parseLayoutFeatures
-from ufo2ft.featureWriters import ast
+from ufo2ft.featureCompiler import FeatureCompiler, parseLayoutFeatures
 from ufo2ft.featureWriters.kernFeatureWriter2 import KernFeatureWriter
+from ufo2ft.util import DFLT_SCRIPTS, unicodeScriptExtensions
 
 from . import FeatureWriterTest
+
+
+class KernFeatureWriterTest(FeatureWriterTest):
+    FeatureWriter = KernFeatureWriter
+
+
+class SameUfoLibResultsExtension(AmberSnapshotExtension):
+    """Make tests use the same snapshots when parameterized.
+
+    Instead of having the snapshots of "test_something[defcon]" and
+    "test_something[ufoLib2]" be duplicates, use the same snapshots for both,
+    because the UFO library shouldn't make a difference.
+    """
+
+    @classmethod
+    def get_snapshot_name(
+        cls, *, test_location: "PyTestLocation", index: "SnapshotIndex"
+    ) -> str:
+        index_suffix = ""
+        if isinstance(index, (str,)):
+            index_suffix = f"[{index}]"
+        elif index:
+            index_suffix = f".{index}"
+        return f"{test_location.methodname}{index_suffix}"
+
+
+@pytest.fixture
+def snapshot(snapshot):
+    return snapshot.use_extension(SameUfoLibResultsExtension)
 
 
 def makeUFO(cls, glyphMap, groups=None, kerning=None, features=None):
     ufo = cls()
     for name, uni in glyphMap.items():
         glyph = ufo.newGlyph(name)
-        if uni is not None:
+        if isinstance(uni, (list, tuple)):
+            glyph.unicodes = uni
+        elif uni is not None:
             glyph.unicode = uni
     if groups is not None:
         ufo.groups.update(groups)
@@ -27,7 +63,9 @@ def makeUFO(cls, glyphMap, groups=None, kerning=None, features=None):
 
 
 def getClassDefs(feaFile):
-    return [s for s in feaFile.statements if isinstance(s, ast.GlyphClassDefinition)]
+    return [
+        s for s in feaFile.statements if isinstance(s, fea_ast.GlyphClassDefinition)
+    ]
 
 
 def getGlyphs(classDef):
@@ -35,1165 +73,1077 @@ def getGlyphs(classDef):
 
 
 def getLookups(feaFile):
-    return [s for s in feaFile.statements if isinstance(s, ast.LookupBlock)]
+    return [s for s in feaFile.statements if isinstance(s, fea_ast.LookupBlock)]
 
 
 def getPairPosRules(lookup):
-    return [s for s in lookup.statements if isinstance(s, ast.PairPosStatement)]
+    return [s for s in lookup.statements if isinstance(s, fea_ast.PairPosStatement)]
 
 
-class KernFeatureWriterTest(FeatureWriterTest):
-    FeatureWriter = KernFeatureWriter
+def test_cleanup_missing_glyphs(FontClass):
+    groups = {
+        "public.kern1.A": ["A", "Aacute", "Abreve", "Acircumflex"],
+        "public.kern2.B": ["B", "D", "E", "F"],
+        "public.kern1.C": ["foobar"],
+    }
+    kerning = {
+        ("public.kern1.A", "public.kern2.B"): 10,
+        ("public.kern1.A", "baz"): -25,
+        ("baz", "public.kern2.B"): -20,
+        ("public.kern1.C", "public.kern2.B"): 20,
+    }
+    ufo = FontClass()
+    exclude = {"Abreve", "D", "foobar"}
+    for glyphs in groups.values():
+        for glyph in glyphs:
+            if glyph in exclude:
+                continue
+            ufo.newGlyph(glyph)
+    ufo.groups.update(groups)
+    ufo.kerning.update(kerning)
 
-    def test_cleanup_missing_glyphs(self, FontClass):
-        groups = {
-            "public.kern1.A": ["A", "Aacute", "Abreve", "Acircumflex"],
-            "public.kern2.B": ["B", "D", "E", "F"],
-            "public.kern1.C": ["foobar"],
-        }
-        kerning = {
-            ("public.kern1.A", "public.kern2.B"): 10,
-            ("public.kern1.A", "baz"): -25,
-            ("baz", "public.kern2.B"): -20,
-            ("public.kern1.C", "public.kern2.B"): 20,
-        }
-        ufo = FontClass()
-        exclude = {"Abreve", "D", "foobar"}
-        for glyphs in groups.values():
-            for glyph in glyphs:
-                if glyph in exclude:
-                    continue
-                ufo.newGlyph(glyph)
-        ufo.groups.update(groups)
-        ufo.kerning.update(kerning)
+    writer = KernFeatureWriter()
+    feaFile = parseLayoutFeatures(ufo)
+    writer.write(ufo, feaFile)
 
-        writer = KernFeatureWriter()
-        feaFile = parseLayoutFeatures(ufo)
+    classDefs = getClassDefs(feaFile)
+    assert len(classDefs) == 2
+    assert classDefs[0].name == "kern1.dflt.A"
+    assert classDefs[1].name == "kern2.dflt.B"
+    assert getGlyphs(classDefs[0]) == ["A", "Aacute", "Acircumflex"]
+    assert getGlyphs(classDefs[1]) == ["B", "E", "F"]
+
+    lookups = getLookups(feaFile)
+    assert len(lookups) == 1
+    kern_lookup = lookups[0]
+    # We have no codepoints defined for these, so they're considered common
+    assert kern_lookup.name == "kern_dflt"
+    rules = getPairPosRules(kern_lookup)
+    assert len(rules) == 1
+    assert str(rules[0]) == "pos @kern1.dflt.A @kern2.dflt.B 10;"
+
+
+def test_ignoreMarks(snapshot, FontClass):
+    font = FontClass()
+    for name in ("one", "four", "six"):
+        font.newGlyph(name)
+    font.kerning.update({("four", "six"): -55.0, ("one", "six"): -30.0})
+    # default is ignoreMarks=True
+    writer = KernFeatureWriter()
+    feaFile = fea_ast.FeatureFile()
+    assert writer.write(font, feaFile)
+
+    assert feaFile.asFea() == snapshot
+
+    writer = KernFeatureWriter(ignoreMarks=False)
+    feaFile = fea_ast.FeatureFile()
+    assert writer.write(font, feaFile)
+
+    assert feaFile.asFea() == snapshot
+
+
+def test_mark_to_base_kern(snapshot, FontClass):
+    font = FontClass()
+    for name in ("A", "B", "C"):
+        font.newGlyph(name).unicode = ord(name)
+    font.newGlyph("acutecomb").unicode = 0x0301
+    font.kerning.update({("A", "acutecomb"): -55.0, ("B", "C"): -30.0})
+
+    font.features.text = """\
+        @Bases = [A B C];
+        @Marks = [acutecomb];
+        table GDEF {
+            GlyphClassDef @Bases, [], @Marks, ;
+        } GDEF;
+        """
+
+    # default is ignoreMarks=True
+    feaFile = KernFeatureWriterTest.writeFeatures(font)
+    assert feaFile.asFea() == snapshot
+
+    feaFile = KernFeatureWriterTest.writeFeatures(font, ignoreMarks=False)
+    assert feaFile.asFea() == snapshot
+
+
+def test_mark_to_base_only(snapshot, FontClass):
+    font = FontClass()
+    for name in ("A", "B", "C"):
+        font.newGlyph(name)
+    font.newGlyph("acutecomb").unicode = 0x0301
+    font.kerning.update({("A", "acutecomb"): -55.0})
+
+    font.features.text = """\
+        @Bases = [A B C];
+        @Marks = [acutecomb];
+        table GDEF {
+            GlyphClassDef @Bases, [], @Marks, ;
+        } GDEF;
+        """
+
+    # default is ignoreMarks=True
+    feaFile = KernFeatureWriterTest.writeFeatures(font)
+    assert feaFile.asFea() == snapshot
+
+
+def test_mode(snapshot, FontClass):
+    ufo = FontClass()
+    for name in ("one", "four", "six", "seven"):
+        ufo.newGlyph(name)
+    existing = """\
+        feature kern {
+            pos one four' -50 six;
+        } kern;
+        """
+    ufo.features.text = existing
+    ufo.kerning.update({("seven", "six"): 25.0})
+
+    writer = KernFeatureWriter()  # default mode="skip"
+    feaFile = parseLayoutFeatures(ufo)
+    assert not writer.write(ufo, feaFile)
+
+    assert str(feaFile) == snapshot(name="existing")
+
+    # pass optional "append" mode
+    writer = KernFeatureWriter(mode="append")
+    feaFile = parseLayoutFeatures(ufo)
+    assert writer.write(ufo, feaFile)
+
+    assert feaFile.asFea() == snapshot
+
+    # pass "skip" mode explicitly
+    writer = KernFeatureWriter(mode="skip")
+    feaFile = parseLayoutFeatures(ufo)
+    assert not writer.write(ufo, feaFile)
+
+    assert feaFile.asFea() == snapshot(name="existing")
+
+
+def test_insert_comment_before(snapshot, FontClass):
+    ufo = FontClass()
+    for name in ("one", "four", "six", "seven"):
+        ufo.newGlyph(name)
+    existing = """\
+        feature kern {
+            #
+            # Automatic Code
+            #
+            pos one four' -50 six;
+        } kern;
+        """
+    ufo.features.text = existing
+    ufo.kerning.update({("seven", "six"): 25.0})
+
+    writer = KernFeatureWriter()
+    feaFile = parseLayoutFeatures(ufo)
+    assert writer.write(ufo, feaFile)
+
+    assert feaFile.asFea() == snapshot
+
+    # test append mode ignores insert marker
+    generated = KernFeatureWriterTest.writeFeatures(ufo, mode="append")
+    assert generated.asFea() == snapshot
+
+
+def test_comment_wrong_case_or_missing(snapshot, FontClass, caplog):
+    ufo = FontClass()
+    for name in ("a", "b"):
+        ufo.newGlyph(name)
+    ufo.kerning.update({("a", "b"): 25.0})
+    ufo.features.text = (
+        """
+        feature kern {
+            # Automatic code
+        } kern;
+        """
+    ).strip()
+
+    with caplog.at_level(logging.WARNING):
+        compiler = FeatureCompiler(ufo, featureWriters=[KernFeatureWriter])
+        font = compiler.compile()
+
+    # We mis-cased the insertion marker above, so it's ignored and we end up
+    # with an empty `kern` block overriding the other kerning in the font
+    # source and therefore no `GPOS` table.
+    assert "miscased" in caplog.text
+    assert "Dropping the former" in caplog.text
+    assert "GPOS" not in font
+
+    # Append mode ignores insertion markers and so should not log warnings
+    # and have kerning in the final font.
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        compiler = FeatureCompiler(
+            ufo, featureWriters=[KernFeatureWriter(mode="append")]
+        )
+        font = compiler.compile()
+
+    assert not caplog.text
+    assert "GPOS" in font
+
+
+def test_insert_comment_before_extended(snapshot, FontClass):
+    ufo = FontClass()
+    for name in ("one", "four", "six", "seven"):
+        ufo.newGlyph(name)
+    existing = """\
+        feature kern {
+            #
+            # Automatic Code End
+            #
+            pos one four' -50 six;
+        } kern;
+        """
+    ufo.features.text = existing
+    ufo.kerning.update({("seven", "six"): 25.0})
+
+    writer = KernFeatureWriter()
+    feaFile = parseLayoutFeatures(ufo)
+    assert writer.write(ufo, feaFile)
+
+    assert feaFile.asFea() == snapshot
+
+
+def test_insert_comment_after(snapshot, FontClass):
+    ufo = FontClass()
+    for name in ("one", "four", "six", "seven"):
+        ufo.newGlyph(name)
+    existing = """\
+        feature kern {
+            pos one four' -50 six;
+            #
+            # Automatic Code
+            #
+        } kern;
+        """
+    ufo.features.text = existing
+    ufo.kerning.update({("seven", "six"): 25.0})
+
+    writer = KernFeatureWriter()
+    feaFile = parseLayoutFeatures(ufo)
+    assert writer.write(ufo, feaFile)
+
+    assert feaFile.asFea() == snapshot
+
+    # test append mode ignores insert marker
+    generated = KernFeatureWriterTest.writeFeatures(ufo, mode="append")
+    assert generated.asFea() == snapshot
+
+
+def test_insert_comment_middle(snapshot, FontClass):
+    ufo = FontClass()
+    for name in ("one", "four", "six", "seven"):
+        ufo.newGlyph(name)
+    existing = """\
+        feature kern {
+            pos one four' -50 six;
+            #
+            # Automatic Code
+            #
+            pos one six' -50 six;
+        } kern;
+        """
+    ufo.features.text = existing
+    ufo.kerning.update({("seven", "six"): 25.0})
+
+    writer = KernFeatureWriter()
+    feaFile = parseLayoutFeatures(ufo)
+
+    with pytest.raises(
+        InvalidFeaturesData,
+        match="Insert marker has rules before and after, feature kern "
+        "cannot be inserted.",
+    ):
         writer.write(ufo, feaFile)
 
-        classDefs = getClassDefs(feaFile)
-        assert len(classDefs) == 2
-        assert classDefs[0].name == "kern1.A"
-        assert classDefs[1].name == "kern2.B"
-        assert getGlyphs(classDefs[0]) == ["A", "Aacute", "Acircumflex"]
-        assert getGlyphs(classDefs[1]) == ["B", "E", "F"]
+    # test append mode ignores insert marker
+    generated = KernFeatureWriterTest.writeFeatures(ufo, mode="append")
+    assert generated.asFea() == snapshot
 
-        lookups = getLookups(feaFile)
-        assert len(lookups) == 1
-        kern_ltr = lookups[0]
-        assert kern_ltr.name == "kern_ltr"
-        rules = getPairPosRules(kern_ltr)
-        assert len(rules) == 1
-        assert str(rules[0]) == "pos @kern1.A @kern2.B 10;"
 
-    def test_ignoreMarks(self, FontClass):
-        font = FontClass()
-        for name in ("one", "four", "six"):
-            font.newGlyph(name)
-        font.kerning.update({("four", "six"): -55.0, ("one", "six"): -30.0})
-        # default is ignoreMarks=True
-        writer = KernFeatureWriter()
-        feaFile = ast.FeatureFile()
-        assert writer.write(font, feaFile)
+def test_arabic_numerals(snapshot, FontClass):
+    """Test that arabic numerals (with bidi type AN) are kerned LTR.
 
-        assert str(feaFile) == dedent(
-            """\
-            lookup kern_ltr {
-                lookupflag IgnoreMarks;
-                pos four six -55;
-                pos one six -30;
-            } kern_ltr;
+    See:
 
-            feature kern {
-                lookup kern_ltr;
-            } kern;
-            """
-        )
+    * https://github.com/googlei18n/ufo2ft/issues/198
+    * https://github.com/googlei18n/ufo2ft/pull/200
 
-        writer = KernFeatureWriter(ignoreMarks=False)
-        feaFile = ast.FeatureFile()
-        assert writer.write(font, feaFile)
+    Additionally, some Arabic numerals are used in more than one script. One
+    approach is to look at other glyphs with distinct script associations
+    and consider the font to be supporting those.
+    """
+    ufo = FontClass()
+    for name, code in [("four-ar", 0x664), ("seven-ar", 0x667)]:
+        glyph = ufo.newGlyph(name)
+        glyph.unicode = code
+    ufo.kerning.update({("four-ar", "seven-ar"): -30})
 
-        assert str(feaFile) == dedent(
-            """\
-            lookup kern_ltr {
-                pos four six -55;
-                pos one six -30;
-            } kern_ltr;
+    generated = KernFeatureWriterTest.writeFeatures(ufo)
 
-            feature kern {
-                lookup kern_ltr;
-            } kern;
-            """
-        )
+    assert generated.asFea() == snapshot
 
-    def test_mark_to_base_kern(self, FontClass):
-        font = FontClass()
-        for name in ("A", "B", "C"):
-            font.newGlyph(name)
-        font.newGlyph("acutecomb").unicode = 0x0301
-        font.kerning.update({("A", "acutecomb"): -55.0, ("B", "C"): -30.0})
+    ufo.newGlyph("alef-ar").unicode = 0x627
+    generated = KernFeatureWriterTest.writeFeatures(ufo)
 
-        font.features.text = dedent(
-            """\
-            @Bases = [A B C];
-            @Marks = [acutecomb];
-            table GDEF {
-                GlyphClassDef @Bases, [], @Marks, ;
-            } GDEF;
-            """
-        )
+    assert generated.asFea() == snapshot
 
-        # default is ignoreMarks=True
-        feaFile = self.writeFeatures(font)
-        assert str(feaFile) == dedent(
-            """\
-            lookup kern_ltr {
-                lookupflag IgnoreMarks;
-                pos B C -30;
-            } kern_ltr;
+    ufo.features.text = """
+        languagesystem DFLT dflt;
+        languagesystem Thaa dflt;
+    """
+    generated = KernFeatureWriterTest.writeFeatures(ufo)
 
-            lookup kern_ltr_marks {
-                pos A acutecomb -55;
-            } kern_ltr_marks;
+    assert generated.asFea() == snapshot
 
-            feature kern {
-                lookup kern_ltr;
-                lookup kern_ltr_marks;
-            } kern;
-            """
-        )
+    del ufo["alef-ar"]
+    generated = KernFeatureWriterTest.writeFeatures(ufo)
 
-        feaFile = self.writeFeatures(font, ignoreMarks=False)
-        assert str(feaFile) == dedent(
-            """\
-            lookup kern_ltr {
-                pos A acutecomb -55;
-                pos B C -30;
-            } kern_ltr;
+    assert generated.asFea() == snapshot
 
-            feature kern {
-                lookup kern_ltr;
-            } kern;
-            """
-        )
 
-    def test_mark_to_base_only(self, FontClass):
-        font = FontClass()
-        for name in ("A", "B", "C"):
-            font.newGlyph(name)
-        font.newGlyph("acutecomb").unicode = 0x0301
-        font.kerning.update({("A", "acutecomb"): -55.0})
+def test_skip_zero_class_kerns(snapshot, FontClass):
+    glyphs = {
+        "A": ord("A"),
+        "B": ord("B"),
+        "C": ord("C"),
+        "D": ord("D"),
+        "E": ord("E"),
+        "F": ord("F"),
+        "G": ord("G"),
+        "H": ord("H"),
+    }
+    groups = {
+        "public.kern1.foo": ["A", "B"],
+        "public.kern2.bar": ["C", "D"],
+        "public.kern1.baz": ["E", "F"],
+        "public.kern2.nul": ["G", "H"],
+    }
+    kerning = {
+        ("public.kern1.foo", "public.kern2.bar"): 10,
+        ("public.kern1.baz", "public.kern2.bar"): -10,
+        ("public.kern1.foo", "D"): 15,
+        ("A", "public.kern2.bar"): 5,
+        ("G", "H"): -5,
+        # class-class zero-value pairs are skipped
+        ("public.kern1.foo", "public.kern2.nul"): 0,
+    }
 
-        font.features.text = dedent(
-            """\
-            @Bases = [A B C];
-            @Marks = [acutecomb];
-            table GDEF {
-                GlyphClassDef @Bases, [], @Marks, ;
-            } GDEF;
-            """
-        )
+    ufo = makeUFO(FontClass, glyphs, groups, kerning)
+    newFeatures = KernFeatureWriterTest.writeFeatures(ufo)
 
-        # default is ignoreMarks=True
-        feaFile = self.writeFeatures(font)
-        assert str(feaFile) == dedent(
-            """\
-            lookup kern_ltr_marks {
-                pos A acutecomb -55;
-            } kern_ltr_marks;
+    assert newFeatures.asFea() == snapshot
 
-            feature kern {
-                lookup kern_ltr_marks;
-            } kern;
-            """
-        )
 
-    def test_mode(self, FontClass):
-        ufo = FontClass()
-        for name in ("one", "four", "six", "seven"):
-            ufo.newGlyph(name)
-        existing = dedent(
-            """\
-            feature kern {
-                pos one four' -50 six;
-            } kern;
-            """
-        )
-        ufo.features.text = existing
-        ufo.kerning.update({("seven", "six"): 25.0})
+def test_kern_uniqueness(snapshot, FontClass):
+    glyphs = {
+        ".notdef": None,
+        "questiondown": 0xBF,
+        "y": 0x79,
+    }
+    groups = {
+        "public.kern1.questiondown": ["questiondown"],
+        "public.kern2.y": ["y"],
+    }
+    kerning = {
+        ("public.kern1.questiondown", "public.kern2.y"): 15,
+        ("public.kern1.questiondown", "y"): 35,
+        ("questiondown", "public.kern2.y"): -35,
+        ("questiondown", "y"): 35,
+    }
+    ufo = makeUFO(FontClass, glyphs, groups, kerning)
 
-        writer = KernFeatureWriter()  # default mode="skip"
-        feaFile = parseLayoutFeatures(ufo)
-        assert not writer.write(ufo, feaFile)
+    newFeatures = KernFeatureWriterTest.writeFeatures(ufo)
 
-        assert str(feaFile) == existing
+    # The final kerning value for questiondown, y is 35 and all variants
+    # must be present. Ensures the uniqueness filter doesn't filter things
+    # out.
+    assert newFeatures.asFea() == snapshot
 
-        # pass optional "append" mode
-        writer = KernFeatureWriter(mode="append")
-        feaFile = parseLayoutFeatures(ufo)
-        assert writer.write(ufo, feaFile)
 
-        expected = existing + dedent(
-            """
-            lookup kern_ltr {
-                lookupflag IgnoreMarks;
-                pos seven six 25;
-            } kern_ltr;
+def test_kern_LTR_and_RTL(snapshot, FontClass):
+    glyphs = {
+        ".notdef": None,
+        "four": 0x34,
+        "seven": 0x37,
+        "A": 0x41,
+        "V": 0x56,
+        "Aacute": 0xC1,
+        "alef-ar": 0x627,
+        "reh-ar": 0x631,
+        "zain-ar": 0x632,
+        "lam-ar": 0x644,
+        "four-ar": 0x664,
+        "seven-ar": 0x667,
+        # # we also add glyphs without unicode codepoint, but linked to
+        # # an encoded 'character' glyph by some GSUB rule
+        "alef-ar.isol": None,
+        "lam-ar.init": None,
+        "reh-ar.fina": None,
+    }
+    groups = {
+        "public.kern1.A": ["A", "Aacute"],
+        "public.kern1.reh": ["reh-ar", "zain-ar", "reh-ar.fina"],
+        "public.kern2.alef": ["alef-ar", "alef-ar.isol"],
+    }
+    kerning = {
+        ("public.kern1.A", "V"): -40,
+        ("seven", "four"): -25,
+        ("reh-ar.fina", "lam-ar.init"): -80,
+        ("public.kern1.reh", "public.kern2.alef"): -100,
+        ("four-ar", "seven-ar"): -30,
+    }
+    features = """\
+        languagesystem DFLT dflt;
+        languagesystem latn dflt;
+        languagesystem latn TRK;
+        languagesystem arab dflt;
+        languagesystem arab URD;
 
-            feature kern {
-                lookup kern_ltr;
-            } kern;
-            """
-        )
-        assert str(feaFile) == expected
+        feature init {
+            script arab;
+            sub lam-ar by lam-ar.init;
+            language URD;
+        } init;
 
-        # pass "skip" mode explicitly
-        writer = KernFeatureWriter(mode="skip")
-        feaFile = parseLayoutFeatures(ufo)
-        assert not writer.write(ufo, feaFile)
+        feature fina {
+            script arab;
+            sub reh-ar by reh-ar.fina;
+            language URD;
+        } fina;
 
-        assert str(feaFile) == existing
-
-    def test_insert_comment_before(self, FontClass):
-        ufo = FontClass()
-        for name in ("one", "four", "six", "seven"):
-            ufo.newGlyph(name)
-        existing = dedent(
-            """\
-            feature kern {
-                #
-                # Automatic Code
-                #
-                pos one four' -50 six;
-            } kern;
-            """
-        )
-        ufo.features.text = existing
-        ufo.kerning.update({("seven", "six"): 25.0})
-
-        writer = KernFeatureWriter()
-        feaFile = parseLayoutFeatures(ufo)
-        assert writer.write(ufo, feaFile)
-
-        expected = dedent(
-            """\
-            lookup kern_ltr {
-                lookupflag IgnoreMarks;
-                pos seven six 25;
-            } kern_ltr;
-
-            feature kern {
-                lookup kern_ltr;
-            } kern;
-
-            feature kern {
-                #
-                #
-                pos one four' -50 six;
-            } kern;
-            """
-        )
-
-        assert str(feaFile).strip() == expected.strip()
-
-        # test append mode ignores insert marker
-        generated = self.writeFeatures(ufo, mode="append")
-        assert str(generated) == dedent(
-            """\
-            lookup kern_ltr {
-                lookupflag IgnoreMarks;
-                pos seven six 25;
-            } kern_ltr;
-
-            feature kern {
-                lookup kern_ltr;
-            } kern;
-            """
-        )
-
-    def test_insert_comment_before_extended(self, FontClass):
-        ufo = FontClass()
-        for name in ("one", "four", "six", "seven"):
-            ufo.newGlyph(name)
-        existing = dedent(
-            """\
-            feature kern {
-                #
-                # Automatic Code End
-                #
-                pos one four' -50 six;
-            } kern;
-            """
-        )
-        ufo.features.text = existing
-        ufo.kerning.update({("seven", "six"): 25.0})
-
-        writer = KernFeatureWriter()
-        feaFile = parseLayoutFeatures(ufo)
-        assert writer.write(ufo, feaFile)
-
-        expected = dedent(
-            """\
-            lookup kern_ltr {
-                lookupflag IgnoreMarks;
-                pos seven six 25;
-            } kern_ltr;
-
-            feature kern {
-                lookup kern_ltr;
-            } kern;
-
-            feature kern {
-                #
-                #
-                pos one four' -50 six;
-            } kern;
-            """
-        )
-
-        assert str(feaFile).strip() == expected.strip()
-
-    def test_insert_comment_after(self, FontClass):
-        ufo = FontClass()
-        for name in ("one", "four", "six", "seven"):
-            ufo.newGlyph(name)
-        existing = dedent(
-            """\
-            feature kern {
-                pos one four' -50 six;
-                #
-                # Automatic Code
-                #
-            } kern;
-            """
-        )
-        ufo.features.text = existing
-        ufo.kerning.update({("seven", "six"): 25.0})
-
-        writer = KernFeatureWriter()
-        feaFile = parseLayoutFeatures(ufo)
-        assert writer.write(ufo, feaFile)
-
-        expected = dedent(
-            """\
-            feature kern {
-                pos one four' -50 six;
-                #
-                #
-            } kern;
-
-            lookup kern_ltr {
-                lookupflag IgnoreMarks;
-                pos seven six 25;
-            } kern_ltr;
-
-            feature kern {
-                lookup kern_ltr;
-            } kern;
-            """
-        )
-
-        assert str(feaFile) == expected
-
-        # test append mode ignores insert marker
-        generated = self.writeFeatures(ufo, mode="append")
-        assert str(generated) == dedent(
-            """\
-            lookup kern_ltr {
-                lookupflag IgnoreMarks;
-                pos seven six 25;
-            } kern_ltr;
-
-            feature kern {
-                lookup kern_ltr;
-            } kern;
-            """
-        )
-
-    def test_insert_comment_middle(self, FontClass):
-        ufo = FontClass()
-        for name in ("one", "four", "six", "seven"):
-            ufo.newGlyph(name)
-        existing = dedent(
-            """\
-            feature kern {
-                pos one four' -50 six;
-                #
-                # Automatic Code
-                #
-                pos one six' -50 six;
-            } kern;
-            """
-        )
-        ufo.features.text = existing
-        ufo.kerning.update({("seven", "six"): 25.0})
-
-        writer = KernFeatureWriter()
-        feaFile = parseLayoutFeatures(ufo)
-
-        with pytest.raises(
-            InvalidFeaturesData,
-            match="Insert marker has rules before and after, feature kern "
-            "cannot be inserted.",
-        ):
-            writer.write(ufo, feaFile)
-
-        # test append mode ignores insert marker
-        generated = self.writeFeatures(ufo, mode="append")
-        assert str(generated) == dedent(
-            """\
-            lookup kern_ltr {
-                lookupflag IgnoreMarks;
-                pos seven six 25;
-            } kern_ltr;
-
-            feature kern {
-                lookup kern_ltr;
-            } kern;
-            """
-        )
-
-    def test_arabic_numerals(self, FontClass):
-        """Test that arabic numerals (with bidi type AN) are kerned LTR.
-        https://github.com/googlei18n/ufo2ft/issues/198
-        https://github.com/googlei18n/ufo2ft/pull/200
+        feature isol {
+            script arab;
+            sub alef-ar by alef-ar.isol;
+        } isol;
         """
-        ufo = FontClass()
-        for name, code in [("four-ar", 0x664), ("seven-ar", 0x667)]:
-            glyph = ufo.newGlyph(name)
-            glyph.unicode = code
-        ufo.kerning.update({("four-ar", "seven-ar"): -30})
-        ufo.features.text = dedent(
-            """
-            languagesystem DFLT dflt;
-            languagesystem arab dflt;
-            """
-        )
-
-        generated = self.writeFeatures(ufo)
-
-        assert str(generated) == dedent(
-            """\
-            lookup kern_rtl {
-                lookupflag IgnoreMarks;
-                pos four-ar seven-ar -30;
-            } kern_rtl;
-
-            feature kern {
-                lookup kern_rtl;
-            } kern;
-            """
-        )
-
-    def test__groupScriptsByTagAndDirection(self, FontClass):
-        font = FontClass()
-        font.features.text = dedent(
-            """
-            languagesystem DFLT dflt;
-            languagesystem latn dflt;
-            languagesystem latn TRK;
-            languagesystem arab dflt;
-            languagesystem arab URD;
-            languagesystem deva dflt;
-            languagesystem dev2 dflt;
-            languagesystem math dflt;
-            """
-        )
-
-        feaFile = parseLayoutFeatures(font)
-        scripts = ast.getScriptLanguageSystems(feaFile)
-        scriptGroups = KernFeatureWriter._groupScriptsByTagAndDirection(scripts)
-
-        assert "kern" in scriptGroups
-        assert list(scriptGroups["kern"]["LTR"]) == [
-            ("latn", ["dflt", "TRK "]),
-            ("math", ["dflt"]),
-        ]
-        assert list(scriptGroups["kern"]["RTL"]) == [("arab", ["dflt", "URD "])]
-
-        assert "dist" in scriptGroups
-        assert list(scriptGroups["dist"]["LTR"]) == [
-            ("deva", ["dflt"]),
-            ("dev2", ["dflt"]),
-        ]
-
-    def test_getKerningClasses(self, FontClass):
-        font = FontClass()
-        for i in range(65, 65 + 6):  # A..F
-            font.newGlyph(chr(i))
-        font.groups.update({"public.kern1.A": ["A", "B"], "public.kern2.C": ["C", "D"]})
-        # simulate a name clash between pre-existing class definitions in
-        # feature file, and those generated by the feature writer
-        font.features.text = "@kern1.A = [E F];"
-
-        feaFile = parseLayoutFeatures(font)
-        side1Classes, side2Classes = KernFeatureWriter.getKerningClasses(font, feaFile)
-
-        assert "public.kern1.A" in side1Classes
-        # the new class gets a unique name
-        assert side1Classes["public.kern1.A"].name == "kern1.A_1"
-        assert getGlyphs(side1Classes["public.kern1.A"]) == ["A", "B"]
-
-        assert "public.kern2.C" in side2Classes
-        assert side2Classes["public.kern2.C"].name == "kern2.C"
-        assert getGlyphs(side2Classes["public.kern2.C"]) == ["C", "D"]
-
-    def test_correct_invalid_class_names(self, FontClass):
-        font = FontClass()
-        for i in range(65, 65 + 12):  # A..L
-            font.newGlyph(chr(i))
-        font.groups.update(
-            {
-                "public.kern1.foo$": ["A", "B", "C"],
-                "public.kern1.foo@": ["D", "E", "F"],
-                "@public.kern2.bar": ["G", "H", "I"],
-                "public.kern2.bar&": ["J", "K", "L"],
-            }
-        )
-        font.kerning.update(
-            {
-                ("public.kern1.foo$", "@public.kern2.bar"): 10,
-                ("public.kern1.foo@", "public.kern2.bar&"): -10,
-            }
-        )
-
-        side1Classes, side2Classes = KernFeatureWriter.getKerningClasses(font)
-
-        assert side1Classes["public.kern1.foo$"].name == "kern1.foo"
-        assert side1Classes["public.kern1.foo@"].name == "kern1.foo_1"
-        # no valid 'public.kern{1,2}.' prefix, skipped
-        assert "@public.kern2.bar" not in side2Classes
-        assert side2Classes["public.kern2.bar&"].name == "kern2.bar"
-
-    def test_getKerningPairs(self, FontClass):
-        font = FontClass()
-        for i in range(65, 65 + 8):  # A..H
-            font.newGlyph(chr(i))
-        font.groups.update(
-            {
-                "public.kern1.foo": ["A", "B"],
-                "public.kern2.bar": ["C", "D"],
-                "public.kern1.baz": ["E", "F"],
-                "public.kern2.nul": ["G", "H"],
-            }
-        )
-        font.kerning.update(
-            {
-                ("public.kern1.foo", "public.kern2.bar"): 10,
-                ("public.kern1.baz", "public.kern2.bar"): -10,
-                ("public.kern1.foo", "D"): 15,
-                ("A", "public.kern2.bar"): 5,
-                ("G", "H"): -5,
-                # class-class zero-value pairs are skipped
-                ("public.kern1.foo", "public.kern2.nul"): 0,
-            }
-        )
-
-        s1c, s2c = KernFeatureWriter.getKerningClasses(font)
-        pairs = KernFeatureWriter.getKerningPairs(font, s1c, s2c)
-        assert len(pairs) == 5
-
-        assert "G H -5" in repr(pairs[0])
-        assert (pairs[0].firstIsClass, pairs[0].secondIsClass) == (False, False)
-        assert pairs[0].glyphs == {"G", "H"}
-
-        assert "A @kern2.bar 5" in repr(pairs[1])
-        assert (pairs[1].firstIsClass, pairs[1].secondIsClass) == (False, True)
-        assert pairs[1].glyphs == {"A", "C", "D"}
-
-        assert "@kern1.foo D 15" in repr(pairs[2])
-        assert (pairs[2].firstIsClass, pairs[2].secondIsClass) == (True, False)
-        assert pairs[2].glyphs == {"A", "B", "D"}
-
-        assert "@kern1.baz @kern2.bar -10" in repr(pairs[3])
-        assert (pairs[3].firstIsClass, pairs[3].secondIsClass) == (True, True)
-        assert pairs[3].glyphs == {"C", "D", "E", "F"}
-
-        assert "@kern1.foo @kern2.bar 10" in repr(pairs[4])
-        assert (pairs[4].firstIsClass, pairs[4].secondIsClass) == (True, True)
-        assert pairs[4].glyphs == {"A", "B", "C", "D"}
-
-    def test_kern_LTR_and_RTL(self, FontClass):
-        glyphs = {
-            ".notdef": None,
-            "four": 0x34,
-            "seven": 0x37,
-            "A": 0x41,
-            "V": 0x56,
-            "Aacute": 0xC1,
-            "alef-ar": 0x627,
-            "reh-ar": 0x631,
-            "zain-ar": 0x632,
-            "lam-ar": 0x644,
-            "four-ar": 0x664,
-            "seven-ar": 0x667,
-            # # we also add glyphs without unicode codepoint, but linked to
-            # # an encoded 'character' glyph by some GSUB rule
-            "alef-ar.isol": None,
-            "lam-ar.init": None,
-            "reh-ar.fina": None,
-        }
-        groups = {
-            "public.kern1.A": ["A", "Aacute"],
-            "public.kern1.reh": ["reh-ar", "zain-ar", "reh-ar.fina"],
-            "public.kern2.alef": ["alef-ar", "alef-ar.isol"],
-        }
-        kerning = {
-            ("public.kern1.A", "V"): -40,
-            ("seven", "four"): -25,
-            ("reh-ar.fina", "lam-ar.init"): -80,
-            ("public.kern1.reh", "public.kern2.alef"): -100,
-            ("four-ar", "seven-ar"): -30,
-        }
-        features = dedent(
-            """\
-            languagesystem DFLT dflt;
-            languagesystem latn dflt;
-            languagesystem latn TRK;
-            languagesystem arab dflt;
-            languagesystem arab URD;
-
-            feature init {
-                script arab;
-                sub lam-ar by lam-ar.init;
-                language URD;
-            } init;
-
-            feature fina {
-                script arab;
-                sub reh-ar by reh-ar.fina;
-                language URD;
-            } fina;
-            """
-        )
-
-        ufo = makeUFO(FontClass, glyphs, groups, kerning, features)
-
-        newFeatures = self.writeFeatures(ufo, ignoreMarks=False)
-
-        assert str(newFeatures) == dedent(
-            """\
-            @kern1.A = [A Aacute];
-            @kern1.reh = [reh-ar zain-ar reh-ar.fina];
-            @kern2.alef = [alef-ar alef-ar.isol];
-
-            lookup kern_dflt {
-                pos seven four -25;
-            } kern_dflt;
-
-            lookup kern_ltr {
-                enum pos @kern1.A V -40;
-            } kern_ltr;
-
-            lookup kern_rtl {
-                pos four-ar seven-ar -30;
-                pos reh-ar.fina lam-ar.init <-80 0 -80 0>;
-                pos @kern1.reh @kern2.alef <-100 0 -100 0>;
-            } kern_rtl;
-
-            feature kern {
-                lookup kern_dflt;
-                script latn;
-                language dflt;
-                lookup kern_ltr;
-                language TRK;
-                script arab;
-                language dflt;
-                lookup kern_rtl;
-                language URD;
-            } kern;
-            """
-        )
-
-    def test_kern_LTR_and_RTL_with_marks(self, FontClass):
-        glyphs = {
-            ".notdef": None,
-            "four": 0x34,
-            "seven": 0x37,
-            "A": 0x41,
-            "V": 0x56,
-            "Aacute": 0xC1,
-            "acutecomb": 0x301,
-            "alef-ar": 0x627,
-            "reh-ar": 0x631,
-            "zain-ar": 0x632,
-            "lam-ar": 0x644,
-            "four-ar": 0x664,
-            "seven-ar": 0x667,
-            "fatha-ar": 0x64E,
-            # # we also add glyphs without unicode codepoint, but linked to
-            # # an encoded 'character' glyph by some GSUB rule
-            "alef-ar.isol": None,
-            "lam-ar.init": None,
-            "reh-ar.fina": None,
-        }
-        groups = {
-            "public.kern1.A": ["A", "Aacute"],
-            "public.kern1.reh": ["reh-ar", "zain-ar", "reh-ar.fina"],
-            "public.kern2.alef": ["alef-ar", "alef-ar.isol"],
-        }
-        kerning = {
-            ("public.kern1.A", "V"): -40,
-            ("seven", "four"): -25,
-            ("reh-ar.fina", "lam-ar.init"): -80,
-            ("public.kern1.reh", "public.kern2.alef"): -100,
-            ("four-ar", "seven-ar"): -30,
-            ("V", "acutecomb"): 70,
-            ("reh-ar", "fatha-ar"): 80,
-        }
-        features = dedent(
-            """\
-            languagesystem DFLT dflt;
-            languagesystem latn dflt;
-            languagesystem latn TRK;
-            languagesystem arab dflt;
-            languagesystem arab URD;
-
-            feature init {
-                script arab;
-                sub lam-ar by lam-ar.init;
-                language URD;
-            } init;
-
-            feature fina {
-                script arab;
-                sub reh-ar by reh-ar.fina;
-                language URD;
-            } fina;
-
-            @Bases = [A V Aacute alef-ar reh-ar zain-ar lam-ar
-                      alef-ar.isol lam-ar.init reh-ar.fina];
-            @Marks = [acutecomb fatha-ar];
-            table GDEF {
-                GlyphClassDef @Bases, [], @Marks, ;
-            } GDEF;
-            """
-        )
-
-        ufo = makeUFO(FontClass, glyphs, groups, kerning, features)
-
-        newFeatures = self.writeFeatures(ufo)
-
-        assert str(newFeatures) == dedent(
-            """\
-            @kern1.A = [A Aacute];
-            @kern1.reh = [reh-ar zain-ar reh-ar.fina];
-            @kern2.alef = [alef-ar alef-ar.isol];
-
-            lookup kern_dflt {
-                lookupflag IgnoreMarks;
-                pos seven four -25;
-            } kern_dflt;
-
-            lookup kern_ltr {
-                lookupflag IgnoreMarks;
-                enum pos @kern1.A V -40;
-            } kern_ltr;
-
-            lookup kern_ltr_marks {
-                pos V acutecomb 70;
-            } kern_ltr_marks;
-
-            lookup kern_rtl {
-                lookupflag IgnoreMarks;
-                pos four-ar seven-ar -30;
-                pos reh-ar.fina lam-ar.init <-80 0 -80 0>;
-                pos @kern1.reh @kern2.alef <-100 0 -100 0>;
-            } kern_rtl;
-
-            lookup kern_rtl_marks {
-                pos reh-ar fatha-ar <80 0 80 0>;
-            } kern_rtl_marks;
-
-            feature kern {
-                lookup kern_dflt;
-                script latn;
-                language dflt;
-                lookup kern_ltr;
-                lookup kern_ltr_marks;
-                language TRK;
-                script arab;
-                language dflt;
-                lookup kern_rtl;
-                lookup kern_rtl_marks;
-                language URD;
-            } kern;
-            """
-        )
-
-    def test_kern_RTL_with_marks(self, FontClass):
-        glyphs = {
-            ".notdef": None,
-            "alef-ar": 0x627,
-            "reh-ar": 0x631,
-            "zain-ar": 0x632,
-            "lam-ar": 0x644,
-            "four-ar": 0x664,
-            "seven-ar": 0x667,
-            "fatha-ar": 0x64E,
-            # # we also add glyphs without unicode codepoint, but linked to
-            # # an encoded 'character' glyph by some GSUB rule
-            "alef-ar.isol": None,
-            "lam-ar.init": None,
-            "reh-ar.fina": None,
-        }
-        groups = {
-            "public.kern1.reh": ["reh-ar", "zain-ar", "reh-ar.fina"],
-            "public.kern2.alef": ["alef-ar", "alef-ar.isol"],
-        }
-        kerning = {
-            ("reh-ar.fina", "lam-ar.init"): -80,
-            ("public.kern1.reh", "public.kern2.alef"): -100,
-            ("reh-ar", "fatha-ar"): 80,
-        }
-        features = dedent(
-            """\
-            languagesystem arab dflt;
-            languagesystem arab ARA;
-
-            feature init {
-                script arab;
-                sub lam-ar by lam-ar.init;
-            } init;
-
-            feature fina {
-                script arab;
-                sub reh-ar by reh-ar.fina;
-            } fina;
-
-            @Bases = [alef-ar reh-ar zain-ar lam-ar alef-ar.isol lam-ar.init reh-ar.fina];
-            @Marks = [fatha-ar];
-            table GDEF {
-                GlyphClassDef @Bases, [], @Marks, ;
-            } GDEF;
-            """
-        )
-
-        ufo = makeUFO(FontClass, glyphs, groups, kerning, features)
-
-        newFeatures = self.writeFeatures(ufo)
-
-        assert str(newFeatures) == dedent(
-            """\
-            @kern1.reh = [reh-ar zain-ar reh-ar.fina];
-            @kern2.alef = [alef-ar alef-ar.isol];
-
-            lookup kern_rtl {
-                lookupflag IgnoreMarks;
-                pos reh-ar.fina lam-ar.init <-80 0 -80 0>;
-                pos @kern1.reh @kern2.alef <-100 0 -100 0>;
-            } kern_rtl;
-
-            lookup kern_rtl_marks {
-                pos reh-ar fatha-ar <80 0 80 0>;
-            } kern_rtl_marks;
-
-            feature kern {
-                lookup kern_rtl;
-                lookup kern_rtl_marks;
-            } kern;
-            """
-        )
-
-    def test_kern_LTR_and_RTL_one_uses_DFLT(self, FontClass):
-        glyphs = {"A": 0x41, "V": 0x56, "reh-ar": 0x631, "alef-ar": 0x627}
-        kerning = {("A", "V"): -40, ("reh-ar", "alef-ar"): -100}
-        features = "languagesystem latn dflt;"
-        ufo = makeUFO(FontClass, glyphs, kerning=kerning, features=features)
-        generated = self.writeFeatures(ufo)
-
-        assert str(generated) == dedent(
-            """\
-            lookup kern_ltr {
-                lookupflag IgnoreMarks;
-                pos A V -40;
-            } kern_ltr;
-
-            lookup kern_rtl {
-                lookupflag IgnoreMarks;
-                pos reh-ar alef-ar <-100 0 -100 0>;
-            } kern_rtl;
-
-            feature kern {
-                script DFLT;
-                language dflt;
-                lookup kern_rtl;
-                script latn;
-                language dflt;
-                lookup kern_ltr;
-            } kern;
-            """
-        )
-
-        features = dedent("languagesystem arab dflt;")
-        ufo = makeUFO(FontClass, glyphs, kerning=kerning, features=features)
-        generated = self.writeFeatures(ufo)
-
-        assert str(generated) == dedent(
-            """\
-            lookup kern_ltr {
-                lookupflag IgnoreMarks;
-                pos A V -40;
-            } kern_ltr;
-
-            lookup kern_rtl {
-                lookupflag IgnoreMarks;
-                pos reh-ar alef-ar <-100 0 -100 0>;
-            } kern_rtl;
-
-            feature kern {
-                script DFLT;
-                language dflt;
-                lookup kern_ltr;
-                script arab;
-                language dflt;
-                lookup kern_rtl;
-            } kern;
-            """
-        )
-
-    def test_kern_LTR_and_RTL_cannot_use_DFLT(self, FontClass):
-        glyphs = {"A": 0x41, "V": 0x56, "reh-ar": 0x631, "alef-ar": 0x627}
-        kerning = {("A", "V"): -40, ("reh-ar", "alef-ar"): -100}
-        ufo = makeUFO(FontClass, glyphs, kerning=kerning)
-        with pytest.raises(ValueError, match="cannot use DFLT script"):
-            self.writeFeatures(ufo)
-
-    def test_dist_LTR(self, FontClass):
-        glyphs = {"aaMatra_kannada": 0x0CBE, "ailength_kannada": 0xCD6}
-        groups = {
-            "public.kern1.KND_aaMatra_R": ["aaMatra_kannada"],
-            "public.kern2.KND_ailength_L": ["aaMatra_kannada"],
-        }
-        kerning = {("public.kern1.KND_aaMatra_R", "public.kern2.KND_ailength_L"): 34}
-        features = dedent(
-            """\
-            languagesystem DFLT dflt;
-            languagesystem latn dflt;
-            languagesystem knda dflt;
-            languagesystem knd2 dflt;
-            """
-        )
-
-        ufo = makeUFO(FontClass, glyphs, groups, kerning, features)
-        generated = self.writeFeatures(ufo)
-
-        assert str(generated) == dedent(
-            """\
-            @kern1.KND_aaMatra_R = [aaMatra_kannada];
-            @kern2.KND_ailength_L = [aaMatra_kannada];
-
-            lookup kern_ltr {
-                lookupflag IgnoreMarks;
-                pos @kern1.KND_aaMatra_R @kern2.KND_ailength_L 34;
-            } kern_ltr;
-
-            feature kern {
-                script DFLT;
-                language dflt;
-                lookup kern_ltr;
-                script latn;
-                language dflt;
-                lookup kern_ltr;
-            } kern;
-
-            feature dist {
-                script knda;
-                language dflt;
-                lookup kern_ltr;
-                script knd2;
-                language dflt;
-                lookup kern_ltr;
-            } dist;
-            """
-        )
-
-    def test_dist_RTL(self, FontClass):
-        glyphs = {"u10A06": 0x10A06, "u10A1E": 0x10A1E}
-        kerning = {("u10A1E", "u10A06"): 117}
-        features = dedent(
-            """\
-            languagesystem DFLT dflt;
-            languagesystem arab dflt;
-            languagesystem khar dflt;
-            """
-        )
-        ufo = makeUFO(FontClass, glyphs, kerning=kerning, features=features)
-        generated = self.writeFeatures(ufo)
-
-        assert str(generated) == dedent(
-            """\
-            lookup kern_rtl {
-                lookupflag IgnoreMarks;
-                pos u10A1E u10A06 <117 0 117 0>;
-            } kern_rtl;
-
-            feature kern {
-                script DFLT;
-                language dflt;
-                lookup kern_rtl;
-                script arab;
-                language dflt;
-                lookup kern_rtl;
-            } kern;
-
-            feature dist {
-                script khar;
-                language dflt;
-                lookup kern_rtl;
-            } dist;
-            """
-        )
-
-    def test_dist_LTR_and_RTL(self, FontClass):
-        glyphs = {
-            "aaMatra_kannada": 0x0CBE,
-            "ailength_kannada": 0xCD6,
-            "u10A06": 0x10A06,
-            "u10A1E": 0x10A1E,
-        }
-        groups = {
-            "public.kern1.KND_aaMatra_R": ["aaMatra_kannada"],
-            "public.kern2.KND_ailength_L": ["aaMatra_kannada"],
-        }
-        kerning = {
-            ("public.kern1.KND_aaMatra_R", "public.kern2.KND_ailength_L"): 34,
-            ("u10A1E", "u10A06"): 117,
-        }
-        features = dedent(
-            """\
+
+    ufo = makeUFO(FontClass, glyphs, groups, kerning, features)
+
+    newFeatures = KernFeatureWriterTest.writeFeatures(ufo, ignoreMarks=False)
+
+    assert newFeatures.asFea() == snapshot
+
+
+def test_kern_LTR_and_RTL_with_marks(snapshot, FontClass):
+    glyphs = {
+        ".notdef": None,
+        "four": 0x34,
+        "seven": 0x37,
+        "A": 0x41,
+        "V": 0x56,
+        "Aacute": 0xC1,
+        "acutecomb": 0x301,
+        "alef-ar": 0x627,
+        "reh-ar": 0x631,
+        "zain-ar": 0x632,
+        "lam-ar": 0x644,
+        "four-ar": 0x664,
+        "seven-ar": 0x667,
+        "fatha-ar": 0x64E,
+        # we also add glyphs without unicode codepoint, but linked to
+        # an encoded 'character' glyph by some GSUB rule
+        "alef-ar.isol": None,
+        "lam-ar.init": None,
+        "reh-ar.fina": None,
+    }
+    groups = {
+        "public.kern1.A": ["A", "Aacute"],
+        "public.kern1.reh": ["reh-ar", "zain-ar", "reh-ar.fina"],
+        "public.kern2.alef": ["alef-ar", "alef-ar.isol"],
+    }
+    kerning = {
+        ("public.kern1.A", "V"): -40,
+        ("seven", "four"): -25,
+        ("reh-ar.fina", "lam-ar.init"): -80,
+        ("public.kern1.reh", "public.kern2.alef"): -100,
+        ("four-ar", "seven-ar"): -30,
+        ("V", "acutecomb"): 70,
+        ("reh-ar", "fatha-ar"): 80,
+    }
+    features = """\
+        languagesystem DFLT dflt;
+        languagesystem latn dflt;
+        languagesystem latn TRK;
+        languagesystem arab dflt;
+        languagesystem arab URD;
+
+        feature init {
+            script arab;
+            sub lam-ar by lam-ar.init;
+            language URD;
+        } init;
+
+        feature fina {
+            script arab;
+            sub reh-ar by reh-ar.fina;
+            language URD;
+        } fina;
+
+        feature isol {
+            script arab;
+            sub alef-ar by alef-ar.isol;
+        } isol;
+
+        @Bases = [A V Aacute alef-ar reh-ar zain-ar lam-ar
+                    alef-ar.isol lam-ar.init reh-ar.fina];
+        @Marks = [acutecomb fatha-ar];
+        table GDEF {
+            GlyphClassDef @Bases, [], @Marks, ;
+        } GDEF;
+        """
+
+    ufo = makeUFO(FontClass, glyphs, groups, kerning, features)
+
+    newFeatures = KernFeatureWriterTest.writeFeatures(ufo)
+
+    assert newFeatures.asFea() == snapshot
+
+
+def test_kern_RTL_with_marks(snapshot, FontClass):
+    glyphs = {
+        ".notdef": None,
+        "alef-ar": 0x627,
+        "reh-ar": 0x631,
+        "zain-ar": 0x632,
+        "lam-ar": 0x644,
+        "four-ar": 0x664,
+        "seven-ar": 0x667,
+        "fatha-ar": 0x64E,
+        # we also add glyphs without unicode codepoint, but linked to
+        # an encoded 'character' glyph by some GSUB rule
+        "alef-ar.isol": None,
+        "lam-ar.init": None,
+        "reh-ar.fina": None,
+    }
+    groups = {
+        "public.kern1.reh": ["reh-ar", "zain-ar", "reh-ar.fina"],
+        "public.kern2.alef": ["alef-ar", "alef-ar.isol"],
+    }
+    kerning = {
+        ("reh-ar.fina", "lam-ar.init"): -80,
+        ("public.kern1.reh", "public.kern2.alef"): -100,
+        ("reh-ar", "fatha-ar"): 80,
+    }
+    features = """\
+        languagesystem arab dflt;
+        languagesystem arab ARA;
+
+        feature init {
+            script arab;
+            sub lam-ar by lam-ar.init;
+        } init;
+
+        feature fina {
+            script arab;
+            sub reh-ar by reh-ar.fina;
+        } fina;
+
+        feature isol {
+            script arab;
+            sub alef-ar by alef-ar.isol;
+        } isol;
+
+        @Bases = [alef-ar reh-ar zain-ar lam-ar alef-ar.isol lam-ar.init reh-ar.fina];
+        @Marks = [fatha-ar];
+        table GDEF {
+            GlyphClassDef @Bases, [], @Marks, ;
+        } GDEF;
+        """
+
+    ufo = makeUFO(FontClass, glyphs, groups, kerning, features)
+
+    newFeatures = KernFeatureWriterTest.writeFeatures(ufo)
+    assert newFeatures.asFea() == snapshot
+
+
+def test_kern_independent_of_languagesystem(snapshot, FontClass):
+    glyphs = {"A": 0x41, "V": 0x56, "reh-ar": 0x631, "alef-ar": 0x627}
+    kerning = {("A", "V"): -40, ("reh-ar", "alef-ar"): -100}
+    # No languagesystems declared.
+    ufo = makeUFO(FontClass, glyphs, kerning=kerning)
+    generated = KernFeatureWriterTest.writeFeatures(ufo)
+
+    assert generated.asFea() == snapshot(name="same")
+
+    features = "languagesystem arab dflt;"
+    ufo = makeUFO(FontClass, glyphs, kerning=kerning, features=features)
+    generated = KernFeatureWriterTest.writeFeatures(ufo)
+
+    assert generated.asFea() == snapshot(name="same")
+
+
+def test_dist_LTR(snapshot, FontClass):
+    glyphs = {"aaMatra_kannada": 0x0CBE, "ailength_kannada": 0xCD6}
+    groups = {
+        "public.kern1.KND_aaMatra_R": ["aaMatra_kannada"],
+        "public.kern2.KND_ailength_L": ["aaMatra_kannada"],
+    }
+    kerning = {("public.kern1.KND_aaMatra_R", "public.kern2.KND_ailength_L"): 34}
+    features = """\
+        languagesystem DFLT dflt;
+        languagesystem latn dflt;
+        languagesystem knda dflt;
+        languagesystem knd2 dflt;
+        """
+
+    ufo = makeUFO(FontClass, glyphs, groups, kerning, features)
+    generated = KernFeatureWriterTest.writeFeatures(ufo)
+
+    assert generated.asFea() == snapshot
+
+
+def test_dist_RTL(snapshot, FontClass):
+    glyphs = {"u10A06": 0x10A06, "u10A1E": 0x10A1E}
+    kerning = {("u10A1E", "u10A06"): 117}
+    features = """\
+        languagesystem DFLT dflt;
+        languagesystem arab dflt;
+        languagesystem khar dflt;
+        """
+
+    ufo = makeUFO(FontClass, glyphs, kerning=kerning, features=features)
+    generated = KernFeatureWriterTest.writeFeatures(ufo)
+
+    assert generated.asFea() == snapshot
+
+
+def test_dist_LTR_and_RTL(snapshot, FontClass):
+    glyphs = {
+        "aaMatra_kannada": 0x0CBE,
+        "ailength_kannada": 0xCD6,
+        "u10A06": 0x10A06,
+        "u10A1E": 0x10A1E,
+    }
+    groups = {
+        "public.kern1.KND_aaMatra_R": ["aaMatra_kannada"],
+        "public.kern2.KND_ailength_L": ["aaMatra_kannada"],
+    }
+    kerning = {
+        ("public.kern1.KND_aaMatra_R", "public.kern2.KND_ailength_L"): 34,
+        ("u10A1E", "u10A06"): 117,
+    }
+    features = """\
             languagesystem DFLT dflt;
             languagesystem knda dflt;
             languagesystem knd2 dflt;
             languagesystem khar dflt;
             """
-        )
 
-        ufo = makeUFO(FontClass, glyphs, groups, kerning, features)
-        generated = self.writeFeatures(ufo)
+    ufo = makeUFO(FontClass, glyphs, groups, kerning, features)
+    generated = KernFeatureWriterTest.writeFeatures(ufo)
 
-        assert str(generated) == dedent(
-            """\
-            @kern1.KND_aaMatra_R = [aaMatra_kannada];
-            @kern2.KND_ailength_L = [aaMatra_kannada];
-
-            lookup kern_ltr {
-                lookupflag IgnoreMarks;
-                pos @kern1.KND_aaMatra_R @kern2.KND_ailength_L 34;
-            } kern_ltr;
-
-            lookup kern_rtl {
-                lookupflag IgnoreMarks;
-                pos u10A1E u10A06 <117 0 117 0>;
-            } kern_rtl;
-
-            feature dist {
-                script knda;
-                language dflt;
-                lookup kern_ltr;
-                script knd2;
-                language dflt;
-                lookup kern_ltr;
-                script khar;
-                language dflt;
-                lookup kern_rtl;
-            } dist;
-            """
-        )
-
-    def test_skip_ambiguous_direction_pair(self, FontClass, caplog):
-        caplog.set_level(logging.ERROR)
-
-        ufo = FontClass()
-        ufo.newGlyph("A").unicode = 0x41
-        ufo.newGlyph("one").unicode = 0x31
-        ufo.newGlyph("yod-hb").unicode = 0x5D9
-        ufo.newGlyph("reh-ar").unicode = 0x631
-        ufo.newGlyph("one-ar").unicode = 0x661
-        ufo.newGlyph("bar").unicodes = [0x73, 0x627]
-        ufo.kerning.update(
-            {
-                ("bar", "bar"): 1,
-                ("bar", "A"): 2,
-                ("reh-ar", "A"): 3,
-                ("reh-ar", "one-ar"): 4,
-                ("yod-hb", "one"): 5,
-            }
-        )
-        ufo.features.text = dedent(
-            """\
-            languagesystem DFLT dflt;
-            languagesystem latn dflt;
-            languagesystem arab dflt;
-            """
-        )
-
-        logger = "ufo2ft.featureWriters.kernFeatureWriter2.KernFeatureWriter"
-        with caplog.at_level(logging.WARNING, logger=logger):
-            generated = self.writeFeatures(ufo)
-
-        assert not generated
-        assert len(caplog.records) == 5
-        assert "skipped kern pair with ambiguous direction" in caplog.text
-
-    def test_kern_RTL_and_DFLT_numbers(self, FontClass):
-        glyphs = {"four": 0x34, "seven": 0x37, "bet-hb": 0x5D1, "yod-hb": 0x5D9}
-        kerning = {("seven", "four"): -25, ("yod-hb", "bet-hb"): -100}
-        features = dedent(
-            """\
-            languagesystem DFLT dflt;
-            languagesystem hebr dflt;
-            """
-        )
-
-        ufo = makeUFO(FontClass, glyphs, kerning=kerning, features=features)
-        generated = self.writeFeatures(ufo)
-
-        assert str(generated) == dedent(
-            """\
-            lookup kern_dflt {
-                lookupflag IgnoreMarks;
-                pos seven four -25;
-            } kern_dflt;
-
-            lookup kern_rtl {
-                lookupflag IgnoreMarks;
-                pos yod-hb bet-hb <-100 0 -100 0>;
-            } kern_rtl;
-
-            feature kern {
-                lookup kern_dflt;
-                lookup kern_rtl;
-            } kern;
-            """
-        )
-
-    def test_quantize(self, FontClass):
-        font = FontClass()
-        for name in ("one", "four", "six"):
-            font.newGlyph(name)
-        font.kerning.update({("four", "six"): -57.0, ("one", "six"): -24.0})
-        writer = KernFeatureWriter(quantization=5)
-        feaFile = ast.FeatureFile()
-        assert writer.write(font, feaFile)
-
-        assert str(feaFile) == dedent(
-            """\
-            lookup kern_ltr {
-                lookupflag IgnoreMarks;
-                pos four six -55;
-                pos one six -25;
-            } kern_ltr;
-
-            feature kern {
-                lookup kern_ltr;
-            } kern;
-            """
-        )
+    assert generated.asFea() == snapshot
 
 
-if __name__ == "__main__":
-    import sys
+def test_ambiguous_direction_pair(snapshot, FontClass, caplog):
+    """Test that glyphs with ambiguous BiDi classes get split correctly."""
 
-    sys.exit(pytest.main(sys.argv))
+    glyphs = {
+        "A": 0x0041,
+        "one": 0x0031,
+        "yod-hb": 0x05D9,
+        "reh-ar": 0x0631,
+        "one-ar": 0x0661,
+        "bar": [0x0073, 0x0627],
+    }
+    kerning = {
+        ("bar", "bar"): 1,
+        ("bar", "A"): 2,
+        ("reh-ar", "A"): 3,
+        ("reh-ar", "one-ar"): 4,
+        ("yod-hb", "one"): 5,
+    }
+    features = """\
+        languagesystem DFLT dflt;
+        languagesystem latn dflt;
+        languagesystem arab dflt;
+        """
+    ufo = makeUFO(FontClass, glyphs, kerning=kerning, features=features)
+
+    with caplog.at_level(logging.INFO):
+        generated = KernFeatureWriterTest.writeFeatures(ufo)
+
+    assert generated.asFea() == snapshot
+    assert caplog.messages == [
+        "Skipping part of a kerning pair <bar bar 1> with mixed direction (LeftToRight, RightToLeft)",  # noqa: B950
+        "Skipping part of a kerning pair <bar bar 1> with mixed direction (RightToLeft, LeftToRight)",  # noqa: B950
+        "Skipping part of a kerning pair <bar A 2> with conflicting BiDi classes",  # noqa: B950
+        "Skipping part of a kerning pair <bar A 2> with mixed direction (RightToLeft, LeftToRight)",  # noqa: B950
+        "Skipping part of a kerning pair <reh-ar A 3> with mixed direction (RightToLeft, LeftToRight)",  # noqa: B950
+        "Skipping part of a kerning pair <reh-ar one-ar 4> with conflicting BiDi classes",  # noqa: B950
+        "Skipping part of a kerning pair <yod-hb one 5> with conflicting BiDi classes",  # noqa: B950
+    ]
+
+
+def test_kern_RTL_and_DFLT_numbers(snapshot, FontClass):
+    glyphs = {"four": 0x34, "seven": 0x37, "bet-hb": 0x5D1, "yod-hb": 0x5D9}
+    kerning = {("seven", "four"): -25, ("yod-hb", "bet-hb"): -100}
+    features = """\
+        languagesystem DFLT dflt;
+        languagesystem hebr dflt;
+        """
+
+    ufo = makeUFO(FontClass, glyphs, kerning=kerning, features=features)
+    generated = KernFeatureWriterTest.writeFeatures(ufo)
+
+    assert generated.asFea() == snapshot
+
+
+def test_quantize(snapshot, FontClass):
+    font = FontClass()
+    for name in ("one", "four", "six"):
+        font.newGlyph(name)
+    font.kerning.update({("four", "six"): -57.0, ("one", "six"): -24.0})
+    writer = KernFeatureWriter(quantization=5)
+    feaFile = fea_ast.FeatureFile()
+    writer.write(font, feaFile)
+
+    assert feaFile.asFea() == snapshot
+
+
+def test_skip_spacing_marks(snapshot, data_dir, FontClass):
+    fontPath = data_dir / "SpacingCombiningTest-Regular.ufo"
+    testufo = FontClass(fontPath)
+    generated = KernFeatureWriterTest.writeFeatures(testufo)
+
+    assert generated.asFea() == snapshot
+
+
+def test_kern_split_multi_glyph_class(snapshot, FontClass):
+    """Test that kern pair types are correctly split across directions."""
+
+    glyphs = {
+        "a": ord("a"),
+        "b": ord("b"),
+        "period": ord("."),
+    }
+    groups = {
+        "public.kern1.foo": ["a", "period"],
+        "public.kern2.foo": ["b", "period"],
+    }
+    kerning = {
+        # Glyph-to-glyph
+        ("a", "a"): 1,
+        ("a", "b"): 2,
+        ("a", "period"): 3,
+        ("b", "a"): 4,
+        ("b", "b"): 5,
+        ("b", "period"): 6,
+        ("period", "a"): 7,
+        ("period", "b"): 8,
+        ("period", "period"): 9,
+        # Class-to-glyph
+        ("public.kern1.foo", "b"): 10,
+        ("public.kern1.foo", "period"): 11,
+        # Glyph-to-class
+        ("a", "public.kern2.foo"): 12,
+        ("period", "public.kern2.foo"): 13,
+        # Class-to-class
+        ("public.kern1.foo", "public.kern2.foo"): 14,
+    }
+
+    ufo = makeUFO(FontClass, glyphs, groups, kerning)
+    newFeatures = KernFeatureWriterTest.writeFeatures(ufo)
+
+    assert newFeatures.asFea() == snapshot(name="same")
+
+    # Making a common glyph implicitly have an explicit script assigned (GSUB
+    # closure) will still keep it in the common section.
+    features = """
+        feature ss01 {
+            sub a by period; # Make period be both Latn and Zyyy.
+        } ss01;
+        """
+
+    ufo = makeUFO(FontClass, glyphs, groups, kerning, features)
+    newFeatures = KernFeatureWriterTest.writeFeatures(ufo)
+
+    assert newFeatures.asFea() == snapshot(name="same")
+
+
+def test_kern_split_and_drop(snapshot, FontClass, caplog):
+    """Test that mixed directions pairs are pruned and only the compatible parts
+    are kept."""
+
+    glyphs = {
+        "a": ord("a"),
+        "alpha": ord("α"),
+        "a-orya": 0x0B05,
+        "a-cy": 0x0430,
+        "alef-ar": 0x627,
+        "period": ord("."),
+    }
+    groups = {
+        "public.kern1.foo": ["a", "alpha", "a-orya"],
+        "public.kern2.foo": ["a", "alpha", "a-orya"],
+        "public.kern1.bar": ["a-cy", "alef-ar", "period"],
+        "public.kern2.bar": ["a-cy", "alef-ar", "period"],
+    }
+    kerning = {
+        ("public.kern1.foo", "public.kern2.bar"): 20,
+        ("public.kern1.bar", "public.kern2.foo"): 20,
+    }
+
+    ufo = makeUFO(FontClass, glyphs, groups, kerning)
+    with caplog.at_level(logging.INFO):
+        newFeatures = KernFeatureWriterTest.writeFeatures(ufo)
+
+    assert newFeatures.asFea() == snapshot
+    assert caplog.messages == [
+        "Skipping part of a kerning pair <('a', 'a-orya', 'alpha') ('alef-ar',) 20> with mixed direction (LeftToRight, RightToLeft)",  # noqa: B950
+        "Skipping part of a kerning pair <('alef-ar',) ('a', 'a-orya', 'alpha') 20> with mixed direction (RightToLeft, LeftToRight)",  # noqa: B950
+    ]
+
+
+def test_kern_split_and_drop_mixed(snapshot, caplog, FontClass):
+    """Test that mixed directions pairs are dropped.
+
+    And that scripts with no remaining lookups don't crash.
+    """
+
+    glyphs = {"V": ord("V"), "W": ord("W"), "gba-nko": 0x07DC}
+    groups = {"public.kern1.foo": ["V", "W"], "public.kern2.foo": ["gba-nko", "W"]}
+    kerning = {("public.kern1.foo", "public.kern2.foo"): -20}
+    ufo = makeUFO(FontClass, glyphs, groups, kerning)
+    with caplog.at_level(logging.INFO):
+        newFeatures = KernFeatureWriterTest.writeFeatures(ufo)
+
+    assert newFeatures.asFea() == snapshot
+    assert (
+        "<('V', 'W') ('gba-nko',) -20> with mixed direction (LeftToRight, RightToLeft)"
+        in caplog.text
+    )
+
+
+def test_kern_mixed_bidis(snapshot, caplog, FontClass):
+    """Test that BiDi types for pairs are respected."""
+
+    # TODO: Add Adlam numbers (rtl)
+    glyphs = {
+        "a": ord("a"),
+        "comma": ord(","),
+        "alef-ar": 0x0627,
+        "comma-ar": 0x060C,
+        "one-ar": 0x0661,
+        "one-adlam": 0x1E951,
+    }
+    kerning = {
+        # Undetermined: LTR
+        ("comma", "comma"): -1,
+        # LTR
+        ("a", "a"): 1,
+        ("a", "comma"): 2,
+        ("comma", "a"): 3,
+        # RTL
+        ("alef-ar", "alef-ar"): 4,
+        ("alef-ar", "comma-ar"): 5,
+        ("comma-ar", "alef-ar"): 6,
+        ("one-adlam", "one-adlam"): 10,
+        ("one-adlam", "comma-ar"): 11,
+        ("comma-ar", "one-adlam"): 12,
+        # Mixed: should be dropped
+        ("alef-ar", "one-ar"): 7,
+        ("one-ar", "alef-ar"): 8,
+        ("one-ar", "one-adlam"): 13,
+        # LTR despite being an RTL script
+        ("one-ar", "one-ar"): 9,
+    }
+    ufo = makeUFO(FontClass, glyphs, None, kerning)
+    with caplog.at_level(logging.INFO):
+        newFeatures = KernFeatureWriterTest.writeFeatures(ufo)
+
+    assert newFeatures.asFea() == snapshot
+    assert "<alef-ar one-ar 7> with conflicting BiDi classes" in caplog.text
+    assert "<one-ar alef-ar 8> with conflicting BiDi classes" in caplog.text
+    assert "<one-ar one-adlam 13> with conflicting BiDi classes" in caplog.text
+
+
+def unicodeScript(codepoint: int) -> str:
+    """Returns the Unicode script for a codepoint, combining some
+    scripts into the same bucket.
+
+    This allows lookups to contain more than one script. The most prominent case
+    is being able to kern Hiragana and Katakana against each other, Unicode
+    defines "Hrkt" as an alias for both scripts.
+
+    Note: Keep in sync with unicodeScriptExtensions!
+    """
+    script = unicodedata.script(chr(codepoint))
+    return UNICODE_SCRIPT_ALIASES.get(script, script)
+
+
+def test_kern_zyyy_zinh(snapshot, FontClass):
+    """Test that a sampling of glyphs with a common or inherited script, but a
+    disjoint set of explicit script extensions end up in the correct lookups."""
+    glyphs = {}
+    for i in range(0, 0x110000, 0x10):
+        script = unicodeScript(i)
+        script_extension = unicodeScriptExtensions(i)
+        if script not in script_extension:
+            assert script in DFLT_SCRIPTS
+            name = f"uni{i:04X}"
+            glyphs[name] = i
+    kerning = {(glyph, glyph): i for i, glyph in enumerate(glyphs)}
+    ufo = makeUFO(FontClass, glyphs, None, kerning)
+    newFeatures = KernFeatureWriterTest.writeFeatures(ufo)
+
+    assert newFeatures.asFea() == snapshot
+
+
+def test_kern_hira_kana_hrkt(snapshot, FontClass):
+    """Test that Hiragana and Katakana lands in the same lookup and can be
+    kerned against each other and common glyphs are kerned just once."""
+    glyphs = {"a-hira": 0x3042, "a-kana": 0x30A2, "period": ord(".")}
+    kerning = {
+        ("a-hira", "a-hira"): 1,
+        ("a-hira", "a-kana"): 2,
+        ("a-kana", "a-hira"): 3,
+        ("a-kana", "a-kana"): 4,
+        ("period", "period"): 5,
+        ("a-hira", "period"): 6,
+        ("period", "a-hira"): 7,
+        ("a-kana", "period"): 8,
+        ("period", "a-kana"): 9,
+    }
+    ufo = makeUFO(FontClass, glyphs, None, kerning)
+    newFeatures = KernFeatureWriterTest.writeFeatures(ufo)
+
+    assert newFeatures.asFea() == snapshot
+
+
+# TODO: Keep? Then modify comments.
+def test_defining_classdefs(snapshot, FontClass):
+    """Check that we aren't redefining class definitions with different
+    content."""
+
+    glyphs = {
+        "halant-telugu": 0xC4D,  # Telu
+        "ka-telugu.below": None,  # Telu by substitution
+        "ka-telugu": 0xC15,  # Telu
+        "rVocalicMatra-telugu": 0xC43,  # Telu
+        "sha-telugu.below": None,  # Default
+        "ss-telugu.alt": None,  # Default
+        "ssa-telugu.alt": None,  # Telu by substitution
+        "ssa-telugu": 0xC37,  # Telu
+    }
+    groups = {
+        "public.kern1.sha-telugu.below": ["sha-telugu.below"],
+        # The following group is a mix of Telu and Default through its gylphs. The
+        # kerning for bases below will create a Telu and Default split group.
+        # Important for the NOTE below.
+        "public.kern1.ssa-telugu.alt": ["ssa-telugu.alt", "ss-telugu.alt"],
+        "public.kern2.ka-telugu.below": ["ka-telugu.below"],
+        "public.kern2.rVocalicMatra-telugu": ["rVocalicMatra-telugu"],
+    }
+    kerning = {
+        # The follwoing three pairs are base-to-base pairs:
+        ("public.kern1.sha-telugu.below", "public.kern2.ka-telugu.below"): 20,
+        ("public.kern1.ssa-telugu.alt", "public.kern2.ka-telugu.below"): 60,
+        ("public.kern1.ssa-telugu.alt", "sha-telugu.below"): 150,
+        # NOTE: This last pair kerns bases against marks, triggering an extra
+        # pass to make a mark lookup that will create new classDefs. This extra
+        # pass will work on just this one pair, and kern splitting won't split
+        # off a Default group from `public.kern1.ssa-telugu.alt`, you get just a
+        # Telu pair. Unless the writer keeps track of which classDefs it already
+        # generated, this will overwrite the previous `@kern1.Telu.ssatelugu.alt
+        # = [ssa-telugu.alt]` with `@kern1.Telu.ssatelugu.alt =
+        # [ss-telugu.alt]`, losing kerning.
+        ("public.kern1.ssa-telugu.alt", "public.kern2.rVocalicMatra-telugu"): 180,
+    }
+    features = """
+        feature blwf {
+            script tel2;
+            sub halant-telugu ka-telugu by ka-telugu.below;
+        } blwf;
+
+        feature psts {
+            script tel2;
+            sub ssa-telugu' [rVocalicMatra-telugu sha-telugu.below ka-telugu.below] by ssa-telugu.alt;
+        } psts;
+    """  # noqa: B950
+    ufo = makeUFO(FontClass, glyphs, groups, kerning, features)
+    ufo.lib["public.openTypeCategories"] = {
+        "halant-telugu": "mark",
+        "ka-telugu": "base",
+        "rVocalicMatra-telugu": "mark",
+        "ss-telugu.alt": "base",
+        "ssa-telugu.alt": "base",
+        "ssa-telugu": "base",
+    }
+
+    newFeatures = KernFeatureWriterTest.writeFeatures(ufo)
+
+    assert newFeatures.asFea() == snapshot
+
+
+def test_mark_base_kerning(snapshot, FontClass):
+    """Check that kerning of bases against marks is correctly split into
+    base-only and mixed-mark-and-base lookups, to preserve the semantics of
+    kerning exceptions (pairs modifying the effect of other pairs)."""
+
+    glyphs = {
+        "aa-tamil": 0x0B86,
+        "va-tamil": 0x0BB5,
+        "aulengthmark-tamil": 0x0BD7,
+    }
+    groups = {
+        # Each group is a mix of mark and base glyph.
+        "public.kern1.e-tamil": ["aulengthmark-tamil", "va-tamil"],
+        "public.kern2.e-tamil": ["aulengthmark-tamil", "va-tamil"],
+    }
+    kerning = {
+        ("aa-tamil", "va-tamil"): -20,
+        ("aa-tamil", "public.kern2.e-tamil"): -35,
+        ("va-tamil", "aa-tamil"): -20,
+        ("public.kern1.e-tamil", "aa-tamil"): -35,
+        ("aulengthmark-tamil", "aulengthmark-tamil"): -200,
+        ("public.kern1.e-tamil", "public.kern2.e-tamil"): -100,
+    }
+    ufo = makeUFO(FontClass, glyphs, groups, kerning)
+    ufo.lib["public.openTypeCategories"] = {
+        "aulengthmark-tamil": "mark",
+    }
+
+    newFeatures = KernFeatureWriterTest.writeFeatures(ufo)
+
+    assert newFeatures.asFea() == snapshot
+
+
+def test_hyphenated_duplicates(snapshot, FontClass):
+    """Check that kerning group names are kept separate even if their sanitized
+    names are the same."""
+
+    glyphs = {"comma": ord(","), "period": ord(".")}
+    groups = {
+        "public.kern1.hy-phen": ["comma"],
+        "public.kern1.hyp-hen": ["period"],
+    }
+    kerning = {
+        ("public.kern1.hy-phen", "comma"): 1,
+        ("public.kern1.hyp-hen", "period"): 2,
+    }
+    ufo = makeUFO(FontClass, glyphs, groups, kerning)
+
+    newFeatures = KernFeatureWriterTest.writeFeatures(ufo)
+
+    assert newFeatures.asFea() == snapshot
+
+
+def test_dflt_language(snapshot, FontClass):
+    """Check that languages defined for the special DFLT script are registered
+    as well."""
+
+    glyphs = {"a": ord("a"), "comma": ord(",")}
+    groups = {}
+    kerning = {("a", "a"): 1, ("comma", "comma"): 2}
+    features = """
+        languagesystem DFLT dflt;
+        languagesystem DFLT ZND;
+        languagesystem latn dflt;
+        languagesystem latn ANG;
+    """
+    ufo = makeUFO(FontClass, glyphs, groups, kerning, features)
+
+    newFeatures = KernFeatureWriterTest.writeFeatures(ufo)
+
+    assert newFeatures.asFea() == snapshot

--- a/tests/featureWriters/variableFeatureWriter_test.py
+++ b/tests/featureWriters/variableFeatureWriter_test.py
@@ -103,15 +103,8 @@ def test_variable_features_old_kern_writer(FontClass):
         markClass dotabove-ar <anchor (wght=100:100 wght=1000:125) (wght=100:320 wght=1000:416)> @MC_top;
         markClass gravecmb <anchor 250 400> @MC_top;
 
-        @kern1.ltr.a = [a];
         @kern1.rtl.alef = [alef-ar.fina];
-        @kern2.ltr.a = [a];
         @kern2.rtl.alef = [alef-ar.fina];
-
-        lookup kern_ltr {
-            lookupflag IgnoreMarks;
-            pos @kern1.ltr.a @kern2.ltr.a 0;
-        } kern_ltr;
 
         lookup kern_rtl {
             lookupflag IgnoreMarks;
@@ -122,15 +115,11 @@ def test_variable_features_old_kern_writer(FontClass):
         feature kern {
             script DFLT;
             language dflt;
-            lookup kern_ltr;
+            lookup kern_rtl;
 
             script arab;
             language dflt;
             lookup kern_rtl;
-
-            script latn;
-            language dflt;
-            lookup kern_ltr;
         } kern;
 
         feature mark {

--- a/tests/featureWriters/variableFeatureWriter_test.py
+++ b/tests/featureWriters/variableFeatureWriter_test.py
@@ -103,19 +103,34 @@ def test_variable_features_old_kern_writer(FontClass):
         markClass dotabove-ar <anchor (wght=100:100 wght=1000:125) (wght=100:320 wght=1000:416)> @MC_top;
         markClass gravecmb <anchor 250 400> @MC_top;
 
-        @kern1.a = [a];
-        @kern1.alef = [alef-ar.fina];
-        @kern2.a = [a];
-        @kern2.alef = [alef-ar.fina];
+        @kern1.ltr.a = [a];
+        @kern1.rtl.alef = [alef-ar.fina];
+        @kern2.ltr.a = [a];
+        @kern2.rtl.alef = [alef-ar.fina];
+
+        lookup kern_ltr {
+            lookupflag IgnoreMarks;
+            pos @kern1.ltr.a @kern2.ltr.a 0;
+        } kern_ltr;
 
         lookup kern_rtl {
             lookupflag IgnoreMarks;
             pos alef-ar.fina alef-ar.fina <(wght=100:15 wght=1000:35) 0 (wght=100:15 wght=1000:35) 0>;
-            pos @kern1.alef @kern2.alef <(wght=100:0 wght=1000:1) 0 (wght=100:0 wght=1000:1) 0>;
+            pos @kern1.rtl.alef @kern2.rtl.alef <(wght=100:0 wght=1000:1) 0 (wght=100:0 wght=1000:1) 0>;
         } kern_rtl;
 
         feature kern {
+            script DFLT;
+            language dflt;
+            lookup kern_ltr;
+
+            script arab;
+            language dflt;
             lookup kern_rtl;
+
+            script latn;
+            language dflt;
+            lookup kern_ltr;
         } kern;
 
         feature mark {


### PR DESCRIPTION
Take the new kern writer and rework it to split by direction again, like the old writer. Replace the old writer.

Internal testing showed that the new writer likes to stick together a lot of scripts in fonts that employ cross-script kerning for ease of design, negating the advantages of the script splitter. We had the idea of reworking the splitter to put things into the same lookup instead and insert subtable breaks by script, but then we found that repacking the kerning generated by the old writer with Harfbuzz and then using the GPOS compression in fonttools actually gets us back to the small sizes by the original splitter at reasonable compile times. Maybe there is no need to try and be smarter.

We decided to propose going back to the old writer that splits by direction (plus the detail enhancements the new one got) and use GPOS compression instead for releasing fonts. The resulting kerning will work in InDesign with the default composer and in other apps that allow cross-script kerning. The difference is that it will always work, not just when the font has cross-script kerning between the desired scripts.

I took the opportunity to refactor the code a bit, by copy-pasting and adapting the new writer piece by piece and [getting the important business logic in a straight line](https://github.com/googlefonts/ufo2ft/blob/dcdddd27f40b1f9d5ee36441cb3765e420959db3/Lib/ufo2ft/featureWriters/kernFeatureWriter.py#L314-L337). The writer has been validated with [this branch of kerning-validator](https://github.com/daltonmaag/kerning-validator/compare/main...filter-only-bidis), which was modified to generate all glyph pairs that are allowed by (my understanding of the) BiDi logic to be in the same run.

I rewrote the tests to use syrupy for snapshot testing, because it made it easier to update tests after changing the writer. I also ported all the tests to use plain pytest conventions instead of unittest.

TODO:
* ~~How important is it to have camelCase instead of snake_case?~~ Not important for internal code.
* [x] Potentially some TODO or XXX cleanups I need to do another pass over.