### PR TITLE
fix: check if uvs mapping code point in cmap table

### DIFF
--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -547,7 +547,7 @@ class BaseOutlineCompiler:
                 uvsList = []
                 for hexvalue, glyphName in glyphMapping.items():
                     value = int(hexvalue, 16)
-                    if glyphName == mapping[value]:
+                    if value in mapping and glyphName == mapping[value]:
                         uvsList.append((value, None))
                     else:
                         uvsList.append((value, glyphName))

--- a/tests/data/Bug908.ufo/fontinfo.plist
+++ b/tests/data/Bug908.ufo/fontinfo.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>familyName</key>
+		<string>Bug 908</string>
+		<key>note</key>
+		<string>https://github.com/googlei18n/ufo2ft/issues/908</string>
+		<key>unitsPerEm</key>
+		<integer>1000</integer>
+		<key>xHeight</key>
+		<integer>500</integer>
+		<key>ascender</key>
+		<integer>750</integer>
+		<key>capHeight</key>
+		<integer>750</integer>
+		<key>descender</key>
+		<integer>-250</integer>
+		<key>postscriptUnderlinePosition</key>
+		<integer>-200</integer>
+		<key>postscriptUnderlineThickness</key>
+		<integer>20</integer>
+	</dict>
+</plist>

--- a/tests/data/Bug908.ufo/glyphs/_notdef.glif
+++ b/tests/data/Bug908.ufo/glyphs/_notdef.glif
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name=".notdef" format="2">
+	<advance width="500"/>
+	<outline>
+		<contour>
+			<point x="450" y="0" type="line"/>
+			<point x="450" y="750" type="line"/>
+			<point x="50" y="750" type="line"/>
+			<point x="50" y="0" type="line"/>
+		</contour>
+		<contour>
+			<point x="400" y="50" type="line"/>
+			<point x="100" y="50" type="line"/>
+			<point x="100" y="700" type="line"/>
+			<point x="400" y="700" type="line"/>
+		</contour>
+	</outline>
+</glyph>

--- a/tests/data/Bug908.ufo/glyphs/contents.plist
+++ b/tests/data/Bug908.ufo/glyphs/contents.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>.notdef</key>
+		<string>_notdef.glif</string>
+		<key>u2F803</key>
+		<string>u2F_803.glif</string>
+	</dict>
+</plist>

--- a/tests/data/Bug908.ufo/glyphs/u2F_803.glif
+++ b/tests/data/Bug908.ufo/glyphs/u2F_803.glif
@@ -1,0 +1,173 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="u2F803" format="2">
+  <advance width="1024"/>
+  <outline>
+    <contour>
+      <point x="330" y="531" type="line"/>
+      <point x="330" y="401" type="line"/>
+      <point x="587" y="401" type="line"/>
+      <point x="587" y="425"/>
+      <point x="588" y="457" type="qcurve"/>
+      <point x="588" y="531" type="line"/>
+    </contour>
+    <contour>
+      <point x="343" y="157" type="line"/>
+      <point x="300" y="158"/>
+      <point x="291" y="170" type="qcurve"/>
+      <point x="282" y="183"/>
+      <point x="282" y="216" type="qcurve"/>
+      <point x="282" y="509" type="line"/>
+      <point x="281" y="545"/>
+      <point x="277" y="584" type="qcurve"/>
+      <point x="275" y="594"/>
+      <point x="279" y="597" type="qcurve"/>
+      <point x="284" y="599"/>
+      <point x="291" y="590" type="qcurve"/>
+      <point x="307" y="575"/>
+      <point x="325" y="562" type="qcurve"/>
+      <point x="561" y="562" type="line"/>
+      <point x="573" y="562"/>
+      <point x="580" y="569" type="qcurve"/>
+      <point x="605" y="595" type="line"/>
+      <point x="610" y="602"/>
+      <point x="619" y="596" type="qcurve"/>
+      <point x="650" y="573"/>
+      <point x="672" y="554" type="qcurve"/>
+      <point x="679" y="546"/>
+      <point x="670" y="545" type="qcurve"/>
+      <point x="653" y="542"/>
+      <point x="644" y="533" type="qcurve"/>
+      <point x="636" y="524"/>
+      <point x="636" y="514" type="qcurve"/>
+      <point x="636" y="466" type="line"/>
+      <point x="637" y="398"/>
+      <point x="644" y="339" type="qcurve"/>
+      <point x="644" y="326"/>
+      <point x="634" y="320" type="qcurve"/>
+      <point x="589" y="294"/>
+      <point x="585" y="295" type="qcurve"/>
+      <point x="581" y="297"/>
+      <point x="582" y="313" type="qcurve"/>
+      <point x="585" y="347"/>
+      <point x="586" y="370" type="qcurve"/>
+      <point x="330" y="370" type="line"/>
+      <point x="330" y="228" type="line"/>
+      <point x="331" y="209"/>
+      <point x="335" y="205" type="qcurve"/>
+      <point x="340" y="199"/>
+      <point x="358" y="199" type="qcurve"/>
+      <point x="644" y="199" type="line"/>
+      <point x="682" y="203"/>
+      <point x="712" y="218" type="qcurve"/>
+      <point x="718" y="221"/>
+      <point x="722" y="217" type="qcurve"/>
+      <point x="742" y="200"/>
+      <point x="760" y="190" type="qcurve"/>
+      <point x="767" y="187"/>
+      <point x="766" y="178" type="qcurve"/>
+      <point x="765" y="169"/>
+      <point x="741" y="165" type="qcurve"/>
+      <point x="704" y="157"/>
+      <point x="662" y="157" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="863" y="-24" type="qcurve"/>
+      <point x="889" y="13" type="line"/>
+      <point x="896" y="22"/>
+      <point x="905" y="13" type="qcurve"/>
+      <point x="976" y="-50"/>
+      <point x="975" y="-65" type="qcurve"/>
+      <point x="973" y="-73"/>
+      <point x="960" y="-74" type="qcurve"/>
+      <point x="156" y="-74" type="line"/>
+      <point x="114" y="-75"/>
+      <point x="83" y="-81" type="qcurve"/>
+      <point x="74" y="-84"/>
+      <point x="73" y="-75" type="qcurve"/>
+      <point x="68" y="-57"/>
+      <point x="53" y="-44" type="qcurve"/>
+      <point x="45" y="-37"/>
+      <point x="49" y="-33" type="qcurve"/>
+      <point x="53" y="-30"/>
+      <point x="60" y="-34" type="qcurve"/>
+      <point x="98" y="-43"/>
+      <point x="144" y="-43" type="qcurve"/>
+      <point x="833" y="-43" type="line"/>
+      <point x="847" y="-42"/>
+    </contour>
+    <contour>
+      <point x="863" y="836" type="qcurve"/>
+      <point x="889" y="873" type="line"/>
+      <point x="896" y="882"/>
+      <point x="905" y="873" type="qcurve"/>
+      <point x="976" y="810"/>
+      <point x="975" y="795" type="qcurve"/>
+      <point x="973" y="787"/>
+      <point x="960" y="786" type="qcurve"/>
+      <point x="156" y="786" type="line"/>
+      <point x="114" y="785"/>
+      <point x="83" y="779" type="qcurve"/>
+      <point x="74" y="776"/>
+      <point x="73" y="785" type="qcurve"/>
+      <point x="68" y="803"/>
+      <point x="53" y="816" type="qcurve"/>
+      <point x="45" y="823"/>
+      <point x="49" y="827" type="qcurve"/>
+      <point x="53" y="830"/>
+      <point x="60" y="826" type="qcurve"/>
+      <point x="98" y="817"/>
+      <point x="144" y="817" type="qcurve"/>
+      <point x="833" y="817" type="line"/>
+      <point x="847" y="818"/>
+    </contour>
+    <contour>
+      <point x="838" y="654" type="line"/>
+      <point x="150" y="654" type="line"/>
+      <point x="150" y="259" type="line"/>
+      <point x="149" y="152"/>
+      <point x="150" y="77" type="qcurve"/>
+      <point x="149" y="62"/>
+      <point x="112" y="37" type="qcurve"/>
+      <point x="104" y="33"/>
+      <point x="100" y="33" type="qcurve"/>
+      <point x="94" y="34"/>
+      <point x="95" y="53" type="qcurve"/>
+      <point x="99" y="153"/>
+      <point x="102" y="259" type="qcurve"/>
+      <point x="102" y="631" type="line"/>
+      <point x="101" y="663"/>
+      <point x="95" y="709" type="qcurve"/>
+      <point x="93" y="719"/>
+      <point x="96" y="720" type="qcurve"/>
+      <point x="97" y="721"/>
+      <point x="142" y="685" type="qcurve"/>
+      <point x="821" y="685" type="line"/>
+      <point x="830" y="685"/>
+      <point x="831" y="686" type="qcurve"/>
+      <point x="856" y="719" type="line"/>
+      <point x="858" y="723"/>
+      <point x="862" y="723" type="qcurve"/>
+      <point x="866" y="723"/>
+      <point x="870" y="719" type="qcurve"/>
+      <point x="901" y="694"/>
+      <point x="925" y="669" type="qcurve"/>
+      <point x="932" y="661"/>
+      <point x="916" y="655" type="qcurve"/>
+      <point x="892" y="645"/>
+      <point x="889" y="641" type="qcurve"/>
+      <point x="886" y="635"/>
+      <point x="886" y="628" type="qcurve"/>
+      <point x="886" y="259" type="line"/>
+      <point x="885" y="152"/>
+      <point x="886" y="77" type="qcurve"/>
+      <point x="885" y="62"/>
+      <point x="848" y="37" type="qcurve"/>
+      <point x="840" y="33"/>
+      <point x="836" y="33" type="qcurve"/>
+      <point x="830" y="34"/>
+      <point x="831" y="53" type="qcurve"/>
+      <point x="835" y="153"/>
+      <point x="838" y="259" type="qcurve"/>
+    </contour>
+  </outline>
+</glyph>

--- a/tests/data/Bug908.ufo/groups.plist
+++ b/tests/data/Bug908.ufo/groups.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+	</dict>
+</plist>

--- a/tests/data/Bug908.ufo/layercontents.plist
+++ b/tests/data/Bug908.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<array>
+		<array>
+			<string>public.default</string>
+			<string>glyphs</string>
+		</array>
+	</array>
+</plist>

--- a/tests/data/Bug908.ufo/lib.plist
+++ b/tests/data/Bug908.ufo/lib.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>public.glyphOrder</key>
+		<array>
+			<string>.notdef</string>
+			<string>u2F803</string>
+		</array>
+		<key>public.unicodeVariationSequences</key>
+    	<dict>
+			<key>FE00</key>
+			<dict>
+				<key>20122</key>
+        		<string>u2F803</string>
+			</dict>
+		</dict>
+	</dict>
+</plist>

--- a/tests/data/Bug908.ufo/metainfo.plist
+++ b/tests/data/Bug908.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>creator</key>
+		<string>copy-paste</string>
+		<key>formatVersion</key>
+		<integer>3</integer>
+	</dict>
+</plist>

--- a/tests/outlineCompiler_test.py
+++ b/tests/outlineCompiler_test.py
@@ -1496,6 +1496,21 @@ def test_MATH_table_invalid(FontClass, compile, attribute):
     with pytest.raises(InvalidFontData, match="Invalid assembly"):
         compile(ufo)
 
+@pytest.mark.parametrize("compile", [compileTTF, compileOTF])
+def test_CMAP_format_14_table_no_cmap_entry(FontClass, compile):
+    #
+    # https://github.com/googlefonts/ufo2ft/issues/908
+    #
+    # Typically, code points listed in the uvsMappings array will have corresponding
+    # entries in a Unicode 'cmap' subtable. This is not required, however.
+    # In Bug908.ufo, the font maps U+20122 U+FE00 to U+2F803, but U+20122
+    # is not in the 'cmap' subtable.
+    ufo = FontClass(getpath("Bug908.ufo"))
+    result = compile(ufo)
+
+    cmap = result.getBestCmap()
+    assert 0x20122 not in cmap
+
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
Fixes #908 

For the rationale, see also https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#non-default-uvs-table

> Typically, code points listed in the uvsMappings array will have corresponding entries in a Unicode 'cmap' subtable. This is not required, however. For example, it might not be the case if a font is intended for use with content in which a given Unicode character only occurs in a variation sequence.