### PR TITLE
stemSnapH and stemSnapV values must be in ascending order

### DIFF
--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -1585,10 +1585,10 @@ class OutlineOTFCompiler(BaseOutlineCompiler):
             familyOtherBlues = [otRound(i) for i in familyOtherBlues]
         stemSnapH = getAttrWithFallback(info, "postscriptStemSnapH")
         if isinstance(stemSnapH, list):
-            stemSnapH = sorted([otRound(i) for i in stemSnapH])
+            stemSnapH = [otRound(i) for i in stemSnapH]
         stemSnapV = getAttrWithFallback(info, "postscriptStemSnapV")
         if isinstance(stemSnapV, list):
-            stemSnapV = sorted([otRound(i) for i in stemSnapV])
+            stemSnapV = [otRound(i) for i in stemSnapV]
         # only write the blues data if some blues are defined.
         if any((blueValues, otherBlues, familyBlues, familyOtherBlues)):
             private.rawDict["BlueFuzz"] = blueFuzz
@@ -1605,9 +1605,9 @@ class OutlineOTFCompiler(BaseOutlineCompiler):
                 private.rawDict["FamilyOtherBlues"] = familyOtherBlues
         # only write the stems if both are defined.
         if stemSnapH and stemSnapV:
-            private.rawDict["StemSnapH"] = stemSnapH
+            private.rawDict["StemSnapH"] = sorted(stemSnapH)
             private.rawDict["StdHW"] = stemSnapH[0]
-            private.rawDict["StemSnapV"] = stemSnapV
+            private.rawDict["StemSnapV"] = sorted(stemSnapV)
             private.rawDict["StdVW"] = stemSnapV[0]
         # populate glyphs
         cffGlyphs = self.getCompiledGlyphs()


### PR DESCRIPTION
The UFO spec states:

> postscriptStemSnapH – List of horizontal stems sorted in the order specified in the Type 1/CFF specification. Up to 12 integers or floats are possible. This corresponds to the Type 1/CFF StemSnapH field.
> 
> postscriptStemSnapV – List of vertical stems sorted in the order specified in the Type 1/CFF specification. Up to 12 integers or floats are possible. This corresponds to the Type 1/CFF StemSnapV field.
> 
> The Type 1/CFF `StdHW` and `StdVW` fields can be derived by taking the first value from the `postscriptStemSnapH` and `postscriptStemSnapV` lists.

If the dominant stem is not the smallest (first) value in `postscriptStemSnapH/V`, but the first value will be put into `StdHW/StdVW`, the UFO `postscriptStemSnapH/V` can't be sorted according to to the Type 1 spec, which states the values must be in ascending order.

I'll file an issue with the UFO spec as well, but this PR fixes the problem by sorting `StemSnapH/V`.