### PR TITLE
[kernFeatureWriter] Fix partial-master glyph-to-class kern exceptions shadowing class-to-glyph

### DIFF
--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
@@ -770,77 +770,17 @@ def getVariableKerningPairs(
         for glyph_name in glyphs
     }
 
-    # Collate every kerning pair in the designspace, as even UFOs that
-    # provide no entry for the pair must contribute a value at their
-    # source's location in the VariableScalar.
-    # NOTE: This is required as the DS+UFO kerning model and the OpenType
-    #       variation model handle the absence of a kerning value at a
-    #       given location differently:
-    #       - DS+UFO:
-    #           If the missing pair excepts another pair, take its value;
-    #           Otherwise, take a value of 0.
-    #       - OpenType:
-    #           Always interpolate from other locations, ignoring more
-    #           general pairs that this one excepts.
-    # See discussion: https://github.com/googlefonts/ufo2ft/pull/635
-    all_pairs: set[tuple[str, str]] = set()
+    # Cache each non-sparse source's kerning keyed by its VariableScalar
+    # location. Sparse sources (those with a layerName) carry no kerning.
+    sources = []
     for source in designspace.sources:
         if source.layerName is not None:
             continue
         assert source.font is not None
-        all_pairs |= set(source.font.kerning)
-
-    kerning_pairs_in_progress: dict[
-        tuple[str | tuple[str], str | tuple[str]], VariableScalar
-    ] = {}
-    for source in designspace.sources:
-        # Skip sparse sources, because they can have no kerning.
-        if source.layerName is not None:
-            continue
-        assert source.font is not None
-
         location = VariableScalarLocation(
             get_userspace_location(designspace, source.location)
         )
-
-        kerning: Mapping[tuple[str, str], float] = source.font.kerning
-        for pair in all_pairs:
-            side1, side2 = pair
-            firstIsClass = side1 in side1Classes
-            secondIsClass = side2 in side2Classes
-
-            # Filter out pairs that reference missing groups or glyphs.
-            # TODO: Can we do this outside of the loop? We know the pairs already.
-            if not firstIsClass and side1 not in glyphSet:
-                continue
-            if not secondIsClass and side2 not in glyphSet:
-                continue
-
-            # Get the kerning value for this source and quantize, following
-            # the DS+UFO semantics described above.
-            value = quantize(
-                lookupKerningValue(
-                    pair,
-                    kerning,
-                    unified_groups,
-                    glyphToFirstGroup=glyphToFirstGroup,
-                    glyphToSecondGroup=glyphToSecondGroup,
-                ),
-                quantization,
-            )
-
-            if firstIsClass:
-                side1 = side1Classes[side1]
-            if secondIsClass:
-                side2 = side2Classes[side2]
-
-            # TODO: Can we instantiate these outside of the loop? We know the pairs already.
-            var_scalar = kerning_pairs_in_progress.setdefault(
-                (side1, side2), VariableScalar()
-            )
-            # NOTE: Avoid using .add_value because it instantiates a new
-            # VariableScalarLocation on each call.
-            var_scalar.values[location] = value
+        sources.append((location, source.font.kerning))
 
     # We may need to provide a default location value to the variation
     # model, find out where that is.
@@ -850,22 +790,121 @@ def getVariableKerningPairs(
         get_userspace_location(designspace, default_source.location)
     )
 
-    result = []
-    for (side1, side2), value in kerning_pairs_in_progress.items():
-        # TODO: Should we interpolate a default value if it's not in the
-        # sources, rather than inserting a zero? What would varLib do?
-        if default_location not in value.values:
-            value.values[default_location] = 0
-        value = collapse_varscalar(value)
-        pair = KerningPair(side1, side2, value)
+    # Collate every kerning pair *key* in the designspace, as even sources
+    # that provide no entry for the pair must contribute a value at their
+    # location in the VariableScalar.
+    # NOTE: This is required because the DS+UFO kerning model and the
+    #       OpenType variation model handle the absence of a kerning value
+    #       at a given location differently:
+    #       - DS+UFO:
+    #           If the missing pair excepts another pair, take its value;
+    #           Otherwise, take a value of 0.
+    #       - OpenType:
+    #           Always interpolate from other locations, ignoring more
+    #           general pairs that this one excepts.
+    # See discussion: https://github.com/googlefonts/ufo2ft/pull/635
+    all_pairs: set[tuple[str, str]] = set()
+    for _, kerning in sources:
+        all_pairs |= set(kerning)
+
+    def build_scalar(side1: str, side2: str) -> VariableScalar:
+        """Resolve the (side1, side2) pair at every source with the DS+UFO
+        kerning cascade and return the resulting VariableScalar."""
+        scalar = VariableScalar()
+        for location, kerning in sources:
+            # NOTE: assign .values directly rather than .add_value, which
+            # instantiates a new VariableScalarLocation on each call.
+            scalar.values[location] = quantize(
+                lookupKerningValue(
+                    (side1, side2),
+                    kerning,
+                    unified_groups,
+                    glyphToFirstGroup=glyphToFirstGroup,
+                    glyphToSecondGroup=glyphToSecondGroup,
+                ),
+                quantization,
+            )
+        # Anchor the default (the model's reference) at 0 when no source
+        # sets it; it's a base value, never interpolated.
+        if default_location not in scalar.values:
+            scalar.values[default_location] = 0
+        return scalar
+
+    def resolve_pairs(side1, side2):
+        """Yield the variable KerningPair(s) for one source kerning key.
+
+        Most keys yield a single pair resolved with the DS+UFO cascade. The
+        exceptions:
+        - a key referencing a missing glyph yields nothing;
+        - a zero-valued class-to-class kern yields nothing;
+        - a glyph-to-class exception is resolved cell by cell. Its value must
+          be defined at every location; where a source omits it the cascade
+          backfills the class-to-class value, and since glyph-to-class
+          outranks class-to-glyph that backfill would shadow a competing
+          class-to-glyph exception on a shared cell -- rendering there a value
+          the source never resolves to (a "phantom"). So group the members by
+          the value each cell lands on and yield one compact class pair when
+          they all agree, else one pair per value group (a lone glyph, or an
+          inline class of the members that agree).
+          See https://github.com/googlefonts/ufo2ft/issues/988.
+        """
+        firstIsClass = side1 in side1Classes
+        secondIsClass = side2 in side2Classes
+
+        # Skip pairs that reference a missing glyph.
+        if not firstIsClass and side1 not in glyphSet:
+            return
+        if not secondIsClass and side2 not in glyphSet:
+            return
+
+        if not firstIsClass and secondIsClass:
+            # getKerningGroups prunes class members to the glyph set, so
+            # every value group is non-empty.
+            members = side2Classes[side2]
+            members_by_value: dict[tuple, list[str]] = {}
+            scalar_by_value: dict[tuple, VariableScalar] = {}
+            for member in members:
+                scalar = build_scalar(side1, member)
+                signature = tuple(sorted(scalar.values.items()))
+                members_by_value.setdefault(signature, []).append(member)
+                scalar_by_value[signature] = scalar
+
+            if len(members_by_value) == 1:
+                [scalar] = scalar_by_value.values()
+                yield KerningPair(side1, members, collapse_varscalar(scalar))
+            else:
+                for signature, group in members_by_value.items():
+                    group.sort()
+                    side2repr = group[0] if len(group) == 1 else tuple(group)
+                    scalar = scalar_by_value[signature]
+                    yield KerningPair(side1, side2repr, collapse_varscalar(scalar))
+            return
+
+        s1 = side1Classes[side1] if firstIsClass else side1
+        s2 = side2Classes[side2] if secondIsClass else side2
+        pair = KerningPair(s1, s2, collapse_varscalar(build_scalar(side1, side2)))
         # Ignore zero-valued class kern pairs. They are the most general
         # kerns, so they don't override anything else like glyph kerns would
         # and zero is the default.
-        if pair.firstIsClass and pair.secondIsClass and pair.value == 0:
-            continue
-        result.append(pair)
+        if not (pair.firstIsClass and pair.secondIsClass and pair.value == 0):
+            yield pair
 
-    return result
+    # The per-cell split can emit a glyph-glyph pair that another key also
+    # yields (an explicit pair, or another overlapping class), so dedupe on the
+    # output pair. Colliding pairs resolve the same cell, so their values match.
+    result: dict[tuple[Any, Any], KerningPair] = {}
+    for side1, side2 in all_pairs:
+        for pair in resolve_pairs(side1, side2):
+            key = (pair.side1, pair.side2)
+            if key in result:
+                # VariableScalar has no value __eq__, so compare contents.
+                a, b = result[key].value, pair.value
+                a = a.values if isinstance(a, VariableScalar) else a
+                b = b.values if isinstance(b, VariableScalar) else b
+                assert a == b, f"conflicting variable kern values for {key}"
+            result[key] = pair
+
+    return list(result.values())
 
 
 def splitKerning(pairs, glyphScripts):

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ fontMath==0.10.0
 
 # alternative UFO implementation
 ufoLib2==0.18.1
+
+# shape compiled fonts in tests to verify the kerning they actually apply
+uharfbuzz==0.55.0

--- a/tests/featureWriters/variableFeatureWriter_test.py
+++ b/tests/featureWriters/variableFeatureWriter_test.py
@@ -1,7 +1,10 @@
 import io
+import itertools
 from textwrap import dedent
 
+import pytest
 from fontTools import designspaceLib
+from fontTools.ufoLib.kerning import lookupKerningValue
 
 from ufo2ft import compileVariableTTF
 
@@ -137,6 +140,40 @@ def test_variable_kern_uniform_override_exception(FontClass):
             lookup kern_Latn;
         } kern;
 """)
+
+
+@pytest.mark.parametrize("coverAllMembers", [False, True])
+def test_variable_kern_matches_source_at_masters(coverAllMembers, FontClass):
+    # At a master location the variation model reconstructs that source exactly,
+    # so the kern the font applies to a pair there must equal the value the
+    # master's own DS+UFO cascade resolves.
+    hb = pytest.importorskip("uharfbuzz")
+
+    designspace = _makePartialExceptionDesignSpace(
+        FontClass, coverAllMembers=coverAllMembers
+    )
+    vf = compileVariableTTF(designspace)
+    buf = io.BytesIO()
+    vf.save(buf)
+    face = hb.Face(buf.getvalue())
+
+    for source in designspace.sources:
+        kerning = source.font.kerning
+        groups = source.font.groups
+        hbFont = hb.Font(face)
+        hbFont.set_variations({"wght": source.location["Weight"]})
+        for first, second in itertools.product(("A", "B"), ("X", "Y")):
+            expected = lookupKerningValue((first, second), kerning, groups)
+            hbBuf = hb.Buffer()
+            hbBuf.add_str(first + second)
+            hbBuf.guess_segment_properties()
+            hb.shape(hbFont, hbBuf, {"kern": True})
+            info, pos = hbBuf.glyph_infos, hbBuf.glyph_positions
+            actual = pos[0].x_advance - hbFont.get_glyph_h_advance(info[0].codepoint)
+            assert actual == expected, (
+                f"{source.name} {first}{second}: "
+                f"font kerns {actual}, source resolves {expected}"
+            )
 
 
 def test_variable_features(FontClass):

--- a/tests/featureWriters/variableFeatureWriter_test.py
+++ b/tests/featureWriters/variableFeatureWriter_test.py
@@ -6,6 +6,139 @@ from fontTools import designspaceLib
 from ufo2ft import compileVariableTTF
 
 
+def _makePartialExceptionDesignSpace(FontClass, *, coverAllMembers=False):
+    """Two masters reproducing a partially-populated, conflicting kerning
+    exception, the case ufo2ft#988 is about.
+
+        side1 class @c1 = {A, B}   side2 class @c2 = {X, Y}
+
+        (A,  @c2)  = 70   master 'bold' only   glyph-to-class exception
+        (@c1, X)   = 30   both masters         class-to-glyph exception
+        (@c1, @c2) = 50   both masters         class-to-class (the general value)
+
+    The overlap cell (A, X) is matched by both exceptions. Its source-faithful
+    resolution is [regular: 30 from the class-to-glyph (no glyph-to-class yet),
+    bold: 70 -- the glyph-to-class wins precedence].
+
+    With coverAllMembers=True, the class-to-glyph exception also covers Y
+    ((@c1, Y) = 30), so both overlap cells (A, X) and (A, Y) resolve identically
+    -- no cell diverges from another. The glyph-to-class pair is then kept
+    compact, but must still carry the agreed cell value [30, 70], not the
+    class-to-class value (50) backfilled where the glyph-to-class is absent.
+    """
+
+    def makeMaster(kerning):
+        font = FontClass()
+        font.newGlyph(".notdef").width = 600
+        for name, unicode in [("A", 0x41), ("B", 0x42), ("X", 0x58), ("Y", 0x59)]:
+            glyph = font.newGlyph(name)
+            glyph.width = 600
+            glyph.unicodes = [unicode]
+            pen = glyph.getPen()
+            pen.moveTo((50, 0))
+            pen.lineTo((550, 0))
+            pen.lineTo((550, 700))
+            pen.lineTo((50, 700))
+            pen.closePath()
+        font.groups["public.kern1.c1"] = ["A", "B"]
+        font.groups["public.kern2.c2"] = ["X", "Y"]
+        font.kerning.update(kerning)
+        font.lib["public.glyphOrder"] = [".notdef", "A", "B", "X", "Y"]
+        return font
+
+    regularKerning = {
+        ("public.kern1.c1", "public.kern2.c2"): 50,  # class-to-class (general)
+        ("public.kern1.c1", "X"): 30,  # class-to-glyph exception
+    }
+    if coverAllMembers:
+        regularKerning[("public.kern1.c1", "Y")] = 30  # class-to-glyph also covers Y
+    regular = makeMaster(regularKerning)
+    # bold adds the glyph-to-class exception (A, @c2) = 70
+    bold = makeMaster({**regularKerning, ("A", "public.kern2.c2"): 70})
+
+    designspace = designspaceLib.DesignSpaceDocument()
+    axis = designspace.newAxisDescriptor()
+    axis.name, axis.tag = "Weight", "wght"
+    axis.minimum, axis.default, axis.maximum = 0, 0, 1000
+    designspace.addAxis(axis)
+    for font, location, name in [(regular, 0, "regular"), (bold, 1000, "bold")]:
+        source = designspace.newSourceDescriptor()
+        source.font = font
+        source.location = {"Weight": location}
+        source.name = source.styleName = name
+        source.familyName = "Test"
+        designspace.addSource(source)
+    return designspace
+
+
+def test_variable_kern_partial_master_exception(FontClass):
+    # A glyph-to-class exception present in only some masters must be resolved
+    # per cell and emitted as its own pair ("pos A X ..."), not as a single
+    # "enum pos A @kern2.c2 ..." with the class-to-class value backfilled where
+    # the exception is absent. That backfill, being glyph-to-class, would shadow
+    # the competing class-to-glyph exception and render a phantom value.
+    tmp = io.StringIO()
+    designspace = _makePartialExceptionDesignSpace(FontClass)
+    compileVariableTTF(designspace, debugFeatureFile=tmp)
+    assert dedent("\n" + tmp.getvalue()) == dedent("""
+        @kern1.Latn.c1 = [A B];
+        @kern2.Latn.c2 = [X Y];
+
+        lookup kern_Latn {
+            lookupflag IgnoreMarks;
+            pos A X (wght=0:30 wght=1000:70);
+            pos A Y (wght=0:50 wght=1000:70);
+            enum pos @kern1.Latn.c1 X 30;
+            pos @kern1.Latn.c1 @kern2.Latn.c2 50;
+        } kern_Latn;
+
+        feature kern {
+            script DFLT;
+            language dflt;
+            lookup kern_Latn;
+
+            script latn;
+            language dflt;
+            lookup kern_Latn;
+        } kern;
+""")
+
+
+def test_variable_kern_uniform_override_exception(FontClass):
+    # When the class-to-glyph exception covers every member of the second-side
+    # class, all overlap cells resolve to the same value, so nothing diverges and
+    # the compact "enum pos A @kern2.c2 ..." form is kept. It must still carry the
+    # agreed cell value (30 at the default), not the class-to-class value (50)
+    # backfilled where the glyph-to-class exception is absent. The backfill would
+    # shadow the class-to-glyph exceptions on every cell at the default -- a
+    # phantom even though no two cells disagree with each other.
+    tmp = io.StringIO()
+    designspace = _makePartialExceptionDesignSpace(FontClass, coverAllMembers=True)
+    compileVariableTTF(designspace, debugFeatureFile=tmp)
+    assert dedent("\n" + tmp.getvalue()) == dedent("""
+        @kern1.Latn.c1 = [A B];
+        @kern2.Latn.c2 = [X Y];
+
+        lookup kern_Latn {
+            lookupflag IgnoreMarks;
+            enum pos A @kern2.Latn.c2 (wght=0:30 wght=1000:70);
+            enum pos @kern1.Latn.c1 X 30;
+            enum pos @kern1.Latn.c1 Y 30;
+            pos @kern1.Latn.c1 @kern2.Latn.c2 50;
+        } kern_Latn;
+
+        feature kern {
+            script DFLT;
+            language dflt;
+            lookup kern_Latn;
+
+            script latn;
+            language dflt;
+            lookup kern_Latn;
+        } kern;
+""")
+
+
 def test_variable_features(FontClass):
     tmp = io.StringIO()
     designspace = designspaceLib.DesignSpaceDocument.fromfile(


### PR DESCRIPTION
Fixes #988

A glyph-to-class kerning exception present in only some masters, conflicting with a class-to-glyph exception on a shared kerning matrix cell, caused the current variable kern writer to backfill the partial glyph-to-class exception with a phantom class-to-class value that would shadow the competing class-to-glyph exception.

The fix resolves glyph-to-class values per individual glyph pairs instead of per key. Each second-side member is resolved against the first glyph for each master (through the normal UFO `lookupKerningValue` cascade), and the members are grouped by the value they land on. When all agree, the pair stays compact and carries the agreed value; when they diverge it's split into one pair per value.

Since #989 moved `getVariableKerningPairs` into a module-level function shared by the default writer and the legacy `kernFeatureWriter2`, the fix covers both.

The first commit has the reproducer test which fails against the current writer, and will pass once the next commit lands.