### PR TITLE
Pass feaIncludeDir to variable feature compiler

### DIFF
--- a/Lib/ufo2ft/_compilers/baseCompiler.py
+++ b/Lib/ufo2ft/_compilers/baseCompiler.py
@@ -459,7 +459,8 @@ class BaseInterpolatableCompiler(BaseCompiler):
         default_ufo = designSpaceDoc.findDefault().font
 
         featureCompiler = VariableFeatureCompiler(
-            default_ufo, designSpaceDoc, ttFont=ttFont, glyphSet=glyphSet
+            default_ufo, designSpaceDoc, ttFont=ttFont, glyphSet=glyphSet,
+            feaIncludeDir=self.feaIncludeDir,
         )
         featureCompiler.compile()
 

--- a/Lib/ufo2ft/_compilers/baseCompiler.py
+++ b/Lib/ufo2ft/_compilers/baseCompiler.py
@@ -459,7 +459,10 @@ class BaseInterpolatableCompiler(BaseCompiler):
         default_ufo = designSpaceDoc.findDefault().font
 
         featureCompiler = VariableFeatureCompiler(
-            default_ufo, designSpaceDoc, ttFont=ttFont, glyphSet=glyphSet,
+            default_ufo,
+            designSpaceDoc,
+            ttFont=ttFont,
+            glyphSet=glyphSet,
             feaIncludeDir=self.feaIncludeDir,
         )
         featureCompiler.compile()

--- a/Lib/ufo2ft/featureCompiler.py
+++ b/Lib/ufo2ft/featureCompiler.py
@@ -433,7 +433,7 @@ class VariableFeatureCompiler(FeatureCompiler):
 
     def setupFeatures(self):
         if self.featureWriters:
-            featureFile = parseLayoutFeatures(self.ufo)
+            featureFile = parseLayoutFeatures(self.ufo, self.feaIncludeDir)
 
             for writer in self.featureWriters:
                 writer.write(self.designspace, featureFile, compiler=self)


### PR DESCRIPTION
Currently the fontmake `--fea-include-dir` argument has no effect when compiling variable fonts, because we don't pass its value to the variable feature compiler.