### PR TITLE
[postProcessor] fontTools.varLib.cff.convertCFFtoCFF2 is deprecated

### DIFF
--- a/Lib/ufo2ft/postProcessor.py
+++ b/Lib/ufo2ft/postProcessor.py
@@ -318,19 +318,22 @@ class PostProcessor:
 
     @staticmethod
     def _convert_cff_to_cff2(otf):
-        from fontTools.varLib.cff import convertCFFtoCFF2
-
         logger.info("Converting CFF table to CFF2")
 
-        # convertCFFtoCFF2 doesn't strip T2CharStrings' widths, so we do it ourselves
-        # https://github.com/fonttools/fonttools/issues/1835
-        charstrings = otf["CFF "].cff[0].CharStrings
-        for glyph_name in otf.getGlyphOrder():
-            cs = charstrings[glyph_name]
-            cs.decompile()
-            cs.program = _stripCharStringWidth(cs.program)
+        try:
+            from fontTools.cffLib.CFFToCFF2 import convertCFFToCFF2
+        except ImportError:
+            from fontTools.varLib.cff import convertCFFtoCFF2 as convertCFFToCFF2
 
-        convertCFFtoCFF2(otf)
+            # convertCFFtoCFF2 doesn't strip T2CharStrings' widths, so we do it ourselves
+            # https://github.com/fonttools/fonttools/issues/1835
+            charstrings = otf["CFF "].cff[0].CharStrings
+            for glyph_name in otf.getGlyphOrder():
+                cs = charstrings[glyph_name]
+                cs.decompile()
+                cs.program = _stripCharStringWidth(cs.program)
+
+        convertCFFToCFF2(otf)
 
     @classmethod
     def _subroutinize(cls, backend, otf, cffVersion):

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     setup_requires=pytest_runner + wheel + ["setuptools_scm"],
     tests_require=["pytest>=2.8"],
     install_requires=[
-        "fonttools[ufo]>=4.50.0",
+        "fonttools[ufo]>=4.52.0",
         "cffsubr>=0.3.0",
         "booleanOperations>=0.9.0",
         "fontMath>=0.9.3",


### PR DESCRIPTION
Try importing fontTools.cffLib.CFFToCFF2.convertCFFToCFF2 first, and confine the width stripping to when the deprecated method is used, as it is already fixed in FontTools.