### PR TITLE
[cursFeatureWriter] Respect direction suffix when setting lookupflag

### DIFF
--- a/Lib/ufo2ft/featureWriters/cursFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/cursFeatureWriter.py
@@ -51,7 +51,9 @@ class CursFeatureWriter(BaseFeatureWriter):
         orderedGlyphSet = self.getOrderedGlyphSet().items()
         cursiveAnchorsPairs = self._getCursiveAnchorPairs(orderedGlyphSet)
         for entryName, exitName in cursiveAnchorsPairs:
-            if shouldSplit:
+            # If the anchors have an explicit direction suffix, don’t set
+            # direction based on the script of the glyphs.
+            if not entryName.endswith((".LTR", ".RTL")) and shouldSplit:
                 # Make LTR lookup
                 LTRlookup = self._makeCursiveLookup(
                     (
@@ -107,6 +109,11 @@ class CursFeatureWriter(BaseFeatureWriter):
         elif direction == "RTL":
             suffix += "_rtl"
         lookup = ast.LookupBlock(name=f"curs{suffix}")
+
+        if entryName.endswith(".RTL"):
+            direction = "RTL"
+        elif entryName.endswith(".LTR"):
+            direction = "LTR"
 
         if direction != "LTR":
             lookup.statements.append(ast.makeLookupFlag(("IgnoreMarks", "RightToLeft")))

--- a/tests/featureWriters/cursFeatureWriter_test.py
+++ b/tests/featureWriters/cursFeatureWriter_test.py
@@ -295,3 +295,134 @@ class CursFeatureWriterTest(FeatureWriterTest):
             } curs;
             """
         )
+
+    def test_curs_feature_forced_RTL(self, testufo):
+        for c in ("a", "b", "c"):
+            g = testufo[c]
+            g.unicode = ord(c)
+            anchors = list(g.anchors)
+            g.anchors = []
+            for a in anchors:
+                g.appendAnchor({"name": a.name + ".RTL", "x": a.x, "y": a.y})
+
+        generated = self.writeFeatures(testufo)
+
+        assert str(generated) == dedent(
+            """\
+                feature curs {
+                    lookup curs_RTL {
+                        lookupflag RightToLeft IgnoreMarks;
+                        pos cursive a <anchor NULL> <anchor 100 200>;
+                        pos cursive b <anchor 0 200> <anchor 111 200>;
+                        pos cursive c <anchor 100 200> <anchor NULL>;
+                    } curs_RTL;
+
+                } curs;
+                """
+        )
+
+    def test_curs_feature_forced_LTR(self, testufo):
+        for n, u in (("a", 0x0627), ("b", 0x0628), ("c", 0x062C)):
+            g = testufo[n]
+            g.unicode = u
+            anchors = list(g.anchors)
+            g.anchors = []
+            for a in anchors:
+                g.appendAnchor({"name": a.name + ".LTR", "x": a.x, "y": a.y})
+
+        generated = self.writeFeatures(testufo)
+
+        assert str(generated) == dedent(
+            """\
+                feature curs {
+                    lookup curs_LTR {
+                        lookupflag IgnoreMarks;
+                        pos cursive a <anchor NULL> <anchor 100 200>;
+                        pos cursive b <anchor 0 200> <anchor 111 200>;
+                        pos cursive c <anchor 100 200> <anchor NULL>;
+                    } curs_LTR;
+
+                } curs;
+                """
+        )
+
+    def test_curs_feature_mixed_forced_direction(self, testufo):
+        testufo["a"].unicode = ord("a")
+        testufo["b"].unicode = ord("b")
+        testufo["c"].unicode = ord("c")
+
+        glyph = testufo.newGlyph("d")
+        glyph.unicode = ord("d")
+        glyph.appendAnchor({"name": "exit.RTL", "x": 110, "y": 210})
+
+        glyph = testufo.newGlyph("e")
+        glyph.unicode = ord("e")
+        glyph.appendAnchor({"name": "entry.RTL", "x": 10, "y": 210})
+        glyph.appendAnchor({"name": "exit.RTL", "x": 121, "y": 210})
+
+        glyph = testufo.newGlyph("f")
+        glyph.unicode = ord("f")
+        glyph.appendAnchor({"name": "entry.RTL", "x": 110, "y": 210})
+
+        glyph = testufo.newGlyph("alef")
+        glyph.unicode = 0x0627
+        glyph.appendAnchor({"name": "entry", "x": 100, "y": 200})
+
+        glyph = testufo.newGlyph("beh")
+        glyph.unicode = 0x0628
+        glyph.appendAnchor({"name": "entry", "x": 0, "y": 200})
+        glyph.appendAnchor({"name": "exit", "x": 111, "y": 200})
+
+        glyph = testufo.newGlyph("jeem")
+        glyph.unicode = 0x062C
+        glyph.appendAnchor({"name": "entry", "x": 100, "y": 200})
+
+        glyph = testufo.newGlyph("heh")
+        glyph.unicode = 0x0647
+        glyph.appendAnchor({"name": "entry.LTR", "x": 110, "y": 210})
+
+        glyph = testufo.newGlyph("waw")
+        glyph.unicode = 0x0648
+        glyph.appendAnchor({"name": "exit.LTR", "x": 10, "y": 210})
+        glyph.appendAnchor({"name": "exit.LTR", "x": 121, "y": 210})
+
+        glyph = testufo.newGlyph("zain")
+        glyph.unicode = 0x0632
+        glyph.appendAnchor({"name": "entry.LTR", "x": 110, "y": 210})
+
+        generated = self.writeFeatures(testufo)
+
+        assert str(generated) == dedent(
+            """\
+                feature curs {
+                    lookup curs_ltr {
+                        lookupflag IgnoreMarks;
+                        pos cursive a <anchor NULL> <anchor 100 200>;
+                        pos cursive b <anchor 0 200> <anchor 111 200>;
+                        pos cursive c <anchor 100 200> <anchor NULL>;
+                    } curs_ltr;
+
+                    lookup curs_rtl {
+                        lookupflag RightToLeft IgnoreMarks;
+                        pos cursive alef <anchor 100 200> <anchor NULL>;
+                        pos cursive beh <anchor 0 200> <anchor 111 200>;
+                        pos cursive jeem <anchor 100 200> <anchor NULL>;
+                    } curs_rtl;
+
+                    lookup curs_LTR {
+                        lookupflag IgnoreMarks;
+                        pos cursive heh <anchor 110 210> <anchor NULL>;
+                        pos cursive waw <anchor NULL> <anchor 10 210>;
+                        pos cursive zain <anchor 110 210> <anchor NULL>;
+                    } curs_LTR;
+
+                    lookup curs_RTL {
+                        lookupflag RightToLeft IgnoreMarks;
+                        pos cursive d <anchor NULL> <anchor 110 210>;
+                        pos cursive e <anchor 10 210> <anchor 121 210>;
+                        pos cursive f <anchor 110 210> <anchor NULL>;
+                    } curs_RTL;
+
+                } curs;
+                """
+        )


### PR DESCRIPTION
By default we set RightToLeft lookupflag for RTL glyphs, which is a sane default. But, despite the flags name, it is not directly related to glyph directionality, rather it defines which glyphs stay at their natural position and which gets shifted. When the flag is set, glyphs to the right gets shifted, otherwise glyphs to the left.

GlyphsApp supports controlling the flag by adding `.RTL` or `.LTR` suffix to the anchor names, so we now support this as well.

See for examples of this:
https://forum.glyphsapp.com/t/is-there-a-solution-for-vertical-kerning-in-arabic-script/26571/39