### PR TITLE
Fix interpolatable CFF closing lines

### DIFF
--- a/Lib/ufo2ft/constants.py
+++ b/Lib/ufo2ft/constants.py
@@ -18,6 +18,8 @@ GLYPHS_PREFIX = "com.schriftgestaltung."
 
 FILTERS_KEY = UFO2FT_PREFIX + "filters"
 
+EXPLICIT_CLOSING_LINE_KEY = UFO2FT_PREFIX + "explicitClosingLine"
+
 MTI_FEATURES_PREFIX = UFO2FT_PREFIX + "mtiFeatures"
 
 FEATURE_WRITERS_KEY = UFO2FT_PREFIX + "featureWriters"

--- a/Lib/ufo2ft/filters/__init__.py
+++ b/Lib/ufo2ft/filters/__init__.py
@@ -13,6 +13,7 @@ from .decomposeTransformedComponents import (
     DecomposeTransformedComponentsIFilter,
 )
 from .dottedCircle import DottedCircleFilter
+from .explicitClosingLine import ExplicitClosingLineIFilter
 from .explodeColorLayerGlyphs import ExplodeColorLayerGlyphsFilter
 from .flattenComponents import FlattenComponentsFilter, FlattenComponentsIFilter
 from .propagateAnchors import PropagateAnchorsFilter, PropagateAnchorsIFilter
@@ -31,6 +32,7 @@ __all__ = [
     "DecomposeTransformedComponentsFilter",
     "DecomposeTransformedComponentsIFilter",
     "DottedCircleFilter",
+    "ExplicitClosingLineIFilter",
     "ExplodeColorLayerGlyphsFilter",
     "FlattenComponentsFilter",
     "FlattenComponentsIFilter",

--- a/Lib/ufo2ft/filters/explicitClosingLine.py
+++ b/Lib/ufo2ft/filters/explicitClosingLine.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fontTools.pens.recordingPen import RecordingPointPen
+
+from ufo2ft.constants import EXPLICIT_CLOSING_LINE_KEY
+from ufo2ft.filters import BaseIFilter
+
+if TYPE_CHECKING:
+    from ufoLib2.objects import Glyph
+
+
+class ExplicitClosingLineIFilter(BaseIFilter):
+    """Mark CFF glyphs that need compatible explicit closing lines."""
+
+    _pre = True
+
+    def filter(self, glyphName: str, glyphs: list[Glyph]) -> bool:
+        if len(glyphs) < 2:
+            return False
+
+        needs_explicit_closing = _needs_explicit_closing_lines(glyphs)
+        modified = False
+        for glyph in glyphs:
+            if needs_explicit_closing:
+                if glyph.lib.get(EXPLICIT_CLOSING_LINE_KEY) is not True:
+                    glyph.lib[EXPLICIT_CLOSING_LINE_KEY] = True
+                    modified = True
+            elif glyph.lib.pop(EXPLICIT_CLOSING_LINE_KEY, None) is not None:
+                modified = True
+        return modified
+
+
+def _needs_explicit_closing_lines(glyphs) -> bool:
+    contours = [_get_contours(glyph) for glyph in glyphs]
+    if not contours:
+        return False
+
+    num_contours = len(contours[0])
+    if not num_contours or any(
+        len(glyph_contours) != num_contours for glyph_contours in contours
+    ):
+        return False
+
+    for contour_index in range(num_contours):
+        contour_group = [glyph_contours[contour_index] for glyph_contours in contours]
+        point_types = [
+            tuple(point_type for _, point_type in contour) for contour in contour_group
+        ]
+        if any(types != point_types[0] for types in point_types):
+            continue
+
+        explicit_closing = [
+            _has_explicit_closing_line(contour) for contour in contour_group
+        ]
+        if any(explicit_closing) and not all(explicit_closing):
+            return True
+
+    return False
+
+
+def _get_contours(glyph):
+    pen = RecordingPointPen()
+    glyph.drawPoints(pen)
+
+    contours = []
+    current_contour = None
+    for operator, args, _kwargs in pen.value:
+        if operator == "beginPath":
+            current_contour = []
+        elif operator == "addPoint":
+            if current_contour is None:
+                continue
+            pt, segment_type = args[:2]
+            current_contour.append((pt, segment_type))
+        elif operator == "endPath":
+            if current_contour is not None:
+                contours.append(current_contour)
+                current_contour = None
+
+    return contours
+
+
+def _first_oncurve_index(contour):
+    for i, (_, segment_type) in enumerate(contour):
+        if segment_type is not None:
+            return i
+    return None
+
+
+def _has_explicit_closing_line(contour) -> bool:
+    if not contour or contour[0][1] == "move":
+        return False
+
+    first_oncurve = _first_oncurve_index(contour)
+    if first_oncurve is None:
+        return False
+
+    first_point, first_type = contour[first_oncurve]
+    if first_type != "line":
+        return False
+
+    previous_point, _ = contour[first_oncurve - 1]
+    return first_point == previous_point

--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -16,7 +16,7 @@ from fontTools.cffLib import (
 from fontTools.misc.arrayTools import unionRect
 from fontTools.misc.roundTools import noRound, otRound
 from fontTools.pens.boundsPen import ControlBoundsPen
-from fontTools.pens.pointPen import SegmentToPointPen
+from fontTools.pens.pointPen import PointToSegmentPen, SegmentToPointPen
 from fontTools.pens.reverseContourPen import ReverseContourPen
 from fontTools.pens.t2CharStringPen import T2CharStringPen
 from fontTools.pens.ttGlyphPen import TTGlyphPointPen
@@ -30,6 +30,7 @@ from ufo2ft.constants import (
     COLOR_LAYERS_KEY,
     COLOR_PALETTES_KEY,
     COLR_CLIP_BOXES_KEY,
+    EXPLICIT_CLOSING_LINE_KEY,
     GLYPHS_MATH_CONSTANTS_KEY,
     GLYPHS_MATH_EXTENDED_SHAPE_KEY,
     GLYPHS_MATH_PREFIX,
@@ -1458,7 +1459,10 @@ class OutlineOTFCompiler(BaseOutlineCompiler):
         if width is not None:
             width = otRound(width)
         pen = T2CharStringPen(width, self.allGlyphs, roundTolerance=self.roundTolerance)
-        glyph.draw(pen)
+        if glyph.lib.get(EXPLICIT_CLOSING_LINE_KEY):
+            glyph.drawPoints(PointToSegmentPen(pen, outputImpliedClosingLine=True))
+        else:
+            glyph.draw(pen)
         charString = pen.getCharString(private, globalSubrs, optimize=self.optimizeCFF)
         return charString
 

--- a/Lib/ufo2ft/preProcessor.py
+++ b/Lib/ufo2ft/preProcessor.py
@@ -16,6 +16,7 @@ from ufo2ft.filters.decomposeComponents import (
     DecomposeComponentsFilter,
     DecomposeComponentsIFilter,
 )
+from ufo2ft.filters.explicitClosingLine import ExplicitClosingLineIFilter
 from ufo2ft.fontInfoData import getAttrWithFallback
 from ufo2ft.util import _GlyphSet, _hasOverflowingComponentTransforms, zip_strict
 
@@ -595,6 +596,8 @@ class OTFInterpolatablePreProcessor(BaseInterpolatablePreProcessor):
         # this interpolatable filter will only run once on all the glyphSets,
         # (see _try_as_interpolatable_filter)
         decompose = DecomposeComponentsIFilter()
+        explicitClosingLine = ExplicitClosingLineIFilter()
         for filters in filterses:
             filters.append(decompose)
+            filters.append(explicitClosingLine)
         return filterses

--- a/tests/filters/explicitClosingLine_test.py
+++ b/tests/filters/explicitClosingLine_test.py
@@ -1,0 +1,164 @@
+from fontTools.pens.pointPen import PointToSegmentPen
+from fontTools.pens.recordingPen import RecordingPen, RecordingPointPen
+
+from ufo2ft.constants import EXPLICIT_CLOSING_LINE_KEY
+from ufo2ft.filters.explicitClosingLine import ExplicitClosingLineIFilter
+
+
+def _make_font(FontClass, glyph_name, contours):
+    font = FontClass()
+    glyph = font.newGlyph(glyph_name)
+    glyph.width = 500
+    pen = glyph.getPointPen()
+    for contour in contours:
+        pen.beginPath()
+        for point in contour:
+            if isinstance(point[0], tuple):
+                point, segment_type = point
+            else:
+                segment_type = "line"
+            pen.addPoint(point, segment_type)
+        pen.endPath()
+    return font
+
+
+def _line_count(glyph, outputImpliedClosingLine=False):
+    return _operator_count(glyph, "lineTo", outputImpliedClosingLine)
+
+
+def _curve_count(glyph, outputImpliedClosingLine=False):
+    return _operator_count(glyph, "curveTo", outputImpliedClosingLine)
+
+
+def _operator_count(glyph, operator_name, outputImpliedClosingLine=False):
+    pen = RecordingPen()
+    glyph.drawPoints(
+        PointToSegmentPen(pen, outputImpliedClosingLine=outputImpliedClosingLine)
+    )
+    return sum(operator == operator_name for operator, _ in pen.value)
+
+
+def _point_count(glyph):
+    pen = RecordingPointPen()
+    glyph.drawPoints(pen)
+    return sum(operator == "addPoint" for operator, _, _ in pen.value)
+
+
+def test_mismatched_explicit_closing_line_gets_duplicate_point(FontClass):
+    font1 = _make_font(
+        FontClass,
+        "o",
+        [
+            [
+                (256, 320),
+                (288, 288),
+                (288, 160),
+                (192, 128),
+                (224, 288),
+                (256, 320),
+            ]
+        ],
+    )
+    font2 = _make_font(
+        FontClass,
+        "o",
+        [
+            [
+                (512, 320),
+                (544, 288),
+                (544, 160),
+                (320, 128),
+                (352, 288),
+                (384, 320),
+            ]
+        ],
+    )
+
+    modified = ExplicitClosingLineIFilter()([font1, font2])
+
+    assert modified == {"o"}
+    assert font1["o"].lib[EXPLICIT_CLOSING_LINE_KEY] is True
+    assert font2["o"].lib[EXPLICIT_CLOSING_LINE_KEY] is True
+    assert _point_count(font1["o"]) == _point_count(font2["o"]) == 6
+    assert _line_count(font1["o"]) != _line_count(font2["o"])
+    assert (
+        _line_count(font1["o"], outputImpliedClosingLine=True)
+        == _line_count(font2["o"], outputImpliedClosingLine=True)
+        == 6
+    )
+
+
+def test_mismatched_explicit_closing_line_with_curves_gets_marker(FontClass):
+    font1 = _make_font(
+        FontClass,
+        "o",
+        [
+            [
+                ((256, 320), "line"),
+                ((288, 288), None),
+                ((288, 160), None),
+                ((192, 128), "curve"),
+                ((224, 288), "line"),
+                ((256, 320), "line"),
+            ]
+        ],
+    )
+    font2 = _make_font(
+        FontClass,
+        "o",
+        [
+            [
+                ((512, 320), "line"),
+                ((544, 288), None),
+                ((544, 160), None),
+                ((320, 128), "curve"),
+                ((352, 288), "line"),
+                ((384, 320), "line"),
+            ]
+        ],
+    )
+
+    modified = ExplicitClosingLineIFilter()([font1, font2])
+
+    assert modified == {"o"}
+    assert font1["o"].lib[EXPLICIT_CLOSING_LINE_KEY] is True
+    assert font2["o"].lib[EXPLICIT_CLOSING_LINE_KEY] is True
+    assert _point_count(font1["o"]) == _point_count(font2["o"]) == 6
+    assert _line_count(font1["o"]) != _line_count(font2["o"])
+    assert _curve_count(font1["o"]) == _curve_count(font2["o"]) == 1
+    assert (
+        _line_count(font1["o"], outputImpliedClosingLine=True)
+        == _line_count(font2["o"], outputImpliedClosingLine=True)
+        == 3
+    )
+    assert (
+        _curve_count(font1["o"], outputImpliedClosingLine=True)
+        == _curve_count(font2["o"], outputImpliedClosingLine=True)
+        == 1
+    )
+
+
+def test_matching_implied_closing_lines_are_unchanged(FontClass):
+    font1 = _make_font(FontClass, "a", [[(0, 0), (100, 0), (100, 100)]])
+    font2 = _make_font(FontClass, "a", [[(0, 0), (200, 0), (200, 100)]])
+
+    modified = ExplicitClosingLineIFilter()([font1, font2])
+
+    assert modified == set()
+    assert EXPLICIT_CLOSING_LINE_KEY not in font1["a"].lib
+    assert EXPLICIT_CLOSING_LINE_KEY not in font2["a"].lib
+    assert _point_count(font1["a"]) == 3
+    assert _point_count(font2["a"]) == 3
+
+
+def test_matching_explicit_closing_lines_are_unchanged(FontClass):
+    font1 = _make_font(FontClass, "a", [[(0, 0), (100, 0), (0, 0)]])
+    font2 = _make_font(FontClass, "a", [[(10, 0), (200, 0), (10, 0)]])
+
+    modified = ExplicitClosingLineIFilter()([font1, font2])
+
+    assert modified == set()
+    assert EXPLICIT_CLOSING_LINE_KEY not in font1["a"].lib
+    assert EXPLICIT_CLOSING_LINE_KEY not in font2["a"].lib
+    assert _point_count(font1["a"]) == 3
+    assert _point_count(font2["a"]) == 3


### PR DESCRIPTION
Compile interpolatable CFF masters with PointToSegmentPen(outputImpliedClosingLine=True) so compatible point contours do not produce mismatched Type 2 command streams when one master's contour end overlaps its start point.

Fixes fonttools/fonttools#4114.