### PR TITLE
[kernFeatureWriter] emit per-cell kern exception pairs individually

### DIFF
--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
@@ -842,10 +842,9 @@ def getVariableKerningPairs(
           backfills the class-to-class value, and since glyph-to-class
           outranks class-to-glyph that backfill would shadow a competing
           class-to-glyph exception on a shared cell -- rendering there a value
-          the source never resolves to (a "phantom"). So group the members by
-          the value each cell lands on and yield one compact class pair when
-          they all agree, else one pair per value group (a lone glyph, or an
-          inline class of the members that agree).
+          the source never resolves to (a "phantom"). So resolve each member
+          against the cascade and emit it as its own pair, carrying the value
+          that cell actually lands on.
           See https://github.com/googlefonts/ufo2ft/issues/988.
         """
         firstIsClass = side1 in side1Classes
@@ -859,25 +858,13 @@ def getVariableKerningPairs(
 
         if not firstIsClass and secondIsClass:
             # getKerningGroups prunes class members to the glyph set, so
-            # every value group is non-empty.
-            members = side2Classes[side2]
-            members_by_value: dict[tuple, list[str]] = {}
-            scalar_by_value: dict[tuple, VariableScalar] = {}
-            for member in members:
+            # every member resolves to a real pair. Members that agree on a
+            # value could share an inline class, but that only compacts the
+            # debug feature file: enum-expanded and per-glyph pairs compile to
+            # identical GPOS, so keep it simple and emit one pair per member.
+            for member in side2Classes[side2]:
                 scalar = build_scalar(side1, member)
-                signature = tuple(sorted(scalar.values.items()))
-                members_by_value.setdefault(signature, []).append(member)
-                scalar_by_value[signature] = scalar
-
-            if len(members_by_value) == 1:
-                [scalar] = scalar_by_value.values()
-                yield KerningPair(side1, members, collapse_varscalar(scalar))
-            else:
-                for signature, group in members_by_value.items():
-                    group.sort()
-                    side2repr = group[0] if len(group) == 1 else tuple(group)
-                    scalar = scalar_by_value[signature]
-                    yield KerningPair(side1, side2repr, collapse_varscalar(scalar))
+                yield KerningPair(side1, member, collapse_varscalar(scalar))
             return
 
         s1 = side1Classes[side1] if firstIsClass else side1

--- a/tests/featureWriters/variableFeatureWriter_test.py
+++ b/tests/featureWriters/variableFeatureWriter_test.py
@@ -109,12 +109,11 @@ def test_variable_kern_partial_master_exception(FontClass):
 
 def test_variable_kern_uniform_override_exception(FontClass):
     # When the class-to-glyph exception covers every member of the second-side
-    # class, all overlap cells resolve to the same value, so nothing diverges and
-    # the compact "enum pos A @kern2.c2 ..." form is kept. It must still carry the
-    # agreed cell value (30 at the default), not the class-to-class value (50)
-    # backfilled where the glyph-to-class exception is absent. The backfill would
-    # shadow the class-to-glyph exceptions on every cell at the default -- a
-    # phantom even though no two cells disagree with each other.
+    # class, all overlap cells resolve to the same value. Each member is emitted
+    # as its own pair carrying that agreed cell value (30 at the default), not the
+    # class-to-class value (50) backfilled where the glyph-to-class exception is
+    # absent. The backfill would shadow the class-to-glyph exceptions on every
+    # cell at the default -- a phantom even though no two cells disagree.
     tmp = io.StringIO()
     designspace = _makePartialExceptionDesignSpace(FontClass, coverAllMembers=True)
     compileVariableTTF(designspace, debugFeatureFile=tmp)
@@ -124,7 +123,8 @@ def test_variable_kern_uniform_override_exception(FontClass):
 
         lookup kern_Latn {
             lookupflag IgnoreMarks;
-            enum pos A @kern2.Latn.c2 (wght=0:30 wght=1000:70);
+            pos A X (wght=0:30 wght=1000:70);
+            pos A Y (wght=0:30 wght=1000:70);
             enum pos @kern1.Latn.c1 X 30;
             enum pos @kern1.Latn.c1 Y 30;
             pos @kern1.Latn.c1 @kern2.Latn.c2 50;


### PR DESCRIPTION
When resolving a glyph-to-class kern exception cell by cell, the variable writer regrouped members that agreed on a value into a compact enum-class rule. enum-expanded and per-glyph pairs compile to **identical GPOS**, so the **regrouping only compacts the debug feature file**, at the cost of extra logic. Emit each member as its own pair instead. This simplifies the logic and drops an asymmetry that the per-master kern group reconciliation work (#992) would otherwise have to mirror on the first side too.