### PR TITLE
Process contextual anchors for abvm and blwm features

### DIFF
--- a/tests/featureWriters/markFeatureWriter_test.py
+++ b/tests/featureWriters/markFeatureWriter_test.py
@@ -933,6 +933,94 @@ class MarkFeatureWriterTest(FeatureWriterTest):
 
         assert str(generated) == expected
 
+    def test_contextual_abvm_blwm_anchors(self, FontClass):
+        ufo = FontClass()
+        ufo.info.unitsPerEm = 1000
+
+        iMark = ufo.newGlyph("iMark-khmer")
+        iMark.unicode = 0x17B7
+        iMark.appendAnchor({"name": "_topright", "x": 412, "y": 600})
+
+        iiMark = ufo.newGlyph("iiMark-khmer")
+        iiMark.unicode = 0x17B8
+        iiMark.appendAnchor({"name": "_topright", "x": 412, "y": 600})
+
+        kaBelow = ufo.newGlyph("ka-khmer.below")
+        kaBelow.appendAnchor({"name": "_bottom", "x": 276, "y": 0})
+
+        ka = ufo.newGlyph("ka-khmer")
+        ka.unicode = 0x1780
+        ka.appendAnchor({"name": "topright", "x": 470, "y": 600})
+        ka.appendAnchor(
+            {"name": "*topright", "x": 276, "y": 700, "identifier": "*topright"}
+        )
+        ka.appendAnchor({"name": "bottom", "x": 276, "y": 0})
+
+        ka.lib[OBJECT_LIBS_KEY] = {
+            "*topright": {
+                "GPOS_Context": dedent(
+                    """\
+                    lookupflag UseMarkFilteringSet [iiMark-khmer]; * ka-khmer iMark-khmer
+                    lookupflag UseMarkFilteringSet [ka-khmer.below]; * ka-khmer ka-khmer.below
+                    """
+                )
+            }
+        }
+
+        writer = MarkFeatureWriter()
+        feaFile = ast.FeatureFile()
+        assert str(feaFile) == ""
+        assert writer.write(ufo, feaFile)
+
+        assert str(feaFile) == dedent(
+            """\
+            markClass ka-khmer.below <anchor 276 0> @MC_bottom;
+            markClass iMark-khmer <anchor 412 600> @MC_topright;
+            markClass iiMark-khmer <anchor 412 600> @MC_topright;
+
+            lookup abvm_mark2base {
+                pos base ka-khmer
+                    <anchor 470 600> mark @MC_topright;
+            } abvm_mark2base;
+
+            lookup ContextualAbvm_0 {
+                pos base ka-khmer
+                    <anchor 276 700> mark @MC_topright;
+            } ContextualAbvm_0;
+
+            lookup ContextualAbvm_1 {
+                pos base ka-khmer
+                    <anchor 276 700> mark @MC_topright;
+            } ContextualAbvm_1;
+
+            lookup ContextualAbvmDispatch_0 {
+                lookupflag UseMarkFilteringSet [ka-khmer.below];
+                # * ka-khmer ka-khmer.below
+                pos [ka-khmer] @MC_topright' lookup ContextualAbvm_0 ka-khmer ka-khmer.below;
+            } ContextualAbvmDispatch_0;
+
+            lookup ContextualAbvmDispatch_1 {
+                lookupflag UseMarkFilteringSet [iiMark-khmer];
+                # * ka-khmer iMark-khmer
+                pos [ka-khmer] @MC_topright' lookup ContextualAbvm_1 ka-khmer iMark-khmer;
+            } ContextualAbvmDispatch_1;
+
+            feature abvm {
+                lookup abvm_mark2base;
+                lookup ContextualAbvmDispatch_0;
+                lookup ContextualAbvmDispatch_1;
+            } abvm;
+
+            feature blwm {
+                lookup blwm_mark2base {
+                    pos base ka-khmer
+                        <anchor 276 0> mark @MC_bottom;
+                } blwm_mark2base;
+
+            } blwm;
+            """
+        )
+
     def test_shared_script_char(self, FontClass):
         ufo = FontClass()
         ufo.info.unitsPerEm = 1000


### PR DESCRIPTION
* I made a function `_makeAllContextualMarkLookups` (can be renamed to something else) to wrap the generating logic for ctxLkps and refLkps, so it can be shared in `_makeMarkFeature`, `_makeMkmkFeature`, and `_makeAbvmOrBlwmFeature`.
* Update `_isAboveMark` to be usable when checking if the contextual anchors are top or bottom.
* In `_makeContextualAttachments`, I separate the base glyphs for `mark`, and base glyphs for `abvm` and `blwm`.