### PR TITLE
Treat erroneously propagated nukta anchors as below marks

### DIFF
--- a/Lib/ufo2ft/featureWriters/markFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/markFeatureWriter.py
@@ -999,7 +999,11 @@ class MarkFeatureWriter(BaseFeatureWriter):
     def _isAboveMark(self, anchor):
         if anchor.name in self.abvmAnchorNames:
             return True
-        if anchor.name in self.blwmAnchorNames or anchor.name.startswith("bottom"):
+        if (
+            anchor.name in self.blwmAnchorNames
+            or anchor.name.startswith("bottom")
+            or anchor.name.startswith("nukta")
+        ):
             return False
         # Glyphs uses (used to use?) a heuristic to guess whether an anchor
         # should go into abvm or blwm. (See


### PR DESCRIPTION
This is lipstick on a pig: we should not be treating deva conjunct forms as ligatures, and we should not be propagated anchors like we do for ligature glyphs, and so we should never have a nukta_1 anchor.

I don't understand all of the nuances of this larger problem. I do understand, though, that so long as we _are_ creating these anchors, they definitely belong in blwm more than in abvm.

This patch fixes _that_. The main utility of this fix is simply that it is easier for fontc to match this particular miscompilation, so that the two compilers are at least equivalently wrong; when we decide on how we want to address the underlying issue, we can fix it in both places.