### PR TITLE
Support sparse masters in kernFeatureWriter

### DIFF
--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
@@ -586,7 +586,9 @@ class KernFeatureWriter(BaseFeatureWriter):
             spacing = []
             for mark in marks:
                 if all(
-                    source.font[mark].width != 0 for source in self.context.font.sources
+                    source.font[mark].width != 0
+                    for source in self.context.font.sources
+                    if mark in source.font
                 ):
                     spacing.append(mark)
             return spacing


### PR DESCRIPTION
Currently the part of the kern feature writer which tests if a mark is spacing or non-spacing checks for `source.font[mark].width` in all sources of a variable font. If the variable font has sparse masters, the glyph may not appear in some of them, and the kern feature writer crashes.