### PR TITLE
decomposeCompositeGlyph: use reverseFlipped='on_curve_first' to match fontc

### DIFF
--- a/Lib/ufo2ft/util.py
+++ b/Lib/ufo2ft/util.py
@@ -14,7 +14,7 @@ from fontTools.designspaceLib import DesignSpaceDocument
 from fontTools.feaLib.builder import addOpenTypeFeatures
 from fontTools.misc.fixedTools import otRound
 from fontTools.misc.transform import Identity
-from fontTools.pens.filterPen import DecomposingFilterPointPen
+from fontTools.pens.filterPen import DecomposingFilterPointPen, ReverseFlipped
 from fontTools.pens.reverseContourPen import ReverseContourPen
 from fontTools.pens.transformPen import TransformPen
 
@@ -58,7 +58,11 @@ def decomposeCompositeGlyph(
     glyph,
     glyphSet,
     skipMissing=False,
-    reverseFlipped=True,
+    # When decomposing flipped components (with negative determinant), ensure that
+    # the first point is an on-curve point before reversing the winding contour
+    # direction, otherwise they get different starting points than in fontc:
+    # https://github.com/googlefonts/fontc/issues/1633
+    reverseFlipped=ReverseFlipped.ON_CURVE_FIRST,
     include=None,
     decomposeNested=True,
 ):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fonttools[lxml,ufo]==4.59.2
+fonttools[lxml,ufo]==4.60.0
 defcon==0.10.3
 compreffor==0.5.6
 booleanOperations==0.9.0

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     setup_requires=pytest_runner + wheel + ["setuptools_scm"],
     tests_require=["pytest>=2.8"],
     install_requires=[
-        "fonttools[ufo]>=4.59.2",
+        "fonttools[ufo]>=4.60.0",
         "cffsubr>=0.3.0",
         "booleanOperations>=0.9.0",
         "fontMath>=0.9.4",


### PR DESCRIPTION
Will fix https://github.com/googlefonts/fontc/issues/1633 once https://github.com/fonttools/fonttools/pull/3934 is merged