### PR TITLE
[instantiator] use designspace.findDefault() the first time designspace.default is checked

### DIFF
--- a/Lib/ufo2ft/instantiator.py
+++ b/Lib/ufo2ft/instantiator.py
@@ -251,7 +251,7 @@ class Instantiator:
         do_glyphs=True,
     ):
         """Instantiates a new data class from a Designspace object."""
-        if designspace.default is None:
+        if designspace.findDefault() is None:
             raise InstantiatorError(_error_msg_no_default(designspace))
 
         if any(hasattr(axis, "values") for axis in designspace.axes):

--- a/tests/instantiator_test.py
+++ b/tests/instantiator_test.py
@@ -71,7 +71,6 @@ def test_default_groups_only(ufo_module, data_dir, caplog):
     d.addSourceDescriptor(location={"Weight": 300}, font=ufo_module.Font())
     d.addSourceDescriptor(location={"Weight": 900}, font=ufo_module.Font())
     d.addInstanceDescriptor(styleName="2", location={"Weight": 400})
-    d.findDefault()
 
     d.sources[0].font.groups["public.kern1.GRK_alpha_alt_LC_1ST"] = [
         "alpha.alt",
@@ -102,7 +101,6 @@ def test_default_groups_only2(ufo_module, data_dir, caplog):
     d.addSourceDescriptor(location={"Weight": 300}, font=ufo_module.Font())
     d.addSourceDescriptor(location={"Weight": 900}, font=ufo_module.Font())
     d.addInstanceDescriptor(styleName="2", location={"Weight": 400})
-    d.findDefault()
 
     d.sources[0].font.groups["public.kern1.GRK_alpha_alt_LC_1ST"] = [
         "alpha.alt",


### PR DESCRIPTION
otherwise a DS object that was created from code has a 'default' attribute set to None (until findDefault() is first called).
Those loaded from string or file have that set automatically by the respective constructors.