### PR TITLE
update fonttools and fix integration tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fonttools[lxml,ufo]==4.58.5
+fonttools[lxml,ufo]==4.59.1
 defcon==0.10.3
 compreffor==0.5.6
 booleanOperations==0.9.0

--- a/tests/data/DSv5/MutatorSansVariable_Weight-CFF2.ttx
+++ b/tests/data/DSv5/MutatorSansVariable_Weight-CFF2.ttx
@@ -107,7 +107,7 @@
     <sCapHeight value="700"/>
     <usDefaultChar value="0"/>
     <usBreakChar value="32"/>
-    <usMaxContext value="0"/>
+    <usMaxContext value="1"/>
   </OS_2>
 
   <hmtx>

--- a/tests/data/DSv5/MutatorSansVariable_Weight-TTF.ttx
+++ b/tests/data/DSv5/MutatorSansVariable_Weight-TTF.ttx
@@ -121,7 +121,7 @@
     <sCapHeight value="700"/>
     <usDefaultChar value="0"/>
     <usBreakChar value="32"/>
-    <usMaxContext value="0"/>
+    <usMaxContext value="1"/>
   </OS_2>
 
   <hmtx>

--- a/tests/data/DSv5/MutatorSansVariable_Weight_Width-CFF2.ttx
+++ b/tests/data/DSv5/MutatorSansVariable_Weight_Width-CFF2.ttx
@@ -107,7 +107,7 @@
     <sCapHeight value="700"/>
     <usDefaultChar value="0"/>
     <usBreakChar value="32"/>
-    <usMaxContext value="0"/>
+    <usMaxContext value="1"/>
   </OS_2>
 
   <hmtx>

--- a/tests/data/DSv5/MutatorSansVariable_Weight_Width-TTF.ttx
+++ b/tests/data/DSv5/MutatorSansVariable_Weight_Width-TTF.ttx
@@ -121,7 +121,7 @@
     <sCapHeight value="700"/>
     <usDefaultChar value="0"/>
     <usBreakChar value="32"/>
-    <usMaxContext value="0"/>
+    <usMaxContext value="1"/>
   </OS_2>
 
   <hmtx>

--- a/tests/data/DSv5/MutatorSansVariable_Width-CFF2.ttx
+++ b/tests/data/DSv5/MutatorSansVariable_Width-CFF2.ttx
@@ -107,7 +107,7 @@
     <sCapHeight value="700"/>
     <usDefaultChar value="0"/>
     <usBreakChar value="32"/>
-    <usMaxContext value="0"/>
+    <usMaxContext value="1"/>
   </OS_2>
 
   <hmtx>

--- a/tests/data/DSv5/MutatorSansVariable_Width-TTF.ttx
+++ b/tests/data/DSv5/MutatorSansVariable_Width-TTF.ttx
@@ -121,7 +121,7 @@
     <sCapHeight value="700"/>
     <usDefaultChar value="0"/>
     <usBreakChar value="32"/>
-    <usMaxContext value="0"/>
+    <usMaxContext value="1"/>
   </OS_2>
 
   <hmtx>


### PR DESCRIPTION
In Fedora, we noticed that the value of `usMaxContext` changed from `0` to `1` in several files between `fonttools` releases 4.59.0 and 4.59.1.