### PR TITLE
Fix ligatures with unnumbered contextual anchors having their mark attachment dropped

### DIFF
--- a/Lib/ufo2ft/featureWriters/markFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/markFeatureWriter.py
@@ -746,6 +746,8 @@ class MarkFeatureWriter(BaseFeatureWriter):
                 if not anchor.isContextual:
                     continue
 
+                # See "after" truth table for what this logic hopes to achieve:
+                # https://github.com/googlefonts/ufo2ft/pull/890#issuecomment-2498032081
                 if anchor.number is not None and includedOrNoClass(
                     ligatureClass, glyphName
                 ):


### PR DESCRIPTION
If a ligature glyph has a contextual anchor whose name doesn't have a number, it's silently dropped currently. This PR instead sets that anchor number to 1 to be able to keep it around

Previously when using glyphsLib's own implementation of the `ContextualMarkFeatureWriter` (glyphsLib v6.7.1 tested), this was not an issue and the mark attachment worked as expected

Leaving as draft as to confirm this is an okay/safe approach to fixing the problem (maybe some assertions should be added to ensure this isn't clobbering another anchor?). Happy to add unit testing and/or a reproducer as desired

cc @belluzj @jackmcDaMa (who helped me track this down)