### PR TITLE
preProcessor: decompose components whose transform overflows F2Dot14

### DIFF
--- a/tests/data/OverflowingComponentTransforms-Bold.ufo/fontinfo.plist
+++ b/tests/data/OverflowingComponentTransforms-Bold.ufo/fontinfo.plist
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>ascender</key>
+    <integer>800</integer>
+    <key>capHeight</key>
+    <integer>700</integer>
+    <key>descender</key>
+    <integer>-200</integer>
+    <key>familyName</key>
+    <string>Overflowing Component Transforms</string>
+    <key>openTypeHeadCreated</key>
+    <string>2025/09/19 11:59:48</string>
+    <key>openTypeOS2WeightClass</key>
+    <integer>700</integer>
+    <key>styleMapFamilyName</key>
+    <string>Overflowing Component Transforms</string>
+    <key>styleMapStyleName</key>
+    <string>bold</string>
+    <key>styleName</key>
+    <string>Bold</string>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+    <key>versionMajor</key>
+    <integer>1</integer>
+    <key>versionMinor</key>
+    <integer>0</integer>
+  </dict>
+</plist>

--- a/tests/data/OverflowingComponentTransforms-Bold.ufo/glyphs/base.glif
+++ b/tests/data/OverflowingComponentTransforms-Bold.ufo/glyphs/base.glif
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="base" format="2">
+  <advance width="600"/>
+  <outline>
+    <contour>
+      <point x="52" y="404" type="line"/>
+      <point x="52" y="301" type="line"/>
+      <point x="550" y="301" type="line"/>
+      <point x="550" y="404" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/tests/data/OverflowingComponentTransforms-Bold.ufo/glyphs/composite.glif
+++ b/tests/data/OverflowingComponentTransforms-Bold.ufo/glyphs/composite.glif
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="composite" format="2">
+  <advance width="1200"/>
+  <outline>
+    <component base="base"/>
+    <component base="base" xScale="0.8811" yScale="6.4512" xOffset="169" yOffset="-1107"/>
+  </outline>
+</glyph>

--- a/tests/data/OverflowingComponentTransforms-Bold.ufo/glyphs/contents.plist
+++ b/tests/data/OverflowingComponentTransforms-Bold.ufo/glyphs/contents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>base</key>
+    <string>base.glif</string>
+    <key>composite</key>
+    <string>composite.glif</string>
+  </dict>
+</plist>

--- a/tests/data/OverflowingComponentTransforms-Bold.ufo/layercontents.plist
+++ b/tests/data/OverflowingComponentTransforms-Bold.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <array>
+      <string>public.default</string>
+      <string>glyphs</string>
+    </array>
+  </array>
+</plist>

--- a/tests/data/OverflowingComponentTransforms-Bold.ufo/lib.plist
+++ b/tests/data/OverflowingComponentTransforms-Bold.ufo/lib.plist
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.glyphOrder</key>
+    <array>
+      <string>base</string>
+      <string>composite</string>
+    </array>
+  </dict>
+</plist>

--- a/tests/data/OverflowingComponentTransforms-Bold.ufo/metainfo.plist
+++ b/tests/data/OverflowingComponentTransforms-Bold.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>com.github.fonttools.ufoLib</string>
+    <key>formatVersion</key>
+    <integer>3</integer>
+  </dict>
+</plist>

--- a/tests/data/OverflowingComponentTransforms-Regular.ufo/fontinfo.plist
+++ b/tests/data/OverflowingComponentTransforms-Regular.ufo/fontinfo.plist
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>ascender</key>
+    <integer>800</integer>
+    <key>capHeight</key>
+    <integer>700</integer>
+    <key>descender</key>
+    <integer>-200</integer>
+    <key>familyName</key>
+    <string>Overflowing Component Transforms</string>
+    <key>openTypeHeadCreated</key>
+    <string>2025/09/19 11:59:48</string>
+    <key>openTypeOS2WeightClass</key>
+    <integer>400</integer>
+    <key>styleMapFamilyName</key>
+    <string>Overflowing Component Transforms</string>
+    <key>styleMapStyleName</key>
+    <string>regular</string>
+    <key>styleName</key>
+    <string>Regular</string>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+    <key>versionMajor</key>
+    <integer>1</integer>
+    <key>versionMinor</key>
+    <integer>0</integer>
+  </dict>
+</plist>

--- a/tests/data/OverflowingComponentTransforms-Regular.ufo/glyphs/base.glif
+++ b/tests/data/OverflowingComponentTransforms-Regular.ufo/glyphs/base.glif
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="base" format="2">
+  <advance width="600"/>
+  <outline>
+    <contour>
+      <point x="140" y="226" type="line"/>
+      <point x="140" y="184" type="line"/>
+      <point x="487" y="184" type="line"/>
+      <point x="487" y="226" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/tests/data/OverflowingComponentTransforms-Regular.ufo/glyphs/composite.glif
+++ b/tests/data/OverflowingComponentTransforms-Regular.ufo/glyphs/composite.glif
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="composite" format="2">
+  <advance width="1200"/>
+  <outline>
+    <component base="base"/>
+    <component base="base" xScale="0.8811" yScale="6.4512" xOffset="169" yOffset="-1107"/>
+  </outline>
+</glyph>

--- a/tests/data/OverflowingComponentTransforms-Regular.ufo/glyphs/contents.plist
+++ b/tests/data/OverflowingComponentTransforms-Regular.ufo/glyphs/contents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>base</key>
+    <string>base.glif</string>
+    <key>composite</key>
+    <string>composite.glif</string>
+  </dict>
+</plist>

--- a/tests/data/OverflowingComponentTransforms-Regular.ufo/layercontents.plist
+++ b/tests/data/OverflowingComponentTransforms-Regular.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <array>
+      <string>public.default</string>
+      <string>glyphs</string>
+    </array>
+  </array>
+</plist>

--- a/tests/data/OverflowingComponentTransforms-Regular.ufo/lib.plist
+++ b/tests/data/OverflowingComponentTransforms-Regular.ufo/lib.plist
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.glyphOrder</key>
+    <array>
+      <string>base</string>
+      <string>composite</string>
+    </array>
+  </dict>
+</plist>

--- a/tests/data/OverflowingComponentTransforms-Regular.ufo/metainfo.plist
+++ b/tests/data/OverflowingComponentTransforms-Regular.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>com.github.fonttools.ufoLib</string>
+    <key>formatVersion</key>
+    <integer>3</integer>
+  </dict>
+</plist>

--- a/tests/data/OverflowingComponentTransforms.designspace
+++ b/tests/data/OverflowingComponentTransforms.designspace
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<designspace format="5.0">
+  <axes>
+    <axis tag="wght" name="Weight" minimum="400" maximum="700" default="400">
+      <map input="400" output="0"/>
+      <map input="700" output="100"/>
+    </axis>
+  </axes>
+  <sources>
+    <source filename="OverflowingComponentTransforms-Regular.ufo" name="Overflowing Component Transforms Regular">
+      <location>
+        <dimension name="Weight" xvalue="0"/>
+      </location>
+    </source>
+    <source filename="OverflowingComponentTransforms-Bold.ufo" name="Overflowing Component Transforms Bold">
+      <location>
+        <dimension name="Weight" xvalue="100"/>
+      </location>
+    </source>
+  </sources>
+</designspace>


### PR DESCRIPTION
Even though the TTGlyphPen in fonttools already does this for us, it is better to do this decomposition upfront so that filters that are performed later on in the preprocessing pipeline (e.g. removeOverlaps, cubicToQuadratic, etc.) operate on the already decomposed outlines.

This also matches what fontc currently does, and as a bonus give us at least one +1 in the fontc_crater diff (i.e. Ruthie.glyphs).