### PR TITLE
[markFeatureWriter] Consolidate how we consider a mark contextual

### DIFF
--- a/Lib/ufo2ft/constants.py
+++ b/Lib/ufo2ft/constants.py
@@ -158,3 +158,5 @@ USE_SCRIPTS = [
     "Yezi",  # Yezidi
     "Zanb",  # Zanabazar Square
 ]
+
+ANCHOR_LIB_GPOS_CONTEXT_KEY = "GPOS_Context"

--- a/Lib/ufo2ft/featureWriters/markFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/markFeatureWriter.py
@@ -4,7 +4,12 @@ from collections import OrderedDict, defaultdict
 from functools import partial
 from typing import Dict, Optional, Set, Tuple
 
-from ufo2ft.constants import INDIC_SCRIPTS, OBJECT_LIBS_KEY, USE_SCRIPTS
+from ufo2ft.constants import (
+    ANCHOR_LIB_GPOS_CONTEXT_KEY,
+    INDIC_SCRIPTS,
+    OBJECT_LIBS_KEY,
+    USE_SCRIPTS,
+)
 from ufo2ft.featureWriters import BaseFeatureWriter, ast
 from ufo2ft.util import (
     classifyGlyphs,
@@ -133,7 +138,7 @@ def parseAnchorName(
     if ignoreRE is not None:
         anchorName = re.sub(ignoreRE, "", anchorName)
 
-    if anchorName[0] == "*" and libData and "GPOS_Context" in libData:
+    if anchorName[0] == "*" and libData and ANCHOR_LIB_GPOS_CONTEXT_KEY in libData:
         isContextual = True
         anchorName = anchorName[1:]
         anchorName = re.sub(r"\..*", "", anchorName)
@@ -756,7 +761,7 @@ class MarkFeatureWriter(BaseFeatureWriter):
                 else:
                     continue
 
-                anchor_context = anchor.libData["GPOS_Context"].strip()
+                anchor_context = anchor.libData[ANCHOR_LIB_GPOS_CONTEXT_KEY].strip()
                 if not anchor_context:
                     self.log.warning(
                         "contextual anchor '%s' in glyph '%s' has no context data; skipped",

--- a/tests/featureWriters/markFeatureWriter_test.py
+++ b/tests/featureWriters/markFeatureWriter_test.py
@@ -5,7 +5,7 @@ from textwrap import dedent
 
 import pytest
 
-from ufo2ft.constants import OBJECT_LIBS_KEY
+from ufo2ft.constants import ANCHOR_LIB_GPOS_CONTEXT_KEY, OBJECT_LIBS_KEY
 from ufo2ft.featureCompiler import FeatureCompiler, parseLayoutFeatures
 from ufo2ft.featureWriters import ast
 from ufo2ft.featureWriters.markFeatureWriter import (
@@ -2144,7 +2144,7 @@ class MarkFeatureWriterTest(FeatureWriterTest):
     def test_contextual_anchor_no_context(self, testufo, caplog):
         a = testufo["a"]
         a.appendAnchor({"name": "*top", "x": 200, "y": 200, "identifier": "*top"})
-        a.lib[OBJECT_LIBS_KEY] = {"*top": {"GPOS_Context": " "}}
+        a.lib[OBJECT_LIBS_KEY] = {"*top": {ANCHOR_LIB_GPOS_CONTEXT_KEY: " "}}
 
         writer = MarkFeatureWriter()
         feaFile = ast.FeatureFile()


### PR DESCRIPTION
A mark can be contextual if it starts with an asterisk and has "GPOS_Context" in libData, otherwise it is just an ignorable anchor (since it does not starts with a letter).

We were checking for LibData in some places, but in most places we only check of isContextual. This change sets isContextual only of libData is not None and it has "GPOS_Context" key.