### PR TITLE
[markFeatureWriter] Allow setting markClassPrefix using writer options

### DIFF
--- a/tests/featureWriters/markFeatureWriter_test.py
+++ b/tests/featureWriters/markFeatureWriter_test.py
@@ -2309,6 +2309,12 @@ class MarkFeatureWriterTest(FeatureWriterTest):
             assert len(statement.marks) == 1
             assert statement.marks[0][1].name == "MC_top"
 
+    def test_mark_ckass_prefix(self, testufo):
+        writer = MarkFeatureWriter(markClassPrefix="mark")
+        feaFile = ast.FeatureFile()
+        assert writer.write(testufo, feaFile)
+        assert all(c.startswith("mark_") for c in feaFile.markClasses)
+
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
Currently it is only a class attribute, but users may want to set it in fonts (e.g. glyphsLib might use `mark` prefix like Glyphs does).