### PR TITLE
[compile] Populate glyf.glyphs directly to avoid O(n^2) build

### DIFF
--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -1861,7 +1861,10 @@ class OutlineTTFCompiler(BaseOutlineCompiler):
         for name in sorted(self.glyphOrder, key=lambda n: maxComponentDepths.get(n, 0)):
             ttGlyph = ttGlyphs[name]
             self.instructionCompiler.compileGlyphInstructions(ttGlyph, name)
-            glyf[name] = ttGlyph
+            # assign the inner dict directly instead of via glyf[name] = ...; the latter
+            # checks membership against glyphOrder on every assignment and is O(n^2)
+            # for the whole font.
+            glyf.glyphs[name] = ttGlyph
 
         # update various maxp fields based on glyf without needing to compile the font
         if "maxp" in self.otf:


### PR DESCRIPTION
`setupTable_glyf` already fills glyf.glyphOrder with the complete order, then assigned each glyph with `glyf[name] = ttGlyph`.

The problem is fontTools' `glyf.__setitem__` scans glyphOrder for membership on every call, so this was O(n^2)  for the whole font (about 3 seconds of pure list scanning for a 40k-glyph font, and even worse for beyond-64k masters in #987).

We can avoid this by writing the inner `glyf.glyphs` dict directly (which incidentally is what fonttools' FontBuilder does as well). That's all the `__setitem__` method does when a glyph name is already in glyphOrder.

Building the glyf table becomes O(n) indipendent of the installed fontTools version. I will propose a matching speedup separately in fonttools, but ufo2ft needs not depend on it.