### PR TITLE
[markFeatureWriter] Drop “ambiguously connected” info message

### DIFF
--- a/Lib/ufo2ft/featureWriters/markFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/markFeatureWriter.py
@@ -550,28 +550,6 @@ class MarkFeatureWriter(BaseFeatureWriter):
             ),
         )
 
-    def _logIfAmbiguous(self, attachments, groupedMarkClasses):
-        """Warn about ambiguous situations and log the current resolution.
-        An anchor attachment is ambiguous if for the same mark glyph, more
-        than one mark class can be used to attach it to the base.
-        """
-        for attachment in attachments:
-            for markGlyph, markClasses in attachment.getMarkGlyphToMarkClasses():
-                if len(markClasses) > 1:
-                    self.log.info(
-                        "The base glyph %s and mark glyph %s are ambiguously "
-                        "connected by several anchor classes: %s. "
-                        "The last one will prevail.",
-                        attachment.name,
-                        markGlyph,
-                        ", ".join(
-                            markClass
-                            for group in groupedMarkClasses
-                            for markClass in group
-                            if markClass in markClasses
-                        ),
-                    )
-
     def _removeClassPrefix(self, markClass):
         assert markClass.startswith(self.markClassPrefix)
         return markClass[len(self.markClassPrefix) :]
@@ -613,7 +591,6 @@ class MarkFeatureWriter(BaseFeatureWriter):
                 [markClass.name]
                 for _, markClass in sorted(self.context.markClasses.items())
             ]
-        self._logIfAmbiguous(attachments, groupedMarkClasses)
         lookups = []
         for markClasses in groupedMarkClasses:
             lookup = []

--- a/tests/featureWriters/markFeatureWriter_test.py
+++ b/tests/featureWriters/markFeatureWriter_test.py
@@ -1685,12 +1685,6 @@ class MarkFeatureWriterTest(FeatureWriterTest):
 
         generated = self.writeFeatures(ufo, groupMarkClasses=groupMarkClasses)
 
-        assert (
-            "The base glyph a and mark glyph acutecomb are ambiguously "
-            f"connected by several anchor classes: {warning}. "
-            "The last one will prevail." in caplog.text
-        )
-
         assert str(generated) == expected
 
     def test_skipExportGlyphs(self, testufo):


### PR DESCRIPTION
This is a very noisy message, I get it like a thousand time when generating fonts.

It also provides n much value, the glyphs are not “ambiguously connected” since our lookup order is deterministic and font developer engineer can control how lookups are ordered to have specific anchor take precedence over general ones by carefully naming the anchors.

The alleged ambiguity does not influence the feature writer, it is producing the feature code the same way whether there is “ambiguity” or not. It rather affects how layout engines might apply the lookups, but why ufo2ft is concerning itself about that?