### PR TITLE
[kernFeatureWriter] reconcile divergent per-master kern groups in variable path

### DIFF
--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import itertools
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from types import SimpleNamespace
-from typing import Any, Iterator, Mapping
+from typing import Any, Iterator, Mapping, NamedTuple
 
 from fontTools import unicodedata
 from fontTools.designspaceLib import DesignSpaceDocument
@@ -44,6 +44,8 @@ LTR_BIDI_TYPES = {"L", "AN", "EN"}
 AMBIGUOUS_BIDIS = {"R", "L"}
 COMMON_SCRIPTS_SET = {COMMON_SCRIPT}
 COMMON_CLASS_NAME = "Default"
+
+_MAX_LOGGED_DIVERGENT_GLYPHS = 10
 
 
 def unicodeBidiType(uv):
@@ -337,75 +339,11 @@ class KernFeatureWriter(BaseFeatureWriter):
     def getKerningGroups(
         self,
     ) -> tuple[Mapping[str, tuple[str, ...]], Mapping[str, tuple[str, ...]]]:
-        allGlyphs = self.context.glyphSet
-
-        side1Groups: dict[str, tuple[str, ...]] = {}
-        side1Membership: dict[str, str] = {}
-        side2Groups: dict[str, tuple[str, ...]] = {}
-        side2Membership: dict[str, str] = {}
-
-        if isinstance(self.context.font, DesignSpaceDocument):
-            fonts = [source.font for source in self.context.font.sources]
-        else:
-            fonts = [self.context.font]
-
-        for font in fonts:
-            assert font is not None
-            for name, members in font.groups.items():
-                # prune non-existent or skipped glyphs
-                members = {g for g in members if g in allGlyphs}
-                # skip empty groups
-                if not members:
-                    continue
-                # skip groups without UFO3 public.kern{1,2} prefix
-                if name.startswith(SIDE1_PREFIX):
-                    name_truncated = name[len(SIDE1_PREFIX) :]
-                    known_members = members.intersection(side1Membership.keys())
-                    if known_members:
-                        for glyph_name in known_members:
-                            original_name_truncated = side1Membership[glyph_name]
-                            if name_truncated != original_name_truncated:
-                                log_regrouped_glyph(
-                                    "first",
-                                    name,
-                                    original_name_truncated,
-                                    font,
-                                    glyph_name,
-                                )
-                        # Skip the whole group definition if there is any
-                        # overlap problem.
-                        continue
-                    group = side1Groups.get(name)
-                    if group is None:
-                        side1Groups[name] = tuple(sorted(members))
-                        for member in members:
-                            side1Membership[member] = name_truncated
-                    elif set(group) != members:
-                        log_redefined_group("left", name, group, font, members)
-                elif name.startswith(SIDE2_PREFIX):
-                    name_truncated = name[len(SIDE2_PREFIX) :]
-                    known_members = members.intersection(side2Membership.keys())
-                    if known_members:
-                        for glyph_name in known_members:
-                            original_name_truncated = side2Membership[glyph_name]
-                            if name_truncated != original_name_truncated:
-                                log_regrouped_glyph(
-                                    "second",
-                                    name,
-                                    original_name_truncated,
-                                    font,
-                                    glyph_name,
-                                )
-                        # Skip the whole group definition if there is any
-                        # overlap problem.
-                        continue
-                    group = side2Groups.get(name)
-                    if group is None:
-                        side2Groups[name] = tuple(sorted(members))
-                        for member in members:
-                            side2Membership[member] = name_truncated
-                    elif set(group) != members:
-                        log_redefined_group("right", name, group, font, members)
+        side1Groups, side2Groups, side1Membership, side2Membership = (
+            collectKerningGroups(
+                self.context.font, self.context.glyphSet, self.context.isVariable
+            )
+        )
         self.context.side1Membership = side1Membership
         self.context.side2Membership = side2Membership
         return side1Groups, side2Groups
@@ -418,8 +356,6 @@ class KernFeatureWriter(BaseFeatureWriter):
         if self.context.isVariable:
             return getVariableKerningPairs(
                 self.context.font,
-                side1Classes,
-                side2Classes,
                 self.context.glyphSet,
                 self.options,
             )
@@ -745,34 +681,256 @@ class KernFeatureWriter(BaseFeatureWriter):
                 )
 
 
+# One source's glyph -> group name assignments for a single kern side; lists of
+# these are always parallel to the non-sparse sources they were built from.
+GroupMap = dict[str, str]
+
+
+def _sourceGroupMaps(
+    font: Any, glyphSet: Mapping[str, str]
+) -> tuple[GroupMap, GroupMap]:
+    side1Map: GroupMap = {}
+    side2Map: GroupMap = {}
+    for name, members in font.groups.items():
+        members = {g for g in members if g in glyphSet}
+        if not members:
+            continue
+        if name.startswith(SIDE1_PREFIX):
+            for member in members:
+                side1Map[member] = name
+        elif name.startswith(SIDE2_PREFIX):
+            for member in members:
+                side2Map[member] = name
+    return side1Map, side2Map
+
+
+def _groupMembers(maps: list[GroupMap]) -> dict[str, tuple[str, ...]]:
+    """Invert source maps without dropping overlapping groups.
+
+    Inverting the maps rather than font.groups keeps class membership
+    consistent with value resolution: a glyph in two same-side groups of one
+    source (invalid per UFO3) resolves to the last, lookupKerningValue's own
+    tie-break.
+    """
+    members: dict[str, set[str]] = {}
+    for sourceMap in maps:
+        for glyph, name in sourceMap.items():
+            members.setdefault(name, set()).add(glyph)
+    return {name: tuple(sorted(glyphs)) for name, glyphs in members.items()}
+
+
+def _divergentGlyphs(maps: list[GroupMap]) -> set[str]:
+    """Return glyphs whose group assignment differs between sources.
+
+    Ungrouped or absent in a source counts as a distinct assignment.
+    """
+    divergent: set[str] = set()
+    allGlyphs: set[str] = set()
+    for sourceMap in maps:
+        allGlyphs.update(sourceMap)
+    for glyph in allGlyphs:
+        if len({sourceMap.get(glyph) for sourceMap in maps}) > 1:
+            divergent.add(glyph)
+    return divergent
+
+
+def _refineMembers(
+    members: tuple[str, ...], kernedMaps: list[GroupMap]
+) -> list[tuple[tuple[str | None, ...], tuple[str, ...]]]:
+    """Partition members into refined classes by kerned-group signature.
+
+    A member's signature is its kerned group name in each source (None where it
+    has none); members sharing the same signature form one refined class,
+    returned as a (signature, members) pair. Members are assumed sorted, so
+    output is deterministic. kernedMaps hold only groups referenced by that
+    source's kerning: an unkerned group never reaches the compiled ClassDefs
+    that varLib.merger partitions, so its members count as ungrouped here.
+    Grouping by the per-source signature yields the coarsest common refinement
+    that varLib.merger derives with classifyTools.classify; see ufo2ft#992.
+    """
+    bySignature: dict[tuple[str | None, ...], list[str]] = {}
+    for member in members:
+        signature = tuple(kernedMap.get(member) for kernedMap in kernedMaps)
+        bySignature.setdefault(signature, []).append(member)
+    return sorted(
+        ((signature, tuple(refined)) for signature, refined in bySignature.items()),
+        key=lambda pair: pair[1],
+    )
+
+
+class _KernSource(NamedTuple):
+    location: VariableScalarLocation
+    kerning: Mapping[tuple[str, str], float]
+    side1Map: GroupMap
+    side2Map: GroupMap
+
+
+@dataclass
+class _KernSide:
+    """Per-side (kern1 or kern2) partition state for the variable writer.
+
+    Built from the sources' own group maps, it exposes the group union (which,
+    unlike first-wins merging, never strands glyphs that still need variable
+    values) and refines only classes whose membership diverges across masters.
+    Refining splits a class into refined classes: the largest subsets of its
+    members that share the same kerned group in every source (a consistent
+    class stays whole); pairing side1 and side2 refined classes reproduces
+    varLib.merger's refined class matrix, each pair one cell of it. The full
+    maps carry what the sources declare, the kerned maps
+    what the varLib.merge path (variableFeatures=False) sees in the compiled
+    per-master ClassDefs: divergence is detected on the former, the refined
+    partition computed on the latter.
+    """
+
+    kernedMaps: list[GroupMap]
+    groups: dict[str, tuple[str, ...]]
+    divergentGlyphs: set[str]
+    divergentClasses: set[str]
+    _refinedClasses: dict[str, list[tuple[tuple[str | None, ...], tuple[str, ...]]]] = (
+        field(default_factory=dict, init=False)
+    )
+
+    @classmethod
+    def fromSources(cls, sources: list[_KernSource], side: int) -> _KernSide:
+        """Build one side's state; side is 1 or 2, matching kern1/kern2."""
+        assert side in (1, 2)
+        maps = [source.side1Map if side == 1 else source.side2Map for source in sources]
+        # Refine against groups referenced by kerning only; unkerned groups do
+        # not appear in compiled ClassDefs, so treating them as ungrouped
+        # matches varLib.merger.
+        kernedMaps = []
+        for source, sourceMap in zip(sources, maps):
+            kerned = {key[side - 1] for key in source.kerning}
+            kernedMaps.append(
+                {glyph: name for glyph, name in sourceMap.items() if name in kerned}
+            )
+        groups = _groupMembers(maps)
+        divergentGlyphs = _divergentGlyphs(maps)
+        divergentClasses = {
+            name
+            for name, members in groups.items()
+            if divergentGlyphs.intersection(members)
+        }
+        return cls(kernedMaps, groups, divergentGlyphs, divergentClasses)
+
+    def refine(
+        self, name: str
+    ) -> Iterator[tuple[str | tuple[str | None, ...], str | tuple[str, ...]]]:
+        """Yield (names, glyphs) for one glyph or group name of a kern key.
+
+        names feeds build_scalar -- either one name looked up in every source,
+        or a tuple with one name (or None) per source; glyphs is the emitted
+        KerningPair side. A divergent class is split into its refined classes,
+        singletons included, to match varLib.merger's class-based GPOS.
+        """
+        members = self.groups.get(name)
+        if members is None:  # a bare glyph, not a class
+            yield name, name
+            return
+        if name not in self.divergentClasses:
+            yield name, members
+            return
+        if name not in self._refinedClasses:
+            self._refinedClasses[name] = _refineMembers(members, self.kernedMaps)
+        yield from self._refinedClasses[name]
+
+
+def collectKerningGroups(designspaceOrFont, glyphSet, isVariable) -> tuple[
+    dict[str, tuple[str, ...]],
+    dict[str, tuple[str, ...]],
+    dict[str, str],
+    dict[str, str],
+]:
+    """Merge kern groups for both kern writers.
+
+    Returns merged side1/side2 group maps plus glyph -> truncated-group-name
+    memberships. Memberships are backfilled from groups that first-source-wins
+    merging drops, so refined classes can still be named.
+    """
+    allGlyphs = glyphSet
+
+    side1Groups: dict[str, tuple[str, ...]] = {}
+    side1Membership: dict[str, str] = {}
+    side2Groups: dict[str, tuple[str, ...]] = {}
+    side2Membership: dict[str, str] = {}
+    # Fallback names for glyphs stranded by first-wins merging, recorded before
+    # any drop so a stranded glyph can still name its refined class.
+    side1Fallback: dict[str, str] = {}
+    side2Fallback: dict[str, str] = {}
+
+    if isinstance(designspaceOrFont, DesignSpaceDocument):
+        fonts = [source.font for source in designspaceOrFont.sources]
+    else:
+        fonts = [designspaceOrFont]
+
+    # Variable builds reconcile cross-source overlaps later, so only static
+    # builds warn about dropped groups.
+    warn_on_drop = not isVariable
+
+    for font in fonts:
+        assert font is not None
+        for name, members in font.groups.items():
+            # prune non-existent or skipped glyphs
+            members = {g for g in members if g in allGlyphs}
+            # skip empty groups
+            if not members:
+                continue
+            if name.startswith(SIDE1_PREFIX):
+                prefix = SIDE1_PREFIX
+                groups, membership = side1Groups, side1Membership
+                fallback = side1Fallback
+                side_label = "first"
+            elif name.startswith(SIDE2_PREFIX):
+                prefix = SIDE2_PREFIX
+                groups, membership = side2Groups, side2Membership
+                fallback = side2Fallback
+                side_label = "second"
+            else:
+                continue
+            name_truncated = name[len(prefix) :]
+            for member in members:
+                fallback.setdefault(member, name_truncated)
+            known_members = members.intersection(membership.keys())
+            if known_members:
+                if warn_on_drop:
+                    for glyph_name in known_members:
+                        original_name_truncated = membership[glyph_name]
+                        if name_truncated != original_name_truncated:
+                            log_regrouped_glyph(
+                                side_label,
+                                name,
+                                original_name_truncated,
+                                font,
+                                glyph_name,
+                            )
+                # Skip the whole group definition if there is any overlap problem.
+                continue
+            group = groups.get(name)
+            if group is None:
+                groups[name] = tuple(sorted(members))
+                for member in members:
+                    membership[member] = name_truncated
+            elif set(group) != members and warn_on_drop:
+                log_redefined_group(side_label, name, group, font, members)
+    # Apply the fallback names last, keeping already-merged names canonical.
+    # Deferred to here (not written mid-merge) because the merge reads
+    # membership to decide drops.
+    for member, name_truncated in side1Fallback.items():
+        side1Membership.setdefault(member, name_truncated)
+    for member, name_truncated in side2Fallback.items():
+        side2Membership.setdefault(member, name_truncated)
+    return side1Groups, side2Groups, side1Membership, side2Membership
+
+
 def getVariableKerningPairs(
     designspace: DesignSpaceDocument,
-    side1Classes: Mapping[str, tuple[str, ...]],
-    side2Classes: Mapping[str, tuple[str, ...]],
     glyphSet: Mapping[str, str],
     options: SimpleNamespace,
 ) -> list[KerningPair]:
     quantization = options.quantization
 
-    # Gather utility variables for faster kerning lookups.
-    # TODO: Do we construct these in code elsewhere?
-    assert not (set(side1Classes) & set(side2Classes))
-    unified_groups = {**side1Classes, **side2Classes}
-
-    glyphToFirstGroup = {
-        glyph_name: group_name  # TODO: Is this overwrite safe? User input is adversarial
-        for group_name, glyphs in side1Classes.items()
-        for glyph_name in glyphs
-    }
-    glyphToSecondGroup = {
-        glyph_name: group_name
-        for group_name, glyphs in side2Classes.items()
-        for glyph_name in glyphs
-    }
-
-    # Cache each non-sparse source's kerning keyed by its VariableScalar
-    # location. Sparse sources (those with a layerName) carry no kerning.
-    sources = []
+    # Resolve each non-sparse source against its own group maps.
+    sources: list[_KernSource] = []
     for source in designspace.sources:
         if source.layerName is not None:
             continue
@@ -780,7 +938,23 @@ def getVariableKerningPairs(
         location = VariableScalarLocation(
             get_userspace_location(designspace, source.location)
         )
-        sources.append((location, source.font.kerning))
+        side1Map, side2Map = _sourceGroupMaps(source.font, glyphSet)
+        sources.append(_KernSource(location, source.font.kerning, side1Map, side2Map))
+
+    kern1 = _KernSide.fromSources(sources, 1)
+    kern2 = _KernSide.fromSources(sources, 2)
+
+    divergent = kern1.divergentGlyphs | kern2.divergentGlyphs
+    if divergent:
+        # Avoid listing hundreds of glyph names in one log record.
+        shown = ", ".join(sorted(divergent)[:_MAX_LOGGED_DIVERGENT_GLYPHS])
+        if len(divergent) > _MAX_LOGGED_DIVERGENT_GLYPHS:
+            shown += f", ... ({len(divergent) - _MAX_LOGGED_DIVERGENT_GLYPHS} more)"
+        LOGGER.info(
+            "Reconciling kerning groups that differ across masters for %d glyph(s): %s",
+            len(divergent),
+            shown,
+        )
 
     # We may need to provide a default location value to the variation
     # model, find out where that is.
@@ -803,27 +977,38 @@ def getVariableKerningPairs(
     #           Always interpolate from other locations, ignoring more
     #           general pairs that this one excepts.
     # See discussion: https://github.com/googlefonts/ufo2ft/pull/635
-    all_pairs: set[tuple[str, str]] = set()
-    for _, kerning in sources:
-        all_pairs |= set(kerning)
+    all_pairs = {pair for source in sources for pair in source.kerning}
 
-    def build_scalar(side1: str, side2: str) -> VariableScalar:
-        """Resolve the (side1, side2) pair at every source with the DS+UFO
-        kerning cascade and return the resulting VariableScalar."""
+    def build_scalar(side1Names, side2Names) -> VariableScalar:
+        """Resolve per-source glyph/group names with the DS+UFO kerning cascade.
+
+        A bare name is used for every source; a tuple supplies one name (or
+        None) per source. Glyph names use the full cascade; group names match
+        only class-level entries; None (no kerned class in that source)
+        resolves to 0, varLib.merger's class 0.
+        """
+        if isinstance(side1Names, str):
+            side1Names = (side1Names,) * len(sources)
+        if isinstance(side2Names, str):
+            side2Names = (side2Names,) * len(sources)
         scalar = VariableScalar()
-        for location, kerning in sources:
+        for source, side1, side2 in zip(sources, side1Names, side2Names):
+            if side1 is None or side2 is None:
+                value = 0
+            else:
+                value = quantize(
+                    lookupKerningValue(
+                        (side1, side2),
+                        source.kerning,
+                        {},  # groups unused when explicit maps are passed
+                        glyphToFirstGroup=source.side1Map,
+                        glyphToSecondGroup=source.side2Map,
+                    ),
+                    quantization,
+                )
             # NOTE: assign .values directly rather than .add_value, which
             # instantiates a new VariableScalarLocation on each call.
-            scalar.values[location] = quantize(
-                lookupKerningValue(
-                    (side1, side2),
-                    kerning,
-                    unified_groups,
-                    glyphToFirstGroup=glyphToFirstGroup,
-                    glyphToSecondGroup=glyphToSecondGroup,
-                ),
-                quantization,
-            )
+            scalar.values[source.location] = value
         # Anchor the default (the model's reference) at 0 when no source
         # sets it; it's a base value, never interpolated.
         if default_location not in scalar.values:
@@ -846,9 +1031,11 @@ def getVariableKerningPairs(
           against the cascade and emit it as its own pair, carrying the value
           that cell actually lands on.
           See https://github.com/googlefonts/ufo2ft/issues/988.
+        - a class whose membership diverges across masters is refined into the
+          per-master common refinement (see _KernSide.refine, #992).
         """
-        firstIsClass = side1 in side1Classes
-        secondIsClass = side2 in side2Classes
+        firstIsClass = side1 in kern1.groups
+        secondIsClass = side2 in kern2.groups
 
         # Skip pairs that reference a missing glyph.
         if not firstIsClass and side1 not in glyphSet:
@@ -857,24 +1044,28 @@ def getVariableKerningPairs(
             return
 
         if not firstIsClass and secondIsClass:
-            # getKerningGroups prunes class members to the glyph set, so
-            # every member resolves to a real pair. Members that agree on a
-            # value could share an inline class, but that only compacts the
-            # debug feature file: enum-expanded and per-glyph pairs compile to
+            # The source group maps prune members to the glyph set, so every
+            # member resolves to a real pair. Members that agree on a value
+            # could share an inline class, but that only compacts the debug
+            # feature file: enum-expanded and per-glyph pairs compile to
             # identical GPOS, so keep it simple and emit one pair per member.
-            for member in side2Classes[side2]:
+            # Per-member resolution also covers divergent membership -- each
+            # member takes its own per-source value -- so no refinement is
+            # needed here.
+            for member in kern2.groups[side2]:
                 scalar = build_scalar(side1, member)
                 yield KerningPair(side1, member, collapse_varscalar(scalar))
             return
 
-        s1 = side1Classes[side1] if firstIsClass else side1
-        s2 = side2Classes[side2] if secondIsClass else side2
-        pair = KerningPair(s1, s2, collapse_varscalar(build_scalar(side1, side2)))
-        # Ignore zero-valued class kern pairs. They are the most general
-        # kerns, so they don't override anything else like glyph kerns would
-        # and zero is the default.
-        if not (pair.firstIsClass and pair.secondIsClass and pair.value == 0):
-            yield pair
+        for names1, glyphs1 in kern1.refine(side1):
+            for names2, glyphs2 in kern2.refine(side2):
+                pair = KerningPair(
+                    glyphs1, glyphs2, collapse_varscalar(build_scalar(names1, names2))
+                )
+                # Zero class-to-class pairs override nothing, even when refined.
+                if firstIsClass and secondIsClass and pair.value == 0:
+                    continue
+                yield pair
 
     # The per-cell split can emit a glyph-glyph pair that another key also
     # yields (an explicit pair, or another overlapping class), so dedupe on the

--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
@@ -10,6 +10,7 @@ from fontTools import unicodedata
 from fontTools.designspaceLib import DesignSpaceDocument
 from fontTools.feaLib.variableScalar import Location as VariableScalarLocation
 from fontTools.feaLib.variableScalar import VariableScalar
+from fontTools.misc.classifyTools import classify
 from fontTools.ufoLib.kerning import lookupKerningValue
 from fontTools.unicodedata import script_horizontal_direction
 
@@ -741,21 +742,25 @@ def _refineMembers(
 
     A member's signature is its kerned group name in each source (None where it
     has none); members sharing the same signature form one refined class,
-    returned as a (signature, members) pair. Members are assumed sorted, so
-    output is deterministic. kernedMaps hold only groups referenced by that
-    source's kerning: an unkerned group never reaches the compiled ClassDefs
-    that varLib.merger partitions, so its members count as ungrouped here.
-    Grouping by the per-source signature yields the coarsest common refinement
-    that varLib.merger derives with classifyTools.classify; see ufo2ft#992.
+    returned as a (signature, members) pair, sorted for deterministic output.
+    kernedMaps hold only groups referenced by that source's kerning: an
+    unkerned group never reaches the compiled ClassDefs that varLib.merger
+    partitions, so its members count as ungrouped here. The members are
+    bucketed per source by their group, and classifyTools.classify -- the same
+    primitive varLib.merger uses -- derives the coarsest common refinement;
+    see ufo2ft#992.
     """
-    bySignature: dict[tuple[str | None, ...], list[str]] = {}
-    for member in members:
-        signature = tuple(kernedMap.get(member) for kernedMap in kernedMaps)
-        bySignature.setdefault(signature, []).append(member)
-    return sorted(
-        ((signature, tuple(refined)) for signature, refined in bySignature.items()),
-        key=lambda pair: pair[1],
-    )
+    perSourceSets: list[list[str]] = []
+    for kernedMap in kernedMaps:
+        byGroup: dict[str | None, list[str]] = {}
+        for member in members:
+            byGroup.setdefault(kernedMap.get(member), []).append(member)
+        perSourceSets.extend(byGroup.values())
+    classes, _ = classify(perSourceSets, sort=False)
+    return [
+        (tuple(kernedMap.get(cell[0]) for kernedMap in kernedMaps), cell)
+        for cell in sorted(tuple(sorted(refined)) for refined in classes)
+    ]
 
 
 class _KernSource(NamedTuple):

--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter2.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter2.py
@@ -36,7 +36,6 @@ from typing import Any, Iterator, Mapping, cast
 
 import fontTools.feaLib.ast as fea_ast
 from fontTools import unicodedata
-from fontTools.designspaceLib import DesignSpaceDocument
 from fontTools.unicodedata import script_horizontal_direction
 
 from ufo2ft.featureWriters import BaseFeatureWriter, ast
@@ -52,13 +51,10 @@ from .kernFeatureWriter import (
     DIST_ENABLED_SCRIPTS,
     LTR_BIDI_TYPES,
     RTL_BIDI_TYPES,
-    SIDE1_PREFIX,
-    SIDE2_PREFIX,
     KerningPair,
     addClassDefinition,
+    collectKerningGroups,
     getVariableKerningPairs,
-    log_redefined_group,
-    log_regrouped_glyph,
 )
 
 if sys.version_info < (3, 10):
@@ -344,7 +340,7 @@ def unicodeScriptDirection(uv: int) -> Direction | None:
 def extract_kerning_data(context: KernContext, options: SimpleNamespace) -> Any:
     side1Groups, side2Groups = get_kerning_groups(context)
     if context.isVariable:
-        pairs = get_variable_kerning_pairs(context, options, side1Groups, side2Groups)
+        pairs = get_variable_kerning_pairs(context, options)
     else:
         pairs = get_kerning_pairs(context, options, side1Groups, side2Groups)
 
@@ -368,75 +364,9 @@ def extract_kerning_data(context: KernContext, options: SimpleNamespace) -> Any:
 
 
 def get_kerning_groups(context: KernContext) -> tuple[KerningGroup, KerningGroup]:
-    allGlyphs = context.glyphSet
-
-    side1Groups: dict[str, tuple[str, ...]] = {}
-    side1Membership: dict[str, str] = {}
-    side2Groups: dict[str, tuple[str, ...]] = {}
-    side2Membership: dict[str, str] = {}
-
-    if isinstance(context.font, DesignSpaceDocument):
-        fonts = [source.font for source in context.font.sources]
-    else:
-        fonts = [context.font]
-
-    for font in fonts:
-        assert font is not None
-        for name, members in font.groups.items():
-            # prune non-existent or skipped glyphs
-            members = {g for g in members if g in allGlyphs}
-            # skip empty groups
-            if not members:
-                continue
-            # skip groups without UFO3 public.kern{1,2} prefix
-            if name.startswith(SIDE1_PREFIX):
-                name_truncated = name[len(SIDE1_PREFIX) :]
-                known_members = members.intersection(side1Membership.keys())
-                if known_members:
-                    for glyph_name in known_members:
-                        original_name_truncated = side1Membership[glyph_name]
-                        if name_truncated != original_name_truncated:
-                            log_regrouped_glyph(
-                                "first",
-                                name,
-                                original_name_truncated,
-                                font,
-                                glyph_name,
-                            )
-                    # Skip the whole group definition if there is any
-                    # overlap problem.
-                    continue
-                group = side1Groups.get(name)
-                if group is None:
-                    side1Groups[name] = tuple(sorted(members))
-                    for member in members:
-                        side1Membership[member] = name_truncated
-                elif set(group) != members:
-                    log_redefined_group("left", name, group, font, members)
-            elif name.startswith(SIDE2_PREFIX):
-                name_truncated = name[len(SIDE2_PREFIX) :]
-                known_members = members.intersection(side2Membership.keys())
-                if known_members:
-                    for glyph_name in known_members:
-                        original_name_truncated = side2Membership[glyph_name]
-                        if name_truncated != original_name_truncated:
-                            log_regrouped_glyph(
-                                "second",
-                                name,
-                                original_name_truncated,
-                                font,
-                                glyph_name,
-                            )
-                    # Skip the whole group definition if there is any
-                    # overlap problem.
-                    continue
-                group = side2Groups.get(name)
-                if group is None:
-                    side2Groups[name] = tuple(sorted(members))
-                    for member in members:
-                        side2Membership[member] = name_truncated
-                elif set(group) != members:
-                    log_redefined_group("right", name, group, font, members)
+    side1Groups, side2Groups, side1Membership, side2Membership = collectKerningGroups(
+        context.font, context.glyphSet, context.isVariable
+    )
     context.side1Membership = side1Membership
     context.side2Membership = side2Membership
     return side1Groups, side2Groups
@@ -479,8 +409,6 @@ def get_kerning_pairs(
 def get_variable_kerning_pairs(
     context: KernContext,
     options: SimpleNamespace,
-    side1Classes: KerningGroup,
-    side2Classes: KerningGroup,
 ) -> list[KerningPair]:
     # This legacy writer shares the default KernFeatureWriter's variable kerning
     # extraction, so the logic lives in exactly one place. The default writer
@@ -488,8 +416,6 @@ def get_variable_kerning_pairs(
     # KernContext, so unpack them here.
     return getVariableKerningPairs(
         context.font,
-        side1Classes,
-        side2Classes,
         context.glyphSet,
         options,
     )

--- a/tests/featureWriters/variableFeatureWriter_test.py
+++ b/tests/featureWriters/variableFeatureWriter_test.py
@@ -9,6 +9,10 @@ from fontTools import designspaceLib
 from fontTools.ufoLib.kerning import lookupKerningValue
 
 from ufo2ft import compileVariableTTF
+from ufo2ft.featureWriters.kernFeatureWriter import (
+    _refineMembers,
+    collectKerningGroups,
+)
 from ufo2ft.featureWriters.kernFeatureWriter2 import (
     KernFeatureWriter as KernFeatureWriter2,
 )
@@ -515,6 +519,63 @@ def _makeDivergentGroupsDesignSpace(FontClass, mode):
         source.familyName = "Test"
         designspace.addSource(source)
     return designspace
+
+
+@pytest.mark.parametrize(
+    "members, kernedMaps, expected",
+    [
+        pytest.param(
+            ("X", "Y"),
+            [{"X": "right", "Y": "right"}, {"X": "right", "Y": "right"}],
+            [(("right", "right"), ("X", "Y"))],
+            id="consistent-membership-one-class",
+        ),
+        pytest.param(
+            ("X", "Y"),
+            [{"X": "right", "Y": "right"}, {"X": "right", "Y": "other"}],
+            [(("right", "right"), ("X",)), (("right", "other"), ("Y",))],
+            id="regrouped-alone-splits-off",
+        ),
+        pytest.param(
+            ("X", "Y", "Z"),
+            [
+                {"X": "right", "Y": "right", "Z": "right"},
+                {"X": "right", "Y": "other", "Z": "other"},
+            ],
+            [(("right", "right"), ("X",)), (("right", "other"), ("Y", "Z"))],
+            id="regrouped-together-stays-one-class",
+        ),
+        pytest.param(
+            ("W", "X"),
+            [{"X": "right"}, {"X": "right"}],
+            [((None, None), ("W",)), (("right", "right"), ("X",))],
+            id="ungrouped-everywhere-shares-fallback-class",
+        ),
+        pytest.param(
+            ("X", "Y", "Z"),
+            [{"X": "right", "Y": "right", "Z": "right"}, {"X": "right"}],
+            [(("right", "right"), ("X",)), (("right", None), ("Y", "Z"))],
+            id="unkerned-groups-omitted-matching-varlib",
+        ),
+    ],
+)
+def test_refineMembers_partitions_by_cross_source_signature(
+    members, kernedMaps, expected
+):
+    # Pin the partition primitive independently of full font compilation.
+    assert _refineMembers(members, kernedMaps) == expected
+
+
+def test_collectKerningGroups_backfills_merge_dropped_glyphs(FontClass):
+    # late_added strands Y outside merged classes; backfill preserves its name.
+    designspace = _makeDivergentGroupsDesignSpace(FontClass, "late_added")
+    glyphSet = {g: None for g in ("A", "B", "X", "Y", "Z", "W")}
+    _, side2Groups, _, side2Membership = collectKerningGroups(
+        designspace, glyphSet, isVariable=True
+    )
+    assert side2Groups["public.kern2.right"] == ("X",)
+    assert "Y" not in {g for members in side2Groups.values() for g in members}
+    assert side2Membership["Y"] == "right"
 
 
 @pytest.mark.parametrize(

--- a/tests/featureWriters/variableFeatureWriter_test.py
+++ b/tests/featureWriters/variableFeatureWriter_test.py
@@ -1,12 +1,17 @@
 import io
 import itertools
+from dataclasses import dataclass
 from textwrap import dedent
+from typing import NamedTuple
 
 import pytest
 from fontTools import designspaceLib
 from fontTools.ufoLib.kerning import lookupKerningValue
 
 from ufo2ft import compileVariableTTF
+from ufo2ft.featureWriters.kernFeatureWriter2 import (
+    KernFeatureWriter as KernFeatureWriter2,
+)
 
 
 def _makePartialExceptionDesignSpace(FontClass, *, coverAllMembers=False):
@@ -142,17 +147,16 @@ def test_variable_kern_uniform_override_exception(FontClass):
 """)
 
 
-@pytest.mark.parametrize("coverAllMembers", [False, True])
-def test_variable_kern_matches_source_at_masters(coverAllMembers, FontClass):
+def _assertVariableKernMatchesSources(
+    designspace, firsts, seconds, featureWriters=None
+):
     # At a master location the variation model reconstructs that source exactly,
     # so the kern the font applies to a pair there must equal the value the
     # master's own DS+UFO cascade resolves.
     hb = pytest.importorskip("uharfbuzz")
 
-    designspace = _makePartialExceptionDesignSpace(
-        FontClass, coverAllMembers=coverAllMembers
-    )
-    vf = compileVariableTTF(designspace)
+    kwargs = {} if featureWriters is None else {"featureWriters": featureWriters}
+    vf = compileVariableTTF(designspace, **kwargs)
     buf = io.BytesIO()
     vf.save(buf)
     face = hb.Face(buf.getvalue())
@@ -162,7 +166,7 @@ def test_variable_kern_matches_source_at_masters(coverAllMembers, FontClass):
         groups = source.font.groups
         hbFont = hb.Font(face)
         hbFont.set_variations({"wght": source.location["Weight"]})
-        for first, second in itertools.product(("A", "B"), ("X", "Y")):
+        for first, second in itertools.product(firsts, seconds):
             expected = lookupKerningValue((first, second), kerning, groups)
             hbBuf = hb.Buffer()
             hbBuf.add_str(first + second)
@@ -174,6 +178,388 @@ def test_variable_kern_matches_source_at_masters(coverAllMembers, FontClass):
                 f"{source.name} {first}{second}: "
                 f"font kerns {actual}, source resolves {expected}"
             )
+
+
+@pytest.mark.parametrize("coverAllMembers", [False, True])
+def test_variable_kern_matches_source_at_masters(coverAllMembers, FontClass):
+    designspace = _makePartialExceptionDesignSpace(
+        FontClass, coverAllMembers=coverAllMembers
+    )
+    _assertVariableKernMatchesSources(designspace, ("A", "B"), ("X", "Y"))
+
+
+class _MasterCase(NamedTuple):
+    groups: dict
+    kerning: dict
+
+
+@dataclass
+class _DivergentCase:
+    regular: _MasterCase
+    bold: _MasterCase
+    fea: str
+
+
+_DIVERGENT_CASES = {
+    "glyph_to_class": _DivergentCase(
+        regular=_MasterCase(
+            {"public.kern2.right": ["X", "Y"]},
+            {("A", "public.kern2.right"): 100},
+        ),
+        bold=_MasterCase(
+            {"public.kern2.right": ["X"], "public.kern2.other": ["Y"]},
+            {("A", "public.kern2.right"): 100, ("A", "public.kern2.other"): -50},
+        ),
+        fea="""
+        lookup kern_Latn {
+            lookupflag IgnoreMarks;
+            pos A X 100;
+            pos A Y (wght=0:100 wght=1000:-50);
+        } kern_Latn;
+    """,
+    ),
+    "class_to_class": _DivergentCase(
+        regular=_MasterCase(
+            {"public.kern1.left": ["A", "B"], "public.kern2.right": ["X", "Y"]},
+            {("public.kern1.left", "public.kern2.right"): 100},
+        ),
+        bold=_MasterCase(
+            {
+                "public.kern1.left": ["A", "B"],
+                "public.kern2.right": ["X"],
+                "public.kern2.other": ["Y"],
+            },
+            {
+                ("public.kern1.left", "public.kern2.right"): 100,
+                ("public.kern1.left", "public.kern2.other"): -50,
+            },
+        ),
+        fea="""
+        @kern1.Latn.left = [A B];
+        @kern2.Latn.right = [X];
+        @kern2.Latn.right_1 = [Y];
+
+        lookup kern_Latn {
+            lookupflag IgnoreMarks;
+            pos @kern1.Latn.left @kern2.Latn.right 100;
+            pos @kern1.Latn.left @kern2.Latn.right_1 (wght=0:100 wght=1000:-50);
+        } kern_Latn;
+    """,
+    ),
+    "class_to_glyph": _DivergentCase(
+        regular=_MasterCase(
+            {"public.kern1.left": ["A", "B"]},
+            {("public.kern1.left", "X"): 100},
+        ),
+        bold=_MasterCase(
+            {"public.kern1.left": ["A"], "public.kern1.other": ["B"]},
+            {("public.kern1.left", "X"): 100, ("public.kern1.other", "X"): -50},
+        ),
+        fea="""
+        @kern1.Latn.left = [A];
+        @kern1.Latn.left_1 = [B];
+
+        lookup kern_Latn {
+            lookupflag IgnoreMarks;
+            enum pos @kern1.Latn.left X 100;
+            enum pos @kern1.Latn.left_1 X (wght=0:100 wght=1000:-50);
+        } kern_Latn;
+    """,
+    ),
+    "both_diverge": _DivergentCase(
+        regular=_MasterCase(
+            {"public.kern1.left": ["A", "B"], "public.kern2.right": ["X", "Y"]},
+            {("public.kern1.left", "public.kern2.right"): 100},
+        ),
+        bold=_MasterCase(
+            {
+                "public.kern1.left": ["A"],
+                "public.kern1.other": ["B"],
+                "public.kern2.right": ["X"],
+                "public.kern2.other": ["Y"],
+            },
+            {
+                ("public.kern1.left", "public.kern2.right"): 100,
+                ("public.kern1.left", "public.kern2.other"): -50,
+                ("public.kern1.other", "public.kern2.right"): 70,
+                ("public.kern1.other", "public.kern2.other"): 20,
+            },
+        ),
+        fea="""
+        @kern1.Latn.left = [A];
+        @kern1.Latn.left_1 = [B];
+        @kern2.Latn.right = [X];
+        @kern2.Latn.right_1 = [Y];
+
+        lookup kern_Latn {
+            lookupflag IgnoreMarks;
+            pos @kern1.Latn.left @kern2.Latn.right 100;
+            pos @kern1.Latn.left @kern2.Latn.right_1 (wght=0:100 wght=1000:-50);
+            pos @kern1.Latn.left_1 @kern2.Latn.right (wght=0:100 wght=1000:70);
+            pos @kern1.Latn.left_1 @kern2.Latn.right_1 (wght=0:100 wght=1000:20);
+        } kern_Latn;
+    """,
+    ),
+    # Z and W are stranded by first-wins merging but still need bold's value.
+    "orphan": _DivergentCase(
+        regular=_MasterCase(
+            {"public.kern2.right": ["X", "Y"]},
+            {("A", "public.kern2.right"): 100},
+        ),
+        bold=_MasterCase(
+            {"public.kern2.right": ["X"], "public.kern2.other": ["Y", "Z", "W"]},
+            {("A", "public.kern2.right"): 100, ("A", "public.kern2.other"): -50},
+        ),
+        fea="""
+        lookup kern_Latn {
+            lookupflag IgnoreMarks;
+            pos A W (wght=0:0 wght=1000:-50);
+            pos A X 100;
+            pos A Y (wght=0:100 wght=1000:-50);
+            pos A Z (wght=0:0 wght=1000:-50);
+        } kern_Latn;
+    """,
+    ),
+    # Y is only in bold's dropped group; class naming must still find a name.
+    "late_added": _DivergentCase(
+        regular=_MasterCase(
+            {"public.kern1.left": ["A", "B"], "public.kern2.right": ["X"]},
+            {("public.kern1.left", "public.kern2.right"): 100},
+        ),
+        bold=_MasterCase(
+            {"public.kern1.left": ["A", "B"], "public.kern2.right": ["X", "Y"]},
+            {("public.kern1.left", "public.kern2.right"): 100},
+        ),
+        fea="""
+        @kern1.Latn.left = [A B];
+        @kern2.Latn.right = [X];
+        @kern2.Latn.right_1 = [Y];
+
+        lookup kern_Latn {
+            lookupflag IgnoreMarks;
+            pos @kern1.Latn.left @kern2.Latn.right 100;
+            pos @kern1.Latn.left @kern2.Latn.right_1 (wght=0:0 wght=1000:100);
+        } kern_Latn;
+    """,
+    ),
+    # Y and Z co-move into one refined class.
+    "regrouped": _DivergentCase(
+        regular=_MasterCase(
+            {"public.kern1.left": ["A", "B"], "public.kern2.right": ["X", "Y", "Z"]},
+            {("public.kern1.left", "public.kern2.right"): 100},
+        ),
+        bold=_MasterCase(
+            {
+                "public.kern1.left": ["A", "B"],
+                "public.kern2.right": ["X"],
+                "public.kern2.other": ["Y", "Z"],
+            },
+            {
+                ("public.kern1.left", "public.kern2.right"): 100,
+                ("public.kern1.left", "public.kern2.other"): -50,
+            },
+        ),
+        fea="""
+        @kern1.Latn.left = [A B];
+        @kern2.Latn.right = [X];
+        @kern2.Latn.right_1 = [Y Z];
+
+        lookup kern_Latn {
+            lookupflag IgnoreMarks;
+            pos @kern1.Latn.left @kern2.Latn.right 100;
+            pos @kern1.Latn.left @kern2.Latn.right_1 (wght=0:100 wght=1000:-50);
+        } kern_Latn;
+    """,
+    ),
+    # A Y exception must not smear onto the [Y Z] refined class.
+    "regrouped_exception": _DivergentCase(
+        regular=_MasterCase(
+            {"public.kern1.left": ["A", "B"], "public.kern2.right": ["X", "Y", "Z"]},
+            {
+                ("public.kern1.left", "public.kern2.right"): 100,
+                ("public.kern1.left", "Y"): 30,
+            },
+        ),
+        bold=_MasterCase(
+            {
+                "public.kern1.left": ["A", "B"],
+                "public.kern2.right": ["X"],
+                "public.kern2.other": ["Y", "Z"],
+            },
+            {
+                ("public.kern1.left", "public.kern2.right"): 100,
+                ("public.kern1.left", "public.kern2.other"): -50,
+            },
+        ),
+        fea="""
+        @kern1.Latn.left = [A B];
+        @kern2.Latn.right = [X];
+        @kern2.Latn.right_1 = [Y Z];
+
+        lookup kern_Latn {
+            lookupflag IgnoreMarks;
+            enum pos @kern1.Latn.left Y (wght=0:30 wght=1000:-50);
+            pos @kern1.Latn.left @kern2.Latn.right 100;
+            pos @kern1.Latn.left @kern2.Latn.right_1 (wght=0:100 wght=1000:-50);
+        } kern_Latn;
+    """,
+    ),
+    # The exact B-Y exception must not smear onto B against the refined [Y Z].
+    "both_diverge_exception": _DivergentCase(
+        regular=_MasterCase(
+            {"public.kern1.left": ["A", "B"], "public.kern2.right": ["X", "Y", "Z"]},
+            {
+                ("public.kern1.left", "public.kern2.right"): 100,
+                ("B", "Y"): 30,
+            },
+        ),
+        bold=_MasterCase(
+            {
+                "public.kern1.left": ["A"],
+                "public.kern1.other": ["B"],
+                "public.kern2.right": ["X"],
+                "public.kern2.other": ["Y", "Z"],
+            },
+            {
+                ("public.kern1.left", "public.kern2.right"): 100,
+                ("public.kern1.left", "public.kern2.other"): -50,
+                ("public.kern1.other", "public.kern2.right"): 70,
+                ("public.kern1.other", "public.kern2.other"): 20,
+            },
+        ),
+        fea="""
+        @kern1.Latn.left = [A];
+        @kern1.Latn.left_1 = [B];
+        @kern2.Latn.right = [X];
+        @kern2.Latn.right_1 = [Y Z];
+
+        lookup kern_Latn {
+            lookupflag IgnoreMarks;
+            pos B Y (wght=0:30 wght=1000:20);
+            pos @kern1.Latn.left @kern2.Latn.right 100;
+            pos @kern1.Latn.left @kern2.Latn.right_1 (wght=0:100 wght=1000:-50);
+            pos @kern1.Latn.left_1 @kern2.Latn.right (wght=0:100 wght=1000:70);
+            pos @kern1.Latn.left_1 @kern2.Latn.right_1 (wght=0:100 wght=1000:20);
+        } kern_Latn;
+    """,
+    ),
+    # Unkerned destination groups are invisible to varLib.merger, so Y/Z stay
+    # together.
+    "regrouped_unkerned": _DivergentCase(
+        regular=_MasterCase(
+            {"public.kern1.left": ["A", "B"], "public.kern2.right": ["X", "Y", "Z"]},
+            {("public.kern1.left", "public.kern2.right"): 100},
+        ),
+        bold=_MasterCase(
+            {
+                "public.kern1.left": ["A", "B"],
+                "public.kern2.right": ["X"],
+                "public.kern2.foo": ["Y"],
+                "public.kern2.bar": ["Z"],
+            },
+            {("public.kern1.left", "public.kern2.right"): 100},
+        ),
+        fea="""
+        @kern1.Latn.left = [A B];
+        @kern2.Latn.right = [X];
+        @kern2.Latn.right_1 = [Y Z];
+
+        lookup kern_Latn {
+            lookupflag IgnoreMarks;
+            pos @kern1.Latn.left @kern2.Latn.right 100;
+            pos @kern1.Latn.left @kern2.Latn.right_1 (wght=0:100 wght=1000:0);
+        } kern_Latn;
+    """,
+    ),
+}
+
+
+def _makeDivergentGroupsDesignSpace(FontClass, mode):
+    U = {"A": 0x41, "B": 0x42, "X": 0x58, "Y": 0x59, "Z": 0x5A, "W": 0x57}
+
+    def makeMaster(groups, kerning):
+        font = FontClass()
+        font.newGlyph(".notdef").width = 600
+        order = [".notdef"]
+        for name in ("A", "B", "X", "Y", "Z", "W"):
+            glyph = font.newGlyph(name)
+            glyph.width = 600
+            glyph.unicodes = [U[name]]
+            pen = glyph.getPen()
+            pen.moveTo((50, 0))
+            pen.lineTo((550, 0))
+            pen.lineTo((550, 700))
+            pen.lineTo((50, 700))
+            pen.closePath()
+            order.append(name)
+        # Do not let font objects mutate shared parametrized case data.
+        font.groups.update({name: list(members) for name, members in groups.items()})
+        font.kerning.update(kerning)
+        font.lib["public.glyphOrder"] = order
+        return font
+
+    case = _DIVERGENT_CASES[mode]
+    designspace = designspaceLib.DesignSpaceDocument()
+    axis = designspace.newAxisDescriptor()
+    axis.name, axis.tag = "Weight", "wght"
+    axis.minimum, axis.default, axis.maximum = 0, 0, 1000
+    designspace.addAxis(axis)
+    for (groups, kerning), location, name in [
+        (case.regular, 0, "regular"),
+        (case.bold, 1000, "bold"),
+    ]:
+        source = designspace.newSourceDescriptor()
+        source.font = makeMaster(groups, kerning)
+        source.location = {"Weight": location}
+        source.name = source.styleName = name
+        source.familyName = "Test"
+        designspace.addSource(source)
+    return designspace
+
+
+@pytest.mark.parametrize(
+    "writerClass", [None, KernFeatureWriter2], ids=["writer1", "writer2"]
+)
+@pytest.mark.parametrize("mode", list(_DIVERGENT_CASES))
+def test_variable_kern_divergent_groups_match_sources(mode, writerClass, FontClass):
+    designspace = _makeDivergentGroupsDesignSpace(FontClass, mode)
+    featureWriters = None if writerClass is None else [writerClass()]
+    _assertVariableKernMatchesSources(
+        designspace, ("A", "B"), ("X", "Y", "Z", "W"), featureWriters=featureWriters
+    )
+
+
+# Shared feature/lookup tail for the exact-FEA cases.
+_KERN_FEATURE_TAIL = """
+    feature kern {
+        script DFLT;
+        language dflt;
+        lookup kern_Latn;
+
+        script latn;
+        language dflt;
+        lookup kern_Latn;
+    } kern;
+"""
+
+
+def _normalizeFea(text):
+    # feaLib pads some blank lines with whitespace; rstrip each line so the
+    # golden strings can stay clean, and drop leading/trailing blank lines.
+    return "\n".join(line.rstrip() for line in dedent(text).strip("\n").splitlines())
+
+
+@pytest.mark.parametrize("mode", list(_DIVERGENT_CASES))
+def test_variable_kern_divergent_groups_fea(mode, FontClass):
+    designspace = _makeDivergentGroupsDesignSpace(FontClass, mode)
+    tmp = io.StringIO()
+    compileVariableTTF(designspace, debugFeatureFile=tmp)
+    expected = (
+        _normalizeFea(_DIVERGENT_CASES[mode].fea)
+        + "\n\n"
+        + _normalizeFea(_KERN_FEATURE_TAIL)
+    )
+    assert _normalizeFea(tmp.getvalue()) == expected
 
 
 def test_variable_features(FontClass):


### PR DESCRIPTION
The variable-features KernFeatureWriter resolved every master's kerning through a single font-wide, first-source-wins merged group map. A glyph placed in a different group by some master -- or left ungrouped there -- was still looked up through the merged grouping at every location: each master contributed its own values, but for classes it never put the glyph in, producing variable kerning that matches no source. A group dropped by the first-wins merge also stranded all its members outside every merged class, silently losing their kerning.

Each pair is now resolved against each source's own groups, and a class whose membership diverges is refined into the so-called [coarsest common refinement](https://en.wikipedia.org/wiki/Partition_of_a_set#Refinement_of_partitions) of the per-master partitions -- the same partition varLib.merger derives with [classifyTools.classify](https://github.com/fonttools/fonttools/blob/4.63.0/Lib/fontTools/misc/classifyTools.py#L109) on the compiled per-master ClassDefs (see [_ClassDef_merge_classify](https://github.com/fonttools/fonttools/blob/4.63.0/Lib/fontTools/varLib/merger.py#L485)). The refined class matrix compiles to the same class-based GPOS the varLib.merge path (variableFeatures=False) produces, so a family switching from varLib merging to a single set of variable features (e.g. to compile with fontc, which has the same bug: googlefonts/fontc#339) doesn't get its kerning silently rewritten in the process.

The bug ships in production: [JosefinSlab[wght].ttf](https://github.com/google/fonts/blob/47831f08ec6d6d7ad6b465f23dc9f9a890a2a04b/ofl/josefinslab/JosefinSlab%5Bwght%5D.ttf) on Google Fonts kerns V/Adieresis at -180 at every weight, including Bold, whose own source resolves 0 (Bold regroups Adieresis into a group its kerning never references, but Thin's grouping won the merge, so the class kern kept applying across the whole axis). The current ufo2ft release reproduces the shipped wrong values exactly; with this fix, Josefin Slab Roman compiled with variableFeatures=True produces GPOS byte-identical to the varLib.merge output (a single format-2 PairPos), and HarfBuzz shaping confirms every probed pair at every master matches that master's own source kerning. 

A scan of the fontc-crater corpus found divergent kern groups in 33 of 546 designspaces (including Josefin Slab, Fraunces Italic, IBM Plex Sans Arabic, Source Sans 3, Recursive, ...): only UFO-native projects can hit this, since glyphsLib writes identical groups into every master.

Output is unchanged for families whose groups agree across all masters; for divergent families the GPOS changes, from matching no source to matching all of them, and an INFO log lists the reconciled glyphs. Both kern writers are covered: the logic now lives in a shared collectKerningGroups helper that KernFeatureWriter and kernFeatureWriter2 both delegate to.

Fixes #992.