### PR TITLE
[kernFeatureWriter] ignore zero-valued class kern pairs when building variable kern

### DIFF
--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
@@ -551,7 +551,13 @@ class KernFeatureWriter(BaseFeatureWriter):
             if default_location not in value.values:
                 value.values[default_location] = 0
             value = collapse_varscalar(value)
-            result.append(KerningPair(side1, side2, value))
+            pair = KerningPair(side1, side2, value)
+            # Ignore zero-valued class kern pairs. They are the most general
+            # kerns, so they don't override anything else like glyph kerns would
+            # and zero is the default.
+            if pair.firstIsClass and pair.secondIsClass and pair.value == 0:
+                continue
+            result.append(pair)
 
         return result
 

--- a/tests/data/TestVarfea-Regular.ufo/groups.plist
+++ b/tests/data/TestVarfea-Regular.ufo/groups.plist
@@ -2,15 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
-    <key>alef-ar.fina</key>
-    <dict>
-      <key>alef-ar.fina</key>
-      <integer>15</integer>
-    </dict>
     <key>public.kern1.a</key>
-    <dict>
-      <key>public.kern2.a</key>
-      <integer>0</integer>
-    </dict>
+    <array>
+      <string>a</string>
+    </array>
+    <key>public.kern2.a</key>
+    <array>
+      <string>a</string>
+    </array>
   </dict>
 </plist>

--- a/tests/featureWriters/variableFeatureWriter_test.py
+++ b/tests/featureWriters/variableFeatureWriter_test.py
@@ -103,7 +103,9 @@ def test_variable_features_old_kern_writer(FontClass):
         markClass dotabove-ar <anchor (wght=100:100 wght=1000:125) (wght=100:320 wght=1000:416)> @MC_top;
         markClass gravecmb <anchor 250 400> @MC_top;
 
+        @kern1.a = [a];
         @kern1.alef = [alef-ar.fina];
+        @kern2.a = [a];
         @kern2.alef = [alef-ar.fina];
 
         lookup kern_rtl {


### PR DESCRIPTION
We already prune class-class kerning pairs whose value is 0 when building individual per-master GPOS tables (to be merged with varLib). It makes sense to also do that when we build a single variable GPOS table. This is safe to do because we always place the class-class kerning as the last (after glyph-glyph kerns), so these don't override anything else that may follow and 0 is the default anyway, so they are essentially no-op.