### PR TITLE
Fix trailing space in nameID=4 when styleName is empty

### DIFF
--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -407,7 +407,7 @@ class BaseOutlineCompiler:
         preferredSubfamilyName = getAttrWithFallback(
             font.info, "openTypeNamePreferredSubfamilyName"
         )
-        fullName = f"{preferredFamilyName} {preferredSubfamilyName}"
+        fullName = f"{preferredFamilyName} {preferredSubfamilyName}".strip()
 
         nameVals = {
             0: getAttrWithFallback(font.info, "copyright"),

--- a/tests/outlineCompiler_test.py
+++ b/tests/outlineCompiler_test.py
@@ -312,6 +312,16 @@ class OutlineTTFCompilerTest:
         actual = compiler.otf["name"].getName(1, 3, 1, 1033).string
         assert actual == "Custom Name for Windows"
 
+    def test_setupTable_name_empty_styleName(self, quadufo):
+        """nameID=4 (full name) should not have trailing space when styleName is empty."""
+        quadufo.info.styleName = ""
+        quadufo.info.styleMapFamilyName = None
+        quadufo.info.openTypeNamePreferredSubfamilyName = None
+        compiler = OutlineTTFCompiler(quadufo)
+        compiler.compile()
+        fullName = compiler.otf["name"].getName(4, 3, 1, 1033).string
+        assert fullName == fullName.strip()
+
     def test_post_underline_without_public_key(self, quadufo):
         compiler = OutlineTTFCompiler(quadufo)
         compiler.compile()


### PR DESCRIPTION
A little issue I noticed in some of the itfoundry fonts; some of these have an explicitly empty styleName, which introduced trailing whitespace in the name records.

When a UFO has styleName set to an empty string, the full font name (nameID=4) was constructed as f"{family} {subfamily}" producing a trailing space. Add .strip() to match the pattern used elsewhere (e.g. styleMapFamilyNameFallback, in fontInfoData.py).