### PR TITLE
Fix nukta anchor classification

### DIFF
--- a/Lib/ufo2ft/featureWriters/markFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/markFeatureWriter.py
@@ -999,7 +999,7 @@ class MarkFeatureWriter(BaseFeatureWriter):
     def _isAboveMark(self, anchor):
         if anchor.name in self.abvmAnchorNames:
             return True
-        if anchor.name in self.blwmAnchorNames or anchor.name.startswith("bottom"):
+        if anchor.name in self.blwmAnchorNames or anchor.name.startswith(('bottom', 'nukta')):
             return False
         # Glyphs uses (used to use?) a heuristic to guess whether an anchor
         # should go into abvm or blwm. (See
@@ -1012,7 +1012,7 @@ class MarkFeatureWriter(BaseFeatureWriter):
         return True
 
     def _isBelowMark(self, anchor):
-        return not self._isAboveMark(anchor)
+        return anchor.name in self.blwmAnchorNames or anchor.name.startswith(('bottom', 'nukta'))
 
     def _makeAbvmOrBlwmFeature(self, tag, include):
         if tag == "abvm":

--- a/tests/featureWriters/anchor_classification_test.py
+++ b/tests/featureWriters/anchor_classification_test.py
@@ -1,0 +1,27 @@
+import pytest
+from ufo2ft.featureWriters.markFeatureWriter import MarkFeatureWriter
+
+
+def test_nukta_variants():
+    """Test that anchors named nukta_1, nukta_2 etc are correctly classified as below marks."""
+    writer = MarkFeatureWriter()
+    
+    # Mock anchor objects for testing
+    nukta1 = type('Anchor', (), {'name': 'nukta_1'})
+    nukta2 = type('Anchor', (), {'name': 'nukta_2'})
+    
+    # These should be classified as below marks
+    assert not writer._isAboveMark(nukta1)
+    assert not writer._isAboveMark(nukta2)
+    
+    # Regular nukta should still work
+    nukta = type('Anchor', (), {'name': 'nukta'})
+    assert not writer._isAboveMark(nukta)
+    
+    # Other below mark anchors should still work
+    bottom = type('Anchor', (), {'name': 'bottom'})
+    assert not writer._isAboveMark(bottom)
+    
+    # Above mark anchors should still work
+    top = type('Anchor', (), {'name': 'top'})
+    assert writer._isAboveMark(top)


### PR DESCRIPTION
Fixes #902 <!-- Needed for GitHub to link the issue to the PR -->

## Fix nukta anchor classification
This fixes incorrect classification of composite nukta anchors (e.g. `nukta_1`, `nukta_2`) by:

- Modifying `_isAboveMark` to check for names starting with &#39;nukta&#39;
- Making `_isBelowMark` explicitly check for nukta variants instead of just negating `_isAboveMark`
- Adding test cases to verify proper behavior with nukta variants

The change ensures nukta variants are correctly placed in BLWM features instead of ABVM.

---

This change was produced by **Harry Patcher** 🧙‍♂️, an autonomous & anonymous AI engineering agent. No human was involved in creating this pull request.

Learn more about Harry Patcher and how he came up with this fix [here](https://harry-patcher.ai/viewer?url=aHR0cHM6Ly9naXN0LmdpdGh1Yi5jb20vaGFycnktcGF0Y2hlci8wMzc5YjU0MjMxZTc1MDBmMjVhYmQxY2MzMjVmMmE2ZC9yYXcvc3dlYmVuY2hfZ29vZ2xlZm9udHNfX3VmbzJmdC05MDIuanNvbg&amp;pr=aHR0cHM6Ly9naXRodWIuY29tL2dvb2dsZWZvbnRzL3VmbzJmdC9wdWxsLzkyMw) 🔍.

Harry cannot yet respond to review feedback. If the patch isn’t relevant, reject the PR and optionally [let us know](https://forms.office.com/Pages/ResponsePage.aspx?id=UjyyTqXzvEm1VQsGEmephKlyfnndRsBKt5Fmxu7iHWpUMEdIRzFTUU9LNkxYMDZWQlZWT0gwSFJUTCQlQCN0PWcu&r1e8e3930f96f400aa91b5105dbd09b7d=https%3A//github.com/googlefonts/ufo2ft/pull/923&rb85bea8de07843f9835f9d001f689f4c=https%3A//github.com/googlefonts/ufo2ft&r034de175aef248b29aaf36f2a5e92912=https%3A//github.com/googlefonts/ufo2ft/pull/923&r9e0cc5d7ff8b484e81eb97531d4cefd7=https%3A//github.com/googlefonts/ufo2ft/pull/923) 📬.