### PR TITLE
Fix empty public.postscriptNames dict incorrectly triggering uniXXXX derivation

### DIFF
--- a/Lib/ufo2ft/postProcessor.py
+++ b/Lib/ufo2ft/postProcessor.py
@@ -148,7 +148,7 @@ class PostProcessor:
             useProductionNames = self.ufo.lib.get(
                 USE_PRODUCTION_NAMES,
                 not self.ufo.lib.get(GLYPHS_DONT_USE_PRODUCTION_NAMES)
-                and self._postscriptNames is not None,
+                and self._postscriptNames,
             )
         else:
             keepGlyphNames = True

--- a/tests/outlineCompiler_test.py
+++ b/tests/outlineCompiler_test.py
@@ -958,6 +958,12 @@ class NamesTest:
             "lll",
         ]
 
+    def test_empty_postscript_names_no_rename(self, testufo):
+        testufo.lib["public.postscriptNames"] = {}
+        original_order = compileTTF(testufo, useProductionNames=False).getGlyphOrder()
+        result = compileTTF(testufo).getGlyphOrder()
+        assert result == original_order
+
     def test_warn_name_exceeds_max_length(self, testufo, caplog):
         long_name = 64 * "a"
         testufo.newGlyph(long_name)


### PR DESCRIPTION
When a UFO's `lib.plist` contains `public.postscriptNames` as an empty dict (`<dict/>`), ufo2ft incorrectly derives `uniXXXX`/`uXXXXX` production names for all glyphs. But an empty mapping should mean "no glyphs are renamed," same as if it were absent.

The [Georama](https://github.com/productiontype/Georama) family has `<key>public.postscriptNames</key><dict/>` in all 7 masters. fontmake renames every glyph to uniXXXX; fontc correctly keeps the source names.

The problem is the `is not None` check in `process_glyph_names()`: an empty dict `{}` passes that check, so `useProductionNames` is set to `True`. Then in `_build_production_name()`, the truthiness guard `if self._postscriptNames:` skips the (empty) mapping and incorrectly falls through to unicode-based derivation.

The fix changes `is not None` to a truthiness check so empty and absent are treated the same, matching the documented semantics from commit 2f800cb:

> If the mapping is not present, no glyph names are renamed.

There is already a way to explicitly opt into uniXXXX renaming by setting the `com.github.googlei18n.ufo2ft.useProductionNames` lib key to `true` (or by passing `--production-names` to fontmake CLI in absence of an explicit `public.postscriptNames` dict in the lib):

```xml
<key>com.github.googlei18n.ufo2ft.useProductionNames</key>
<true/>
```

An empty `public.postscriptNames` dict was never supposed to implicitly trigger the same behavior.
